### PR TITLE
Harden parsers against brittle table assumptions

### DIFF
--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -1,17 +1,13 @@
 package site
 
 import (
-	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 )
 
-var spaceRe = regexp.MustCompile(`\s+`)
-var minuteAtEndRe = regexp.MustCompile(`(\d{1,3})\s*$`)
-var minuteAnywhereRe = regexp.MustCompile(`(\d{1,3}(?:\+\d{1,2})?)`)
-
+// parseLeaguePage parses a competition page into rounds and fixtures.
+// It prefers structural markers and match-link semantics over fixed table widths.
 func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	page := &LeaguePage{URL: url}
 
@@ -29,197 +25,12 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	return page
 }
 
-func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
-	title := normalizeWhitespace(doc.Find("title").First().Text())
-	if title == "" {
-		return nil
-	}
-
-	table := doc.Find("table.main[width='480']").First()
-	if table.Length() == 0 {
-		return &MatchPage{Title: title, URL: url}
-	}
-
-	page := &MatchPage{Title: title, URL: url}
-
-	page.Competition = normalizeWhitespace(table.Find("tr").First().Find("b").First().Text())
-	metaCell := table.Find("tr").Eq(1).Find("td[colspan='3']").First()
-	page.Meta = normalizeWhitespace(metaCell.Text())
-
-	page.Weather = normalizeWhitespace(table.Find("img[src*='pog_termo']").Parent().Text())
-
-	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
-		tds := row.Find("td")
-		if tds.Length() != 3 {
-			return
-		}
-
-		left := normalizeWhitespace(tds.Eq(0).Text())
-		middle := normalizeWhitespace(tds.Eq(1).Text())
-		right := normalizeWhitespace(tds.Eq(2).Text())
-
-		if page.Score == "" && left != "" && right != "" && strings.Contains(middle, "-") {
-			page.HomeTeam = left
-			page.AwayTeam = right
-			page.Score = middle
-			return
-		}
-
-		if strings.Contains(middle, "-") {
-			if left != "" && right == "" {
-				page.Events = append(page.Events, MatchEvent{
-					MinuteText: extractMinute(left),
-					Kind:       "GOAL",
-					TeamSide:   "home",
-					Text:       left,
-				})
-			}
-
-			if right != "" && left == "" {
-				page.Events = append(page.Events, MatchEvent{
-					MinuteText: extractMinute(right),
-					Kind:       "GOAL",
-					TeamSide:   "away",
-					Text:       right,
-				})
-			}
-		}
-	})
-
-	table.Find("tr[bgcolor]").Each(func(_ int, row *goquery.Selection) {
-		tds := row.Find("td")
-		if tds.Length() != 3 {
-			return
-		}
-
-		if player := parsePlayerCell(tds.Eq(0)); player != nil {
-			page.HomeLineup = append(page.HomeLineup, *player)
-			for _, event := range playerTimelineEvents(*player, "home") {
-				page.Events = append(page.Events, event)
-			}
-		}
-		if player := parsePlayerCell(tds.Eq(2)); player != nil {
-			page.AwayLineup = append(page.AwayLineup, *player)
-			for _, event := range playerTimelineEvents(*player, "away") {
-				page.Events = append(page.Events, event)
-			}
-		}
-	})
-
-	table.Find("tr td[colspan='3']").Each(func(_ int, td *goquery.Selection) {
-		text := normalizeWhitespace(td.Text())
-		if !strings.Contains(strings.ToLower(text), "przeczytaj news") {
-			return
-		}
-
-		page.NewsTitle = normalizeWhitespace(td.Find("a").First().Text())
-		page.NewsURL = strings.TrimSpace(td.Find("a").First().AttrOr("href", ""))
-	})
-
-	return page
-}
-
-func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
-	events := make([]MatchEvent, 0, 2)
-
-	for _, marker := range player.Events {
-		event := MatchEvent{TeamSide: side, Text: player.Name}
-
-		switch {
-		case marker == "YC":
-			event.Kind = "YC"
-		case marker == "RC":
-			event.Kind = "RC"
-		case strings.Contains(marker, "->"):
-			event.Kind = "SUB"
-			event.MinuteText = extractMinute(marker)
-			event.Text = marker
-		default:
-			event.Kind = "EVENT"
-			event.Text = marker
-		}
-
-		events = append(events, event)
-	}
-
-	return events
-}
-
-func parsePlayerCell(cell *goquery.Selection) *PlayerLine {
-	raw := normalizeWhitespace(cell.Text())
-	if raw == "" {
-		return nil
-	}
-
-	anchors := make([]string, 0, 3)
-	cell.Find("a").Each(func(_ int, a *goquery.Selection) {
-		name := normalizeWhitespace(a.Text())
-		if name != "" {
-			anchors = append(anchors, name)
-		}
-	})
-
-	name := raw
-	if len(anchors) > 0 {
-		name = anchors[0]
-	}
-
-	events := make([]string, 0, 3)
-	if cell.Find("img[src*='yel.gif']").Length() > 0 {
-		events = append(events, "YC")
-	}
-	if cell.Find("img[src*='red.gif'], img[src*='red2.gif']").Length() > 0 {
-		events = append(events, "RC")
-	}
-
-	if cell.Find("img[src*='sub.gif']").Length() > 0 && len(anchors) > 1 {
-		replacement := anchors[len(anchors)-1]
-		minute := substitutionMinute(raw, replacement)
-		if minute != "" {
-			events = append(events, fmt.Sprintf("%s' -> %s", minute, replacement))
-		} else {
-			events = append(events, fmt.Sprintf("sub -> %s", replacement))
-		}
-	}
-
-	return &PlayerLine{Name: name, Events: events, RawText: raw}
-}
-
-func substitutionMinute(raw, replacement string) string {
-	idx := strings.Index(raw, replacement)
-	if idx <= 0 {
-		return ""
-	}
-
-	prefix := normalizeWhitespace(raw[:idx])
-	matches := minuteAtEndRe.FindStringSubmatch(prefix)
-	if len(matches) < 2 {
-		return ""
-	}
-
-	return matches[1]
-}
-
-func extractMinute(text string) string {
-	matches := minuteAnywhereRe.FindStringSubmatch(text)
-	if len(matches) < 2 {
-		return ""
-	}
-
-	return matches[1]
-}
-
 func parseRounds(doc *goquery.Document) []Round {
 	rounds := make([]Round, 0, 16)
 	currentName := ""
 
-	doc.Find("table.main[width='600']").Each(func(_ int, table *goquery.Selection) {
-		text := normalizeWhitespace(table.Text())
-		if strings.Contains(strings.ToLower(text), "kolejka") {
-			name := strings.TrimSpace(table.Find("u").First().Text())
-			if name == "" {
-				name = text
-			}
+	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+		if name, ok := roundNameFromTable(table); ok {
 			currentName = name
 			return
 		}
@@ -234,32 +45,71 @@ func parseRounds(doc *goquery.Document) []Round {
 			roundName = "Wyniki"
 		}
 
+		if len(rounds) > 0 && rounds[len(rounds)-1].Name == roundName {
+			rounds[len(rounds)-1].Fixtures = append(rounds[len(rounds)-1].Fixtures, fixtures...)
+			return
+		}
+
 		rounds = append(rounds, Round{Name: roundName, Fixtures: fixtures})
 	})
 
 	return rounds
 }
 
+func roundNameFromTable(table *goquery.Selection) (string, bool) {
+	if table.Find("a[href*='mecz.php']").Length() > 0 {
+		return "", false
+	}
+
+	heading := normalizeWhitespace(table.Find("u").First().Text())
+	if looksLikeRoundHeading(heading) {
+		return heading, true
+	}
+
+	text := normalizeWhitespace(table.Text())
+	if looksLikeRoundHeading(text) {
+		return text, true
+	}
+
+	return "", false
+}
+
+func looksLikeRoundHeading(text string) bool {
+	if text == "" {
+		return false
+	}
+
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "kolejka") || strings.Contains(lower, "runda")
+}
+
 func parseFixturesTable(table *goquery.Selection) []Fixture {
 	fixtures := make([]Fixture, 0, 16)
 
 	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
-		tds := row.Find("td")
-		if tds.Length() < 3 {
+		matchLinks := row.Find("a[href*='mecz.php']")
+		if matchLinks.Length() != 1 {
 			return
 		}
 
-		scoreCell := tds.Eq(1)
-		matchLink := strings.TrimSpace(scoreCell.Find("a").AttrOr("href", ""))
-		score := normalizeWhitespace(scoreCell.Text())
-		home := normalizeWhitespace(tds.Eq(0).Text())
-		away := normalizeWhitespace(tds.Eq(2).Text())
-		whenInfo := ""
-		if tds.Length() > 3 {
-			whenInfo = normalizeWhitespace(tds.Eq(3).Text())
+		scoreCell := matchLinks.First().Closest("td")
+		if scoreCell.Length() == 0 {
+			return
 		}
 
-		if home == "" || away == "" || score == "" || !strings.Contains(matchLink, "mecz.php") {
+		tds := row.Find("td")
+		scoreIdx := scoreCell.Index()
+		home, _ := nearestTeamCellText(tds, scoreIdx-1, -1)
+		away, awayIdx := nearestTeamCellText(tds, scoreIdx+1, 1)
+		if home == "" || away == "" || isScoreLikeText(home) || isScoreLikeText(away) {
+			return
+		}
+
+		matchLink := strings.TrimSpace(scoreCell.Find("a[href*='mecz.php']").First().AttrOr("href", ""))
+		score := normalizeWhitespace(scoreCell.Text())
+		whenInfo := joinNonEmptyCells(tds, awayIdx+1)
+
+		if score == "" || matchLink == "" {
 			return
 		}
 
@@ -275,6 +125,29 @@ func parseFixturesTable(table *goquery.Selection) []Fixture {
 	return fixtures
 }
 
-func normalizeWhitespace(v string) string {
-	return strings.TrimSpace(spaceRe.ReplaceAllString(v, " "))
+func nearestTeamCellText(tds *goquery.Selection, start, step int) (string, int) {
+	for idx := start; idx >= 0 && idx < tds.Length(); idx += step {
+		text := normalizeWhitespace(tds.Eq(idx).Text())
+		if text != "" {
+			return text, idx
+		}
+	}
+
+	return "", -1
+}
+
+func joinNonEmptyCells(tds *goquery.Selection, start int) string {
+	if start < 0 || start >= tds.Length() {
+		return ""
+	}
+
+	parts := make([]string, 0, 2)
+	for idx := start; idx < tds.Length(); idx++ {
+		value := normalizeWhitespace(tds.Eq(idx).Text())
+		if value != "" {
+			parts = append(parts, value)
+		}
+	}
+
+	return strings.Join(parts, " ")
 }

--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -1,0 +1,278 @@
+package site
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+// parseMatchPage parses a single match page into score, timeline and lineups.
+// It identifies the match table by content signatures instead of a fixed width.
+func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
+	title := normalizeWhitespace(doc.Find("title").First().Text())
+	if title == "" {
+		return nil
+	}
+
+	table := findMatchMainTable(doc)
+	if table.Length() == 0 {
+		return &MatchPage{Title: title, URL: url}
+	}
+
+	page := &MatchPage{Title: title, URL: url}
+
+	page.Competition = normalizeWhitespace(table.Find("tr").First().Find("b").First().Text())
+	page.Meta = firstMetaLine(table)
+	page.Weather = normalizeWhitespace(table.Find("img[src*='pog_termo']").Parent().Text())
+
+	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
+		tds := row.Find("td")
+		if tds.Length() != 3 {
+			return
+		}
+
+		left := normalizeWhitespace(tds.Eq(0).Text())
+		middle := normalizeWhitespace(tds.Eq(1).Text())
+		right := normalizeWhitespace(tds.Eq(2).Text())
+
+		if page.Score == "" && left != "" && right != "" && strings.Contains(middle, "-") {
+			page.HomeTeam = left
+			page.AwayTeam = right
+			page.Score = middle
+			return
+		}
+
+		if strings.Contains(middle, "-") {
+			if left != "" && right == "" {
+				page.Events = append(page.Events, MatchEvent{
+					MinuteText: extractMinute(left),
+					Kind:       "GOAL",
+					TeamSide:   "home",
+					Text:       left,
+				})
+			}
+
+			if right != "" && left == "" {
+				page.Events = append(page.Events, MatchEvent{
+					MinuteText: extractMinute(right),
+					Kind:       "GOAL",
+					TeamSide:   "away",
+					Text:       right,
+				})
+			}
+		}
+	})
+
+	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
+		if !isLineupRow(row) {
+			return
+		}
+
+		tds := row.Find("td")
+		if tds.Length() != 3 {
+			return
+		}
+
+		if player := parsePlayerCell(tds.Eq(0)); player != nil {
+			page.HomeLineup = append(page.HomeLineup, *player)
+			for _, event := range playerTimelineEvents(*player, "home") {
+				page.Events = append(page.Events, event)
+			}
+		}
+		if player := parsePlayerCell(tds.Eq(2)); player != nil {
+			page.AwayLineup = append(page.AwayLineup, *player)
+			for _, event := range playerTimelineEvents(*player, "away") {
+				page.Events = append(page.Events, event)
+			}
+		}
+	})
+
+	table.Find("tr td[colspan='3']").Each(func(_ int, td *goquery.Selection) {
+		text := normalizeWhitespace(td.Text())
+		if !strings.Contains(strings.ToLower(text), "przeczytaj news") {
+			return
+		}
+
+		page.NewsTitle = normalizeWhitespace(td.Find("a").First().Text())
+		page.NewsURL = strings.TrimSpace(td.Find("a").First().AttrOr("href", ""))
+	})
+
+	return page
+}
+
+func findMatchMainTable(doc *goquery.Document) *goquery.Selection {
+	bestScore := -1
+	best := doc.Find("table.main[width='480']").First()
+
+	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+		score := 0
+		if hasMatchScoreRow(table) {
+			score += 3
+		}
+		if table.Find("img[src*='pog_termo']").Length() > 0 {
+			score++
+		}
+		if table.Find("img[src*='yel.gif'], img[src*='red.gif'], img[src*='red2.gif'], img[src*='sub.gif']").Length() > 0 {
+			score += 2
+		}
+		if table.Find("tr[bgcolor]").Length() > 0 {
+			score++
+		}
+
+		if score > bestScore {
+			bestScore = score
+			best = table
+		}
+	})
+
+	if best.Length() == 0 || bestScore <= 0 {
+		return &goquery.Selection{}
+	}
+
+	return best
+}
+
+func hasMatchScoreRow(table *goquery.Selection) bool {
+	found := false
+	table.Find("tr").EachWithBreak(func(_ int, row *goquery.Selection) bool {
+		tds := row.Find("td")
+		if tds.Length() != 3 {
+			return true
+		}
+
+		left := normalizeWhitespace(tds.Eq(0).Text())
+		middle := normalizeWhitespace(tds.Eq(1).Text())
+		right := normalizeWhitespace(tds.Eq(2).Text())
+		if left != "" && right != "" && strings.Contains(middle, "-") {
+			found = true
+			return false
+		}
+
+		return true
+	})
+
+	return found
+}
+
+func firstMetaLine(table *goquery.Selection) string {
+	meta := ""
+	table.Find("td[colspan='3']").EachWithBreak(func(_ int, td *goquery.Selection) bool {
+		text := normalizeWhitespace(td.Text())
+		if text == "" {
+			return true
+		}
+
+		lower := strings.ToLower(text)
+		if strings.Contains(lower, "przeczytaj news") {
+			return true
+		}
+
+		if td.Find("img[src*='pog_termo']").Length() > 0 {
+			return true
+		}
+
+		meta = text
+		return false
+	})
+
+	return meta
+}
+
+func isLineupRow(row *goquery.Selection) bool {
+	tds := row.Find("td")
+	if tds.Length() != 3 {
+		return false
+	}
+
+	if row.Find("img[src*='yel.gif'], img[src*='red.gif'], img[src*='red2.gif'], img[src*='sub.gif']").Length() > 0 {
+		return true
+	}
+
+	if _, ok := row.Attr("bgcolor"); !ok {
+		return false
+	}
+
+	return tds.Eq(0).Find("a").Length() > 0 || tds.Eq(2).Find("a").Length() > 0
+}
+
+func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
+	events := make([]MatchEvent, 0, 2)
+
+	for _, marker := range player.Events {
+		event := MatchEvent{TeamSide: side, Text: player.Name}
+
+		switch {
+		case marker == "YC":
+			event.Kind = "YC"
+		case marker == "RC":
+			event.Kind = "RC"
+		case strings.Contains(marker, "->"):
+			event.Kind = "SUB"
+			event.MinuteText = extractMinute(marker)
+			event.Text = marker
+		default:
+			event.Kind = "EVENT"
+			event.Text = marker
+		}
+
+		events = append(events, event)
+	}
+
+	return events
+}
+
+func parsePlayerCell(cell *goquery.Selection) *PlayerLine {
+	raw := normalizeWhitespace(cell.Text())
+	if raw == "" {
+		return nil
+	}
+
+	anchors := make([]string, 0, 3)
+	cell.Find("a").Each(func(_ int, a *goquery.Selection) {
+		name := normalizeWhitespace(a.Text())
+		if name != "" {
+			anchors = append(anchors, name)
+		}
+	})
+
+	name := raw
+	if len(anchors) > 0 {
+		name = anchors[0]
+	}
+
+	events := make([]string, 0, 3)
+	if cell.Find("img[src*='yel.gif']").Length() > 0 {
+		events = append(events, "YC")
+	}
+	if cell.Find("img[src*='red.gif'], img[src*='red2.gif']").Length() > 0 {
+		events = append(events, "RC")
+	}
+
+	if cell.Find("img[src*='sub.gif']").Length() > 0 && len(anchors) > 1 {
+		replacement := anchors[len(anchors)-1]
+		minute := substitutionMinute(raw, replacement)
+		if minute != "" {
+			events = append(events, fmt.Sprintf("%s' -> %s", minute, replacement))
+		} else {
+			events = append(events, fmt.Sprintf("sub -> %s", replacement))
+		}
+	}
+
+	return &PlayerLine{Name: name, Events: events, RawText: raw}
+}
+
+func substitutionMinute(raw, replacement string) string {
+	idx := strings.Index(raw, replacement)
+	if idx <= 0 {
+		return ""
+	}
+
+	prefix := normalizeWhitespace(raw[:idx])
+	matches := minuteAtEndRe.FindStringSubmatch(prefix)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	return matches[1]
+}

