### PR TITLE
Scope league round parsing and guard fixture navigation

### DIFF
--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -6,7 +6,8 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// It prefers structural markers and match-link semantics over fixed table widths.
+// League pages drift across seasons, so round extraction anchors on heading tables
+// and `mecz.php` fixture links instead of brittle width/column assumptions.
 func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	page := &LeaguePage{URL: url, LeagueKey: extractLeagueKey(url)}
 
@@ -27,10 +28,12 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 func parseRounds(doc *goquery.Document) []Round {
 	rounds := make([]Round, 0, 16)
 	currentName := ""
+	hasNamedRounds := false
 
-	doc.Find("table").Each(func(_ int, table *goquery.Selection) {
+	leagueTables(doc).Each(func(_ int, table *goquery.Selection) {
 		if name, ok := roundNameFromTable(table); ok {
 			currentName = name
+			hasNamedRounds = true
 			return
 		}
 
@@ -39,11 +42,7 @@ func parseRounds(doc *goquery.Document) []Round {
 			return
 		}
 
-		roundName := currentName
-		if roundName == "" {
-			// Some archive pages omit round headers for a fixture block.
-			roundName = "Wyniki"
-		}
+		roundName := strings.TrimSpace(currentName)
 
 		if len(rounds) > 0 && rounds[len(rounds)-1].Name == roundName {
 			// Source HTML may split one round into adjacent tables with the same heading.
@@ -54,7 +53,39 @@ func parseRounds(doc *goquery.Document) []Round {
 		rounds = append(rounds, Round{Name: roundName, Fixtures: fixtures})
 	})
 
+	if hasNamedRounds {
+		// Once explicit round headings exist, unnamed fixture tables in the same area
+		// are usually standings/nav spillover rather than standalone rounds.
+		namedOnly := make([]Round, 0, len(rounds))
+		for _, round := range rounds {
+			if strings.TrimSpace(round.Name) == "" {
+				continue
+			}
+			namedOnly = append(namedOnly, round)
+		}
+		if len(namedOnly) > 0 {
+			rounds = namedOnly
+		}
+	}
+
+	for i := range rounds {
+		if strings.TrimSpace(rounds[i].Name) != "" {
+			continue
+		}
+		// Fully headerless fixture pages are normalized to a single fallback round.
+		rounds[i].Name = "Wyniki"
+	}
+
 	return rounds
+}
+
+func leagueTables(doc *goquery.Document) *goquery.Selection {
+	mainCell := doc.Find("td.main[align='center']").First()
+	if mainCell.Length() > 0 {
+		return mainCell.Find("table")
+	}
+
+	return doc.Find("table")
 }
 
 func roundNameFromTable(table *goquery.Selection) (string, bool) {
@@ -67,12 +98,43 @@ func roundNameFromTable(table *goquery.Selection) (string, bool) {
 		return heading, true
 	}
 
-	text := normalizeWhitespace(table.Text())
+	if !looksLikeStandaloneHeadingTable(table) {
+		return "", false
+	}
+
+	text := normalizeWhitespace(table.ChildrenFiltered("tbody, tr").Text())
 	if looksLikeRoundHeading(text) {
 		return text, true
 	}
 
 	return "", false
+}
+
+func looksLikeStandaloneHeadingTable(table *goquery.Selection) bool {
+	rows := table.ChildrenFiltered("tbody, tr").ChildrenFiltered("tr")
+	if rows.Length() == 0 {
+		rows = table.ChildrenFiltered("tr")
+	}
+	if rows.Length() != 1 {
+		return false
+	}
+
+	tds := rows.First().ChildrenFiltered("td, th")
+	if tds.Length() != 1 {
+		return false
+	}
+
+	text := normalizeWhitespace(tds.First().Text())
+	if text == "" {
+		return false
+	}
+
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "wyniki") || strings.Contains(lower, "strzelcy") || strings.Contains(lower, "statystyki") || strings.Contains(lower, "ostatnia kolejka") {
+		return false
+	}
+
+	return true
 }
 
 func looksLikeRoundHeading(text string) bool {

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -5,8 +5,18 @@ import (
 	"testing"
 )
 
+type leagueRoundExpectation struct {
+	firstRoundName      string
+	firstRoundFixtures  int
+	firstFixtureMatchID string
+}
+
 func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 	m := loadManifest(t)
+	expected := map[string]leagueRoundExpectation{
+		"league_14072": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9, firstFixtureMatchID: "2022730"},
+		"league_14073": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9, firstFixtureMatchID: "2023371"},
+	}
 	leagues := fixturesByKind(m, "league")
 	if len(leagues) < 6 {
 		t.Fatalf("expected at least 6 league fixtures, got %d", len(leagues))
@@ -61,6 +71,29 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 			}
 			if totalFixtures == 0 {
 				t.Fatalf("expected fixtures for %s", fixture.Name)
+			}
+
+			firstRound := page.Rounds[0]
+			if firstRound.Name == "Wyniki" {
+				t.Fatalf("expected first extracted round to be named in %s", fixture.Name)
+			}
+			for _, round := range page.Rounds {
+				lower := strings.ToLower(round.Name)
+				if strings.Contains(lower, "strzelcy") || strings.Contains(lower, "statystyki") || strings.Contains(lower, "ostatnia kolejka") {
+					t.Fatalf("navigation block parsed as round %q in %s", round.Name, fixture.Name)
+				}
+			}
+
+			if want, ok := expected[fixture.Name]; ok {
+				if firstRound.Name != want.firstRoundName {
+					t.Fatalf("unexpected first round name in %s: got %q want %q", fixture.Name, firstRound.Name, want.firstRoundName)
+				}
+				if len(firstRound.Fixtures) != want.firstRoundFixtures {
+					t.Fatalf("unexpected first round fixture count in %s: got %d want %d", fixture.Name, len(firstRound.Fixtures), want.firstRoundFixtures)
+				}
+				if firstRound.Fixtures[0].MatchID != want.firstFixtureMatchID {
+					t.Fatalf("unexpected first fixture id in %s: got %q want %q", fixture.Name, firstRound.Fixtures[0].MatchID, want.firstFixtureMatchID)
+				}
 			}
 
 			if fixture.Name == "league_14072" || fixture.Name == "league_14073" {

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -113,6 +113,29 @@ func TestParseFixturesTableSkipsRowsWithMultipleMatchLinks(t *testing.T) {
 	}
 }
 
+func TestRoundNameFromTableSkipsNavigationBlocks(t *testing.T) {
+	html := `
+	<table>
+	<tr>
+		<td>
+			.: <a href="/liga/1/liga14072.html" class="main">Wyniki</a> |
+			<a href="/strzelcy.php?id=14072" class="main">Strzelcy</a> |
+			<a href="/stats.php?id=14072" class="main">Statystyki</a> |
+			<a href="/liga/1/liga14072.html#last" class="main">Ostatnia kolejka</a> :.
+		</td>
+	</tr>
+	</table>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	if name, ok := roundNameFromTable(doc.Find("table").First()); ok {
+		t.Fatalf("expected nav block to be ignored, got %q", name)
+	}
+}
+
 func TestValidateMatchPageAllowsPartialWhenTeamsPresent(t *testing.T) {
 	page := &MatchPage{
 		Title:    "Match",

--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -1,0 +1,186 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
+)
+
+type recordingLoader struct {
+	archiveCalls int
+	leagueCalls  int
+	matchCalls   int
+
+	seasons      []site.Season
+	selectedIdx  int
+	competitions []site.Competition
+	league       *site.LeaguePage
+	match        *site.MatchPage
+}
+
+func (l *recordingLoader) LoadArchive(context.Context, string) ([]site.Season, int, []site.Competition, error) {
+	l.archiveCalls++
+	return l.seasons, l.selectedIdx, l.competitions, nil
+}
+
+func (l *recordingLoader) LoadLeague(context.Context, string) (*site.LeaguePage, error) {
+	l.leagueCalls++
+	return l.league, nil
+}
+
+func (l *recordingLoader) LoadMatch(context.Context, string) (*site.MatchPage, error) {
+	l.matchCalls++
+	return l.match, nil
+}
+
+func TestFixtureNavigationDoesNotReloadLeague(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+
+	if loader.leagueCalls != 1 {
+		t.Fatalf("expected one league load after startup, got %d", loader.leagueCalls)
+	}
+
+	if fixture := m.currentFixture(); fixture == nil || fixture.MatchID != "1" {
+		t.Fatalf("expected fixture #1 selected after startup")
+	}
+
+	m, cmd := updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyDown})
+	if cmd != nil {
+		t.Fatalf("expected no command on fixture cursor move down")
+	}
+	if fixture := m.currentFixture(); fixture == nil || fixture.MatchID != "2" {
+		t.Fatalf("expected fixture #2 selected after moving down")
+	}
+	if loader.leagueCalls != 1 {
+		t.Fatalf("fixture cursor move should not reload league, got %d league loads", loader.leagueCalls)
+	}
+	if loader.matchCalls != 0 {
+		t.Fatalf("fixture cursor move should not load match, got %d match loads", loader.matchCalls)
+	}
+
+	m, cmd = updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyUp})
+	if cmd != nil {
+		t.Fatalf("expected no command on fixture cursor move up")
+	}
+	if loader.leagueCalls != 1 {
+		t.Fatalf("switching back to fixture #1 should not reload league, got %d league loads", loader.leagueCalls)
+	}
+	if loader.matchCalls != 0 {
+		t.Fatalf("fixture cursor move should not load match, got %d match loads", loader.matchCalls)
+	}
+
+	if fixture := m.currentFixture(); fixture == nil || fixture.MatchID != "1" {
+		t.Fatalf("expected fixture #1 selected after moving back")
+	}
+}
+
+func TestFixtureEnterLoadsMatchWithoutReloadingLeague(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+
+	m, cmd := updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected enter on fixture to return loadMatch command")
+	}
+	if loader.leagueCalls != 1 {
+		t.Fatalf("expected league load count to stay at 1 before running match command, got %d", loader.leagueCalls)
+	}
+
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd != nil {
+		t.Fatalf("expected no chained command after match load")
+	}
+	if loader.matchCalls != 1 {
+		t.Fatalf("expected one match load, got %d", loader.matchCalls)
+	}
+	if loader.leagueCalls != 1 {
+		t.Fatalf("match open should not trigger league reload, got %d league loads", loader.leagueCalls)
+	}
+	if !m.matchView || m.match == nil || m.match.MatchID != "1" {
+		t.Fatalf("expected match view for fixture #1")
+	}
+}
+
+func bootstrapLeagueLoadedModel(t *testing.T, loader *recordingLoader) Model {
+	t.Helper()
+
+	m := NewModel(loader)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected init command")
+	}
+
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd == nil {
+		t.Fatalf("expected archive loaded flow to schedule league load")
+	}
+
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	for i := 0; i < 4 && cmd != nil; i++ {
+		m, cmd = updateModelWithMsg(t, m, cmd())
+	}
+
+	if loader.leagueCalls != 1 {
+		t.Fatalf("expected one league load after startup, got %d", loader.leagueCalls)
+	}
+	if m.league == nil {
+		t.Fatalf("expected league to be loaded")
+	}
+	if m.focus != focusFixtures {
+		t.Fatalf("expected fixtures focus after league load")
+	}
+
+	return m
+}
+
+func updateModelWithMsg(t *testing.T, m Model, msg tea.Msg) (Model, tea.Cmd) {
+	t.Helper()
+
+	next, cmd := m.Update(msg)
+	updated, ok := next.(Model)
+	if !ok {
+		t.Fatalf("unexpected model type %T", next)
+	}
+
+	return updated, cmd
+}
+
+func newRecordingLoader() *recordingLoader {
+	return &recordingLoader{
+		seasons: []site.Season{{
+			Label:    "2024/2025",
+			URL:      "http://www.90minut.pl/archsezon.php?id_sezon=97",
+			SeasonID: "97",
+			Current:  true,
+		}},
+		selectedIdx: 0,
+		competitions: []site.Competition{{
+			Name:      "Ekstraklasa",
+			URL:       "http://www.90minut.pl/liga/1/liga11233.html",
+			LeagueKey: "liga11233",
+		}},
+		league: &site.LeaguePage{
+			Title:     "Ekstraklasa",
+			URL:       "http://www.90minut.pl/liga/1/liga11233.html",
+			LeagueKey: "liga11233",
+			Rounds: []site.Round{{
+				Name: "1. kolejka",
+				Fixtures: []site.Fixture{
+					{Home: "Team A", Away: "Team B", Score: "1-0", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1", MatchID: "1"},
+					{Home: "Team C", Away: "Team D", Score: "2-2", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=2", MatchID: "2"},
+				},
+			}},
+		},
+		match: &site.MatchPage{
+			URL:      "http://www.90minut.pl/mecz.php?id_mecz=1",
+			MatchID:  "1",
+			HomeTeam: "Team A",
+			AwayTeam: "Team B",
+			Score:    "1-0",
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- scope league round parsing to the main fixture content so standings and nav tables no longer collapse into a giant first `Wyniki` round
- harden round-header detection against navigation blocks like `Wyniki | Strzelcy | Statystyki | Ostatnia kolejka`
- add parser and UI regression tests covering real league fixtures and fixture navigation without redundant league loads

Closes #11

## Testing
- go test ./...
