### PR TITLE
Use stable URL IDs as canonical domain keys

### DIFF
--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -9,7 +9,7 @@ import (
 // parseLeaguePage parses a competition page into rounds and fixtures.
 // It prefers structural markers and match-link semantics over fixed table widths.
 func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
-	page := &LeaguePage{URL: url}
+	page := &LeaguePage{URL: url, LeagueKey: extractLeagueKey(url)}
 
 	page.Title = strings.TrimSpace(doc.Find("title").First().Text())
 	if page.Title == "" {
@@ -119,6 +119,7 @@ func parseFixturesTable(table *goquery.Selection) []Fixture {
 			Score:    score,
 			WhenInfo: whenInfo,
 			MatchURL: matchLink,
+			MatchID:  extractMatchID(matchLink),
 		})
 	})
 

--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -17,10 +17,10 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 
 	table := findMatchMainTable(doc)
 	if table.Length() == 0 {
-		return &MatchPage{Title: title, URL: url}
+		return &MatchPage{Title: title, URL: url, MatchID: extractMatchID(url)}
 	}
 
-	page := &MatchPage{Title: title, URL: url}
+	page := &MatchPage{Title: title, URL: url, MatchID: extractMatchID(url)}
 
 	page.Competition = normalizeWhitespace(table.Find("tr").First().Find("b").First().Text())
 	page.Meta = firstMetaLine(table)

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -1,14 +1,16 @@
 package site
 
 type Season struct {
-	Label   string
-	URL     string
-	Current bool
+	Label    string
+	URL      string
+	SeasonID string
+	Current  bool
 }
 
 type Competition struct {
-	Name string
-	URL  string
+	Name      string
+	URL       string
+	LeagueKey string
 }
 
 type Fixture struct {
@@ -17,6 +19,7 @@ type Fixture struct {
 	Score    string
 	WhenInfo string
 	MatchURL string
+	MatchID  string
 }
 
 type Round struct {
@@ -25,14 +28,16 @@ type Round struct {
 }
 
 type LeaguePage struct {
-	Title  string
-	URL    string
-	Rounds []Round
+	Title     string
+	URL       string
+	LeagueKey string
+	Rounds    []Round
 }
 
 type MatchPage struct {
 	Title       string
 	URL         string
+	MatchID     string
 	Competition string
 	Meta        string
 	Weather     string

--- a/internal/site/parser_archive_test.go
+++ b/internal/site/parser_archive_test.go
@@ -53,6 +53,9 @@ func TestParseSeasonsAndCompetitionsFromArchiveFixtures(t *testing.T) {
 
 			currentCount := 0
 			for _, season := range seasons {
+				if season.SeasonID == "" {
+					t.Fatalf("expected season id for %q", season.URL)
+				}
 				if season.Current {
 					currentCount++
 				}
@@ -69,6 +72,11 @@ func TestParseSeasonsAndCompetitionsFromArchiveFixtures(t *testing.T) {
 			competitions := parseCompetitions(doc, c)
 			if len(competitions) == 0 {
 				t.Fatalf("expected competitions from %s", fixture.Name)
+			}
+			for _, competition := range competitions {
+				if competition.LeagueKey == "" {
+					t.Fatalf("expected league key for %q", competition.URL)
+				}
 			}
 
 			if fixture.Name == "archive_2020_21" {

--- a/internal/site/parser_common.go
+++ b/internal/site/parser_common.go
@@ -1,7 +1,9 @@
 package site
 
 import (
+	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -9,6 +11,7 @@ var spaceRe = regexp.MustCompile(`\s+`)
 var minuteAtEndRe = regexp.MustCompile(`(\d{1,3})\s*$`)
 var minuteAnywhereRe = regexp.MustCompile(`(\d{1,3}(?:\+\d{1,2})?)`)
 var scoreLikeTextRe = regexp.MustCompile(`^\d+\s*-\s*\d+$`)
+var leaguePathKeyRe = regexp.MustCompile(`(?i)(?:^|/)liga/\d+/(liga\d+)\.html$`)
 
 func normalizeWhitespace(v string) string {
 	return strings.TrimSpace(spaceRe.ReplaceAllString(v, " "))
@@ -25,4 +28,64 @@ func extractMinute(text string) string {
 
 func isScoreLikeText(text string) bool {
 	return scoreLikeTextRe.MatchString(normalizeWhitespace(text))
+}
+
+func canonicalURLKey(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return strings.TrimSpace(raw)
+	}
+
+	parsed.Fragment = ""
+	query := parsed.Query()
+	for key := range query {
+		sort.Strings(query[key])
+	}
+	parsed.RawQuery = query.Encode()
+
+	host := strings.ToLower(parsed.Host)
+	path := parsed.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+
+	key := host + path
+	if parsed.RawQuery != "" {
+		key += "?" + parsed.RawQuery
+	}
+
+	if key == "" {
+		return strings.TrimSpace(raw)
+	}
+
+	return key
+}
+
+func extractQueryParam(rawURL, name string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+
+	return strings.TrimSpace(parsed.Query().Get(name))
+}
+
+func extractSeasonID(rawURL string) string {
+	return extractQueryParam(rawURL, "id_sezon")
+}
+
+func extractMatchID(rawURL string) string {
+	return extractQueryParam(rawURL, "id_mecz")
+}
+
+func extractLeagueKey(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err == nil {
+		matches := leaguePathKeyRe.FindStringSubmatch(parsed.EscapedPath())
+		if len(matches) >= 2 {
+			return strings.ToLower(strings.TrimSpace(matches[1]))
+		}
+	}
+
+	return canonicalURLKey(rawURL)
 }

--- a/internal/site/parser_keys_test.go
+++ b/internal/site/parser_keys_test.go
@@ -1,0 +1,46 @@
+package site
+
+import "testing"
+
+func TestExtractStableKeysFromURLs(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		seasonID  string
+		matchID   string
+		leagueKey string
+	}{
+		{
+			name:      "season archive URL",
+			url:       "http://www.90minut.pl/archsezon.php?id_sezon=97",
+			seasonID:  "97",
+			leagueKey: "www.90minut.pl/archsezon.php?id_sezon=97",
+		},
+		{
+			name:      "match URL",
+			url:       "http://www.90minut.pl/mecz.php?id_mecz=2022810",
+			matchID:   "2022810",
+			leagueKey: "www.90minut.pl/mecz.php?id_mecz=2022810",
+		},
+		{
+			name:      "league URL",
+			url:       "http://www.90minut.pl/liga/1/liga11233.html",
+			leagueKey: "liga11233",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractSeasonID(tc.url); got != tc.seasonID {
+				t.Fatalf("extractSeasonID(%q)=%q want %q", tc.url, got, tc.seasonID)
+			}
+			if got := extractMatchID(tc.url); got != tc.matchID {
+				t.Fatalf("extractMatchID(%q)=%q want %q", tc.url, got, tc.matchID)
+			}
+			if got := extractLeagueKey(tc.url); got != tc.leagueKey {
+				t.Fatalf("extractLeagueKey(%q)=%q want %q", tc.url, got, tc.leagueKey)
+			}
+		})
+	}
+}

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -29,6 +29,9 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 			if len(page.Rounds) == 0 {
 				t.Fatalf("expected rounds for %s", fixture.Name)
 			}
+			if page.LeagueKey == "" {
+				t.Fatalf("expected league key for %s", fixture.Name)
+			}
 			for _, round := range page.Rounds {
 				if strings.TrimSpace(round.Name) == "" {
 					t.Fatalf("round with empty name in %s", fixture.Name)
@@ -50,6 +53,9 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 					}
 					if !strings.Contains(match.MatchURL, "mecz.php") {
 						t.Fatalf("fixture match url is not a match link in %s: %q", fixture.Name, match.MatchURL)
+					}
+					if match.MatchID == "" {
+						t.Fatalf("fixture missing match id in %s: %q", fixture.Name, match.MatchURL)
 					}
 				}
 			}

--- a/internal/site/parser_match_test.go
+++ b/internal/site/parser_match_test.go
@@ -34,6 +34,12 @@ func TestParseMatchFixturesFromCorpus(t *testing.T) {
 			if page.Title == "" {
 				t.Fatalf("expected title for %s", fixture.Name)
 			}
+			if page.MatchID == "" {
+				t.Fatalf("expected match id for %s", fixture.Name)
+			}
+			if fixtureID := extractMatchID(fixture.URL); fixtureID != "" && page.MatchID != fixtureID {
+				t.Fatalf("match id mismatch for %s: got %q want %q", fixture.Name, page.MatchID, fixtureID)
+			}
 
 			if hasPolishDiacritic(page.HomeTeam) || hasPolishDiacritic(page.AwayTeam) {
 				foundDiacritics = true

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -34,6 +34,9 @@ func TestParseLeaguePageWithoutWidthSelectors(t *testing.T) {
 	if len(page.Rounds) != 1 {
 		t.Fatalf("expected 1 round, got %d", len(page.Rounds))
 	}
+	if page.LeagueKey != "www.90minut.pl/liga/1/liga-test.html" {
+		t.Fatalf("unexpected league key: %q", page.LeagueKey)
+	}
 	if page.Rounds[0].Name != "1. kolejka" {
 		t.Fatalf("unexpected round name: %q", page.Rounds[0].Name)
 	}
@@ -47,6 +50,9 @@ func TestParseLeaguePageWithoutWidthSelectors(t *testing.T) {
 	}
 	if fixture.MatchURL != "/mecz.php?id_mecz=123" {
 		t.Fatalf("unexpected match URL: %q", fixture.MatchURL)
+	}
+	if fixture.MatchID != "123" {
+		t.Fatalf("unexpected match id: %q", fixture.MatchID)
 	}
 }
 
@@ -73,6 +79,9 @@ func TestParseMatchPageWithout480Width(t *testing.T) {
 	}
 	if page.Score != "2-1" {
 		t.Fatalf("unexpected score: %q", page.Score)
+	}
+	if page.MatchID != "555" {
+		t.Fatalf("unexpected match id: %q", page.MatchID)
 	}
 	if page.HomeTeam != "GKS Tychy" || page.AwayTeam != "Odra Opole" {
 		t.Fatalf("unexpected team names: %q vs %q", page.HomeTeam, page.AwayTeam)

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -46,10 +46,12 @@ func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage
 	if league == nil {
 		return nil, fmt.Errorf("league parse: no round fixtures found")
 	}
+	league.LeagueKey = extractLeagueKey(league.URL)
 
 	for i := range league.Rounds {
 		for j := range league.Rounds[i].Fixtures {
 			league.Rounds[i].Fixtures[j].MatchURL = s.client.Resolve(league.Rounds[i].Fixtures[j].MatchURL)
+			league.Rounds[i].Fixtures[j].MatchID = extractMatchID(league.Rounds[i].Fixtures[j].MatchURL)
 		}
 	}
 
@@ -70,6 +72,7 @@ func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, e
 	if match == nil {
 		return nil, fmt.Errorf("match parse: no details found")
 	}
+	match.MatchID = extractMatchID(match.URL)
 	if match.NewsURL != "" {
 		match.NewsURL = s.client.Resolve(match.NewsURL)
 	}
@@ -127,9 +130,12 @@ func parseSeasons(doc *goquery.Document, c *Client) ([]Season, int) {
 			return
 		}
 
+		resolvedURL := c.Resolve(rawURL)
+
 		season := Season{
-			Label: strings.TrimSpace(s.Text()),
-			URL:   c.Resolve(rawURL),
+			Label:    strings.TrimSpace(s.Text()),
+			URL:      resolvedURL,
+			SeasonID: extractSeasonID(resolvedURL),
 		}
 
 		if _, isSelected := s.Attr("selected"); isSelected {
@@ -178,7 +184,7 @@ func parseCompetitions(doc *goquery.Document, c *Client) []Competition {
 			name = absoluteURL
 		}
 
-		links = append(links, Competition{Name: name, URL: absoluteURL})
+		links = append(links, Competition{Name: name, URL: absoluteURL, LeagueKey: extractLeagueKey(absoluteURL)})
 	})
 
 	return links

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -29,21 +29,21 @@ type archiveLoadedMsg struct {
 }
 
 type competitionsLoadedMsg struct {
-	seasonIdx    int
+	seasonKey    string
 	competitions []site.Competition
 	err          error
 }
 
 type leagueLoadedMsg struct {
-	competitionIdx int
+	competitionKey string
 	league         *site.LeaguePage
 	err            error
 }
 
 type matchLoadedMsg struct {
-	matchURL string
-	match    *site.MatchPage
-	err      error
+	fixtureKey string
+	match      *site.MatchPage
+	err        error
 }
 
 type Model struct {
@@ -135,13 +135,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.loadArchiveCmd("http://www.90minut.pl/archsezon.php")
 			}
 			if m.focus == focusSeasons {
-				return m, m.loadSeasonCompetitionsCmd(m.seasons[m.seasonCursor].URL, m.seasonCursor)
+				season := m.currentSeason()
+				if season == nil {
+					m.loading = false
+					return m, nil
+				}
+				return m, m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season))
 			}
 			if len(m.competitions) == 0 {
 				m.loading = false
 				return m, nil
 			}
-			return m, m.loadLeagueCmd(m.competitions[m.competitionCursor].URL, m.competitionCursor)
+			competition := m.currentCompetition()
+			if competition == nil {
+				m.loading = false
+				return m, nil
+			}
+			return m, m.loadLeagueCmd(competition.URL, competitionRequestKey(*competition))
 		}
 
 	case archiveLoadedMsg:
@@ -162,7 +172,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.loading = true
-		return m, m.loadLeagueCmd(m.competitions[m.competitionCursor].URL, m.competitionCursor)
+		competition := m.currentCompetition()
+		if competition == nil {
+			m.loading = false
+			return m, nil
+		}
+		return m, m.loadLeagueCmd(competition.URL, competitionRequestKey(*competition))
 
 	case competitionsLoadedMsg:
 		m.loading = false
@@ -171,7 +186,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		if msg.seasonIdx != m.seasonCursor {
+		season := m.currentSeason()
+		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
 			return m, nil
 		}
 
@@ -187,7 +203,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.loading = true
-		return m, m.loadLeagueCmd(m.competitions[m.competitionCursor].URL, m.competitionCursor)
+		competition := m.currentCompetition()
+		if competition == nil {
+			m.loading = false
+			return m, nil
+		}
+		return m, m.loadLeagueCmd(competition.URL, competitionRequestKey(*competition))
 
 	case leagueLoadedMsg:
 		m.loading = false
@@ -197,7 +218,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		if msg.competitionIdx != m.competitionCursor {
+		competition := m.currentCompetition()
+		if competition == nil || msg.competitionKey != competitionRequestKey(*competition) {
 			return m, nil
 		}
 
@@ -220,7 +242,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		current := m.currentFixture()
-		if current == nil || current.MatchURL != msg.matchURL {
+		if current == nil || fixtureRequestKey(*current) != msg.fixtureKey {
 			return m, nil
 		}
 
@@ -475,7 +497,12 @@ func (m *Model) handleEnter() tea.Cmd {
 		}
 		m.matchView = false
 		m.match = nil
-		return m.loadSeasonCompetitionsCmd(m.seasons[m.seasonCursor].URL, m.seasonCursor)
+		season := m.currentSeason()
+		if season == nil {
+			m.loading = false
+			return nil
+		}
+		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season))
 
 	case focusCompetitions:
 		if len(m.competitions) == 0 {
@@ -484,7 +511,12 @@ func (m *Model) handleEnter() tea.Cmd {
 		}
 		m.matchView = false
 		m.match = nil
-		return m.loadLeagueCmd(m.competitions[m.competitionCursor].URL, m.competitionCursor)
+		competition := m.currentCompetition()
+		if competition == nil {
+			m.loading = false
+			return nil
+		}
+		return m.loadLeagueCmd(competition.URL, competitionRequestKey(*competition))
 
 	case focusFixtures:
 		fixture := m.currentFixture()
@@ -492,7 +524,7 @@ func (m *Model) handleEnter() tea.Cmd {
 			m.loading = false
 			return nil
 		}
-		return m.loadMatchCmd(fixture.MatchURL)
+		return m.loadMatchCmd(fixture.MatchURL, fixtureRequestKey(*fixture))
 	}
 
 	m.loading = false
@@ -507,6 +539,26 @@ func (m Model) currentRound() *site.Round {
 		return nil
 	}
 	return &m.league.Rounds[m.roundCursor]
+}
+
+func (m Model) currentSeason() *site.Season {
+	if len(m.seasons) == 0 {
+		return nil
+	}
+	if m.seasonCursor < 0 || m.seasonCursor >= len(m.seasons) {
+		return nil
+	}
+	return &m.seasons[m.seasonCursor]
+}
+
+func (m Model) currentCompetition() *site.Competition {
+	if len(m.competitions) == 0 {
+		return nil
+	}
+	if m.competitionCursor < 0 || m.competitionCursor >= len(m.competitions) {
+		return nil
+	}
+	return &m.competitions[m.competitionCursor]
 }
 
 func (m Model) currentFixture() *site.Fixture {
@@ -541,31 +593,52 @@ func (m Model) loadArchiveCmd(url string) tea.Cmd {
 	}
 }
 
-func (m Model) loadSeasonCompetitionsCmd(url string, seasonIdx int) tea.Cmd {
+func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		_, _, competitions, err := m.service.LoadArchive(ctx, url)
-		return competitionsLoadedMsg{seasonIdx: seasonIdx, competitions: competitions, err: err}
+		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, err: err}
 	}
 }
 
-func (m Model) loadLeagueCmd(url string, competitionIdx int) tea.Cmd {
+func (m Model) loadLeagueCmd(url, competitionKey string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		league, err := m.service.LoadLeague(ctx, url)
-		return leagueLoadedMsg{competitionIdx: competitionIdx, league: league, err: err}
+		return leagueLoadedMsg{competitionKey: competitionKey, league: league, err: err}
 	}
 }
 
-func (m Model) loadMatchCmd(url string) tea.Cmd {
+func (m Model) loadMatchCmd(url, fixtureKey string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 		match, err := m.service.LoadMatch(ctx, url)
-		return matchLoadedMsg{matchURL: url, match: match, err: err}
+		return matchLoadedMsg{fixtureKey: fixtureKey, match: match, err: err}
 	}
+}
+
+func seasonRequestKey(season site.Season) string {
+	if season.SeasonID != "" {
+		return "season:" + season.SeasonID
+	}
+	return "season-url:" + strings.TrimSpace(season.URL)
+}
+
+func competitionRequestKey(competition site.Competition) string {
+	if competition.LeagueKey != "" {
+		return "league:" + competition.LeagueKey
+	}
+	return "league-url:" + strings.TrimSpace(competition.URL)
+}
+
+func fixtureRequestKey(fixture site.Fixture) string {
+	if fixture.MatchID != "" {
+		return "match:" + fixture.MatchID
+	}
+	return "match-url:" + strings.TrimSpace(fixture.MatchURL)
 }
 
 func renderSeasonsWindow(seasons []site.Season, cursor int) []string {

--- a/internal/ui/model_keys_test.go
+++ b/internal/ui/model_keys_test.go
@@ -1,0 +1,41 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
+)
+
+func TestRequestKeysPreferStableIDs(t *testing.T) {
+	season := site.Season{URL: "http://www.90minut.pl/archsezon.php?id_sezon=97", SeasonID: "97"}
+	if got := seasonRequestKey(season); got != "season:97" {
+		t.Fatalf("unexpected season request key: %q", got)
+	}
+
+	competition := site.Competition{URL: "http://www.90minut.pl/liga/1/liga11233.html", LeagueKey: "liga11233"}
+	if got := competitionRequestKey(competition); got != "league:liga11233" {
+		t.Fatalf("unexpected competition request key: %q", got)
+	}
+
+	fixture := site.Fixture{MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=2022810", MatchID: "2022810"}
+	if got := fixtureRequestKey(fixture); got != "match:2022810" {
+		t.Fatalf("unexpected fixture request key: %q", got)
+	}
+}
+
+func TestRequestKeysFallbackToURLs(t *testing.T) {
+	season := site.Season{URL: "http://www.90minut.pl/archsezon.php?id_sezon=97"}
+	if got := seasonRequestKey(season); got != "season-url:http://www.90minut.pl/archsezon.php?id_sezon=97" {
+		t.Fatalf("unexpected season fallback key: %q", got)
+	}
+
+	competition := site.Competition{URL: "http://www.90minut.pl/liga/1/liga11233.html"}
+	if got := competitionRequestKey(competition); got != "league-url:http://www.90minut.pl/liga/1/liga11233.html" {
+		t.Fatalf("unexpected competition fallback key: %q", got)
+	}
+
+	fixture := site.Fixture{MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=2022810"}
+	if got := fixtureRequestKey(fixture); got != "match-url:http://www.90minut.pl/mecz.php?id_mecz=2022810" {
+		t.Fatalf("unexpected fixture fallback key: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add canonical stable keys to core parsed models: `SeasonID`, `LeagueKey`, `MatchID`, and page-level `LeagueKey`/`MatchID` while preserving source URLs
- populate IDs/keys from source URLs in parser/service flow so navigation and future joins can rely on stable identifiers instead of display labels
- switch UI async request correlation from cursor indexes to stable request keys derived from IDs (with URL fallback)
- add parser and UI tests for key extraction, ID presence, and key-preference behavior

## Validation
- go test ./...

Closes #4