--- a/internal/site/parser_common.go
+++ b/internal/site/parser_common.go
@@ -1,0 +1,28 @@
+package site
+
+import (
+	"regexp"
+	"strings"
+)
+
+var spaceRe = regexp.MustCompile(`\s+`)
+var minuteAtEndRe = regexp.MustCompile(`(\d{1,3})\s*$`)
+var minuteAnywhereRe = regexp.MustCompile(`(\d{1,3}(?:\+\d{1,2})?)`)
+var scoreLikeTextRe = regexp.MustCompile(`^\d+\s*-\s*\d+$`)
+
+func normalizeWhitespace(v string) string {
+	return strings.TrimSpace(spaceRe.ReplaceAllString(v, " "))
+}
+
+func extractMinute(text string) string {
+	matches := minuteAnywhereRe.FindStringSubmatch(text)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	return matches[1]
+}
+
+func isScoreLikeText(text string) bool {
+	return scoreLikeTextRe.MatchString(normalizeWhitespace(text))
+}

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -45,6 +45,9 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 					if match.Home == "" || match.Away == "" || match.Score == "" {
 						t.Fatalf("fixture has empty fields in %s", fixture.Name)
 					}
+					if isScoreLikeText(match.Home) || isScoreLikeText(match.Away) {
+						t.Fatalf("fixture side parsed as score token in %s: home=%q away=%q", fixture.Name, match.Home, match.Away)
+					}
 					if !strings.Contains(match.MatchURL, "mecz.php") {
 						t.Fatalf("fixture match url is not a match link in %s: %q", fixture.Name, match.MatchURL)
 					}

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -1,0 +1,117 @@
+package site
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+func TestParseLeaguePageWithoutWidthSelectors(t *testing.T) {
+	html := `
+	<html><head><title>Test League</title></head><body>
+	<table><tr><td><u>1. kolejka</u></td></tr></table>
+	<table>
+	<tr>
+		<td>2026-03-01</td>
+		<td>Gornik Leczna</td>
+		<td><a href="/mecz.php?id_mecz=123">2-1</a></td>
+		<td>Zaglebie Sosnowiec</td>
+		<td>18:00</td>
+	</tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga-test.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+	if len(page.Rounds) != 1 {
+		t.Fatalf("expected 1 round, got %d", len(page.Rounds))
+	}
+	if page.Rounds[0].Name != "1. kolejka" {
+		t.Fatalf("unexpected round name: %q", page.Rounds[0].Name)
+	}
+	if len(page.Rounds[0].Fixtures) != 1 {
+		t.Fatalf("expected 1 fixture, got %d", len(page.Rounds[0].Fixtures))
+	}
+
+	fixture := page.Rounds[0].Fixtures[0]
+	if fixture.Home != "Gornik Leczna" || fixture.Away != "Zaglebie Sosnowiec" {
+		t.Fatalf("unexpected fixture sides: %#v", fixture)
+	}
+	if fixture.MatchURL != "/mecz.php?id_mecz=123" {
+		t.Fatalf("unexpected match URL: %q", fixture.MatchURL)
+	}
+}
+
+func TestParseMatchPageWithout480Width(t *testing.T) {
+	html := `
+	<html><head><title>Match Test</title></head><body>
+	<table class="main" width="620">
+	<tr><td colspan="3"><b>I liga</b></td></tr>
+	<tr><td colspan="3">1 marca 2026, 18:00</td></tr>
+	<tr><td>GKS Tychy</td><td>2-1</td><td>Odra Opole</td></tr>
+	<tr><td>(12) Jan Kowalski</td><td>-</td><td></td></tr>
+	<tr bgcolor="#f4f4f4"><td><a href="/wystepy.php?id=1">Jan Kowalski</a></td><td></td><td><a href="/wystepy.php?id=2">Piotr Nowak</a></td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseMatchPage(doc, "http://www.90minut.pl/mecz.php?id_mecz=555")
+	if page == nil {
+		t.Fatalf("expected match page")
+	}
+	if page.Score != "2-1" {
+		t.Fatalf("unexpected score: %q", page.Score)
+	}
+	if page.HomeTeam != "GKS Tychy" || page.AwayTeam != "Odra Opole" {
+		t.Fatalf("unexpected team names: %q vs %q", page.HomeTeam, page.AwayTeam)
+	}
+	if len(page.HomeLineup) != 1 || len(page.AwayLineup) != 1 {
+		t.Fatalf("expected lineup extraction, home=%d away=%d", len(page.HomeLineup), len(page.AwayLineup))
+	}
+}
+
+func TestParseFixturesTableSkipsRowsWithMultipleMatchLinks(t *testing.T) {
+	html := `
+	<table>
+	<tr>
+		<td>Team A</td>
+		<td><a href="/mecz.php?id_mecz=1">1-0</a></td>
+		<td>Team B</td>
+		<td><a href="/mecz.php?id_mecz=2">2-2</a></td>
+	</tr>
+	</table>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	fixtures := parseFixturesTable(doc.Find("table").First())
+	if len(fixtures) != 0 {
+		t.Fatalf("expected matrix-like row to be skipped, got %d fixtures", len(fixtures))
+	}
+}
+
+func TestValidateMatchPageAllowsPartialWhenTeamsPresent(t *testing.T) {
+	page := &MatchPage{
+		Title:    "Match",
+		HomeTeam: "GKS Tychy",
+		AwayTeam: "Odra Opole",
+	}
+
+	if err := validateMatchPage(page); err != nil {
+		t.Fatalf("expected partial page to be allowed, got %v", err)
+	}
+}

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -53,6 +53,10 @@ func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage
 		}
 	}
 
+	if err := validateLeaguePage(league); err != nil {
+		return league, err
+	}
+
 	return league, nil
 }
 
@@ -70,9 +74,49 @@ func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, e
 		match.NewsURL = s.client.Resolve(match.NewsURL)
 	}
 
+	if err := validateMatchPage(match); err != nil {
+		return match, err
+	}
+
 	return match, nil
 }
 
+func validateLeaguePage(page *LeaguePage) error {
+	if page == nil {
+		return fmt.Errorf("league parse: empty page")
+	}
+
+	if len(page.Rounds) == 0 {
+		return fmt.Errorf("league parse: no rounds found")
+	}
+
+	fixtureCount := 0
+	for _, round := range page.Rounds {
+		fixtureCount += len(round.Fixtures)
+	}
+	if fixtureCount == 0 {
+		return fmt.Errorf("league parse: rounds found but fixtures are empty")
+	}
+
+	return nil
+}
+
+func validateMatchPage(page *MatchPage) error {
+	if page == nil {
+		return fmt.Errorf("match parse: empty page")
+	}
+
+	if page.HomeTeam == "" || page.AwayTeam == "" {
+		if page.Score == "" && len(page.Events) == 0 && len(page.HomeLineup) == 0 && len(page.AwayLineup) == 0 {
+			return fmt.Errorf("match parse: missing teams and score")
+		}
+	}
+
+	return nil
+}
+
+// parseSeasons extracts all available seasons and selected season marker
+// from the archive selector.
 func parseSeasons(doc *goquery.Document, c *Client) ([]Season, int) {
 	seasons := make([]Season, 0, 80)
 	selectedIdx := -1
@@ -104,6 +148,7 @@ func parseSeasons(doc *goquery.Document, c *Client) ([]Season, int) {
 	return seasons, selectedIdx
 }
 
+// parseCompetitions extracts season competition links in source order.
 func parseCompetitions(doc *goquery.Document, c *Client) []Competition {
 	links := make([]Competition, 0, 64)
 	seen := map[string]struct{}{}


### PR DESCRIPTION
## Summary
- harden league parser to use structural markers and match-link semantics instead of fixed table width/column assumptions
- split match parsing into a dedicated parser and shared parsing helpers to keep page-type concerns isolated
- prevent silent fixture corruption by skipping matrix-like rows with multiple match links and rejecting score-like team tokens
- add targeted regression tests for non-standard league/match table layouts and parser validation behavior

## Validation
- go test ./...

Closes #2
