### PR TITLE
Document parser/UI contracts and add parser edge-case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Terminal UI for browsing `90minut.pl` (Polish football archive) without an API.
 
 - Small, single-binary Go app.
 - Read-only browsing flow: `season -> league -> fixture -> match`.
+- Startup preloads the selected season and opens its preferred competition (defaults to `Ekstraklasa` when present), then focuses fixtures.
 - Fast navigation and robust HTML parsing over feature breadth.
 
 ## Current Features
@@ -49,11 +50,24 @@ Core pipeline: `fetch -> parse -> render`.
 - 90minut pages use legacy encoding (`iso-8859-2`) and must be decoded before parsing.
 - Prefer semantic selectors over fixed table offsets.
 - URL IDs are treated as stable keys (e.g. season/match links).
+- Async UI loads are keyed by season/competition/fixture IDs so stale responses are ignored if focus changes.
+- Match parsing still assumes mostly three-cell timeline rows and uses heuristic table scoring; add fixtures/tests when source layout drifts.
+
+## Fixture Corpus Maintenance
+
+Parser tests rely on saved HTML fixtures in `internal/site/testdata/fixtures` and `internal/site/testdata/manifest.json`.
+
+```bash
+go run ./cmd/fetchfixtures
+go test ./...
+```
+
+Use this flow when parser behavior changes or when upstream HTML structure drifts.
 
 ## Quality Gates
 
 - CI runs `go test ./...` on pull requests and on pushes to `master`.
-- Local pre-commit checks use `prek` with `.pre-commit-config.yaml`.
+- Local pre-commit checks use `prek` with pre-commit-compatible `.pre-commit-config.yaml`.
 
 ```bash
 prek install

--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -6,7 +6,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// parseLeaguePage parses a competition page into rounds and fixtures.
 // It prefers structural markers and match-link semantics over fixed table widths.
 func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	page := &LeaguePage{URL: url, LeagueKey: extractLeagueKey(url)}
@@ -42,10 +41,12 @@ func parseRounds(doc *goquery.Document) []Round {
 
 		roundName := currentName
 		if roundName == "" {
+			// Some archive pages omit round headers for a fixture block.
 			roundName = "Wyniki"
 		}
 
 		if len(rounds) > 0 && rounds[len(rounds)-1].Name == roundName {
+			// Source HTML may split one round into adjacent tables with the same heading.
 			rounds[len(rounds)-1].Fixtures = append(rounds[len(rounds)-1].Fixtures, fixtures...)
 			return
 		}

--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// parseMatchPage parses a single match page into score, timeline and lineups.
 // It identifies the match table by content signatures instead of a fixed width.
 func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 	title := normalizeWhitespace(doc.Find("title").First().Text())
@@ -44,6 +43,7 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 		}
 
 		if strings.Contains(middle, "-") {
+			// Goal rows keep one side empty; non-empty side maps event ownership.
 			if left != "" && right == "" {
 				page.Events = append(page.Events, MatchEvent{
 					MinuteText: extractMinute(left),
@@ -103,6 +103,7 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 
 func findMatchMainTable(doc *goquery.Document) *goquery.Selection {
 	bestScore := -1
+	// Preserve legacy fallback for older 90minut pages that still use width=480.
 	best := doc.Find("table.main[width='480']").First()
 
 	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
@@ -250,6 +251,7 @@ func parsePlayerCell(cell *goquery.Selection) *PlayerLine {
 	}
 
 	if cell.Find("img[src*='sub.gif']").Length() > 0 && len(anchors) > 1 {
+		// In 90minut substitution cells, the last linked player is the replacement.
 		replacement := anchors[len(anchors)-1]
 		minute := substitutionMinute(raw, replacement)
 		if minute != "" {

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -1,0 +1,98 @@
+package site
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/text/encoding/charmap"
+)
+
+func TestDecodeAndParseISO88592FromContentType(t *testing.T) {
+	html := `<html><head><title>Zażółć gęślą jaźń</title></head><body><div class="main">Piątek</div></body></html>`
+	encoded, err := charmap.ISO8859_2.NewEncoder().Bytes([]byte(html))
+	if err != nil {
+		t.Fatalf("encode fixture html: %v", err)
+	}
+
+	doc, err := decodeAndParse(encoded, "text/html; charset=iso-8859-2")
+	if err != nil {
+		t.Fatalf("decode and parse: %v", err)
+	}
+
+	title := normalizeWhitespace(doc.Find("title").First().Text())
+	if title != "Zażółć gęślą jaźń" {
+		t.Fatalf("unexpected decoded title: %q", title)
+	}
+
+	body := normalizeWhitespace(doc.Find("body").Text())
+	if !strings.Contains(body, "Piątek") {
+		t.Fatalf("expected decoded body to contain diacritics, got %q", body)
+	}
+	if strings.ContainsRune(body, '�') {
+		t.Fatalf("decoded body contains replacement rune: %q", body)
+	}
+}
+
+func TestParseSeasonsDefaultsToFirstWhenNoOptionSelected(t *testing.T) {
+	html := `<html><body><select name="urljump">
+		<option value="/archsezon.php?id_sezon=97">2020/21</option>
+		<option value="/archsezon.php?id_sezon=98">2021/22</option>
+	</select></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic html: %v", err)
+	}
+
+	seasons, selectedIdx := parseSeasons(doc, NewClient())
+	if len(seasons) != 2 {
+		t.Fatalf("expected 2 seasons, got %d", len(seasons))
+	}
+	if selectedIdx != 0 {
+		t.Fatalf("expected selected index 0, got %d", selectedIdx)
+	}
+	if !seasons[0].Current || seasons[1].Current {
+		t.Fatalf("expected only first season marked current: %#v", seasons)
+	}
+}
+
+func TestParseMatchPageGoalSideAssignmentAndStoppageMinutes(t *testing.T) {
+	html := `
+	<html><head><title>Match Test</title></head><body>
+	<table class="main" width="620">
+	<tr><td colspan="3"><b>I liga</b></td></tr>
+	<tr><td colspan="3">1 marca 2026, 18:00</td></tr>
+	<tr><td>GKS Tychy</td><td>2-2</td><td>Odra Opole</td></tr>
+	<tr><td>(45+1) Jan Kowalski</td><td>-</td><td></td></tr>
+	<tr><td></td><td>-</td><td>(90+2) Adam Nowak</td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic html: %v", err)
+	}
+
+	page := parseMatchPage(doc, "http://www.90minut.pl/mecz.php?id_mecz=777")
+	if page == nil {
+		t.Fatalf("expected parsed match page")
+	}
+
+	goals := make([]MatchEvent, 0, 2)
+	for _, event := range page.Events {
+		if event.Kind == "GOAL" {
+			goals = append(goals, event)
+		}
+	}
+
+	if len(goals) != 2 {
+		t.Fatalf("expected 2 goals, got %d", len(goals))
+	}
+	if goals[0].TeamSide != "home" || goals[0].MinuteText != "45+1" {
+		t.Fatalf("unexpected first goal: %#v", goals[0])
+	}
+	if goals[1].TeamSide != "away" || goals[1].MinuteText != "90+2" {
+		t.Fatalf("unexpected second goal: %#v", goals[1])
+	}
+}

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -118,8 +118,7 @@ func validateMatchPage(page *MatchPage) error {
 	return nil
 }
 
-// parseSeasons extracts all available seasons and selected season marker
-// from the archive selector.
+// If archive markup has no selected option, we default to the first season.
 func parseSeasons(doc *goquery.Document, c *Client) ([]Season, int) {
 	seasons := make([]Season, 0, 80)
 	selectedIdx := -1
@@ -154,7 +153,6 @@ func parseSeasons(doc *goquery.Document, c *Client) ([]Season, int) {
 	return seasons, selectedIdx
 }
 
-// parseCompetitions extracts season competition links in source order.
 func parseCompetitions(doc *goquery.Document, c *Client) []Competition {
 	links := make([]Competition, 0, 64)
 	seen := map[string]struct{}{}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -122,6 +122,7 @@ func (m Model) preferredCompetitionIndex() int {
 		return 0
 	}
 	for i, c := range m.competitions {
+		// Keep first load useful for most users without adding config/state persistence.
 		if strings.Contains(strings.ToLower(c.Name), "ekstraklasa") {
 			return i
 		}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -115,6 +115,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		season := m.currentSeason()
+		// Drop stale async results if the user moved to another season.
 		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
 			return m, nil
 		}
@@ -147,6 +148,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		competition := m.currentCompetition()
+		// Drop stale async results if the user switched competitions.
 		if competition == nil || msg.competitionKey != competitionRequestKey(*competition) {
 			return m, nil
 		}
@@ -170,6 +172,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		current := m.currentFixture()
+		// Drop stale async results if the selected fixture changed.
 		if current == nil || fixtureRequestKey(*current) != msg.fixtureKey {
 			return m, nil
 		}


### PR DESCRIPTION
## Summary
- Align README with current app behavior and parser reliability constraints (startup preload flow, stale async guard rationale, fixture-corpus maintenance workflow).
- Tighten code comments to keep non-obvious parsing and async-navigation context while removing syntax narration.
- Add parser edge-case tests for explicit `iso-8859-2` decoding, no-selected-season fallback, and goal side/minute extraction in stoppage time.

## Validation
- `go test ./...`
