### PR TITLE
(#20) Normalize league ordering in site layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terminal UI for browsing `90minut.pl` (Polish football archive) without an API.
 ## Current Features
 
 - Season/competition popup selector from `archsezon.php`.
-- Standings plus round/fixture browsing for the selected league.
+- Standings plus round/fixture browsing for the selected league, with rounds normalized by round number and fixtures within each round ordered by parsed match date.
 - Match details view with:
   - competition/date/meta
   - score
@@ -52,6 +52,7 @@ Core pipeline: `fetch -> parse -> render`.
 - 90minut pages use legacy encoding (`iso-8859-2`) and must be decoded before parsing.
 - Prefer semantic selectors over fixed table offsets.
 - URL IDs are treated as stable keys (e.g. season/match links).
+- League parsing preserves standings table order from the source page, but normalizes rounds by detected round number and fixtures by parsed `WhenInfo` date/time so all consumers see a stable sequence.
 - Async UI loads are keyed by season/competition/fixture IDs so stale responses are ignored if focus changes.
 - Match parsing still assumes mostly three-cell timeline rows and uses heuristic table scoring; add fixtures/tests when source layout drifts.
 

--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -7,8 +7,8 @@ import (
 	"github.com/PuerkitoBio/goquery"
 )
 
-// League pages drift across seasons, so round extraction keys off heading tables
-// and `mecz.php` links instead of width or column positions.
+// League layouts drift across seasons, so round parsing keys off headings and
+// `mecz.php` links, not table shape.
 func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	page := &LeaguePage{URL: url, LeagueKey: extractLeagueKey(url)}
 
@@ -23,7 +23,7 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 		return nil
 	}
 
-	page.Rounds = rounds
+	page.Rounds = normalizeLeagueOrder(rounds)
 	return page
 }
 
@@ -47,7 +47,7 @@ func parseRounds(doc *goquery.Document) []Round {
 		roundName := strings.TrimSpace(currentName)
 
 		if len(rounds) > 0 && rounds[len(rounds)-1].Name == roundName {
-			// Source HTML may split one round into adjacent tables with the same heading.
+			// 90minut sometimes splits one round across adjacent tables under the same heading.
 			rounds[len(rounds)-1].Fixtures = append(rounds[len(rounds)-1].Fixtures, fixtures...)
 			return
 		}
@@ -56,8 +56,8 @@ func parseRounds(doc *goquery.Document) []Round {
 	})
 
 	if hasNamedRounds {
-		// Once explicit round headings exist, unnamed fixture tables in the same area
-		// are usually standings/nav spillover rather than standalone rounds.
+		// If headings exist, unnamed fixture tables here are usually standings/nav spillover,
+		// not separate rounds.
 		namedOnly := make([]Round, 0, len(rounds))
 		for _, round := range rounds {
 			if strings.TrimSpace(round.Name) == "" {
@@ -74,7 +74,7 @@ func parseRounds(doc *goquery.Document) []Round {
 		if strings.TrimSpace(rounds[i].Name) != "" {
 			continue
 		}
-		// Fully headerless fixture pages are normalized to a single fallback round.
+		// Headerless fixture pages still need a stable round label for downstream rendering.
 		rounds[i].Name = "Wyniki"
 	}
 
@@ -203,8 +203,8 @@ func parseFixturesTable(table *goquery.Selection) []Fixture {
 func parseStandings(doc *goquery.Document) []StandingRow {
 	var standings []StandingRow
 
-	// Standings pages drift too, so stop at the first table whose header matches
-	// the classic league columns and stop once parsed rows give way to other content.
+	// Standings tables drift too; take the first table with classic league headers
+	// and stop when rows stop parsing.
 	leagueTables(doc).EachWithBreak(func(_ int, table *goquery.Selection) bool {
 		header := table.Find("tr").FilterFunction(func(_ int, row *goquery.Selection) bool {
 			text := normalizeWhitespace(row.Text())

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -22,6 +22,8 @@ type Fixture struct {
 	MatchID  string
 }
 
+// Round fixtures are normalized to ascending parsed date/time when available;
+// undated entries keep their relative source order after dated fixtures.
 type Round struct {
 	Name     string
 	Fixtures []Fixture
@@ -38,13 +40,15 @@ type StandingRow struct {
 	Points   int
 }
 
+// LeaguePage is the normalized league view returned by the site layer.
 type LeaguePage struct {
 	Title     string
 	URL       string
 	LeagueKey string
 	// Standings stays empty when the page has no detectable table.
 	Standings []StandingRow
-	Rounds    []Round
+	// Rounds are ordered by detected round number when available.
+	Rounds []Round
 }
 
 type MatchPage struct {

--- a/internal/site/ordering.go
+++ b/internal/site/ordering.go
@@ -1,0 +1,179 @@
+package site
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var roundNumberRe = regexp.MustCompile(`\d+`)
+var fixtureDateRe = regexp.MustCompile(`(?i)(\d{1,2})\s+([\p{L}]+)(?:\s+(\d{4}))?(?:,\s*(\d{1,2}):(\d{2}))?`)
+
+// Normalize round and fixture order here so every caller sees the same league structure.
+func normalizeLeagueOrder(rounds []Round) []Round {
+	ordered := make([]Round, len(rounds))
+	copy(ordered, rounds)
+
+	for i := range ordered {
+		ordered[i].Fixtures = normalizeFixturesByDate(ordered[i].Fixtures)
+	}
+
+	type indexedRound struct {
+		round Round
+		index int
+	}
+
+	indexed := make([]indexedRound, len(ordered))
+	for i, round := range ordered {
+		indexed[i] = indexedRound{round: round, index: i}
+	}
+
+	sort.SliceStable(indexed, func(i, j int) bool {
+		numberI, okI := roundNumber(indexed[i].round.Name)
+		numberJ, okJ := roundNumber(indexed[j].round.Name)
+
+		switch {
+		case okI && okJ && numberI != numberJ:
+			return numberI < numberJ
+		case okI != okJ:
+			return okI
+		default:
+			return indexed[i].index < indexed[j].index
+		}
+	})
+
+	for i := range indexed {
+		ordered[i] = indexed[i].round
+	}
+
+	return ordered
+}
+
+func normalizeFixturesByDate(fixtures []Fixture) []Fixture {
+	ordered := make([]Fixture, len(fixtures))
+	copy(ordered, fixtures)
+
+	type indexedFixture struct {
+		fixture Fixture
+		index   int
+	}
+
+	indexed := make([]indexedFixture, len(ordered))
+	for i, fixture := range ordered {
+		indexed[i] = indexedFixture{fixture: fixture, index: i}
+	}
+
+	// Sort parsable dates first; keep undated fixtures in source order at the end.
+	sort.SliceStable(indexed, func(i, j int) bool {
+		dateI, okI := fixtureDateKey(indexed[i].fixture.WhenInfo)
+		dateJ, okJ := fixtureDateKey(indexed[j].fixture.WhenInfo)
+
+		switch {
+		case okI && okJ && dateI != dateJ:
+			return dateI < dateJ
+		case okI != okJ:
+			return okI
+		default:
+			return indexed[i].index < indexed[j].index
+		}
+	})
+
+	for i := range indexed {
+		ordered[i] = indexed[i].fixture
+	}
+
+	return ordered
+}
+
+func roundNumber(name string) (int, bool) {
+	lower := strings.ToLower(normalizeWhitespace(name))
+	if !strings.Contains(lower, "kolejka") && !strings.Contains(lower, "runda") {
+		return 0, false
+	}
+
+	match := roundNumberRe.FindString(lower)
+	if match == "" {
+		return 0, false
+	}
+
+	value, err := strconv.Atoi(match)
+	if err != nil {
+		return 0, false
+	}
+
+	return value, true
+}
+
+func fixtureDateKey(whenInfo string) (int, bool) {
+	matches := fixtureDateRe.FindStringSubmatch(normalizeWhitespace(whenInfo))
+	if len(matches) == 0 {
+		return 0, false
+	}
+
+	day, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0, false
+	}
+
+	month, ok := polishMonthIndex(matches[2])
+	if !ok {
+		return 0, false
+	}
+
+	year := 0
+	if matches[3] != "" {
+		year, err = strconv.Atoi(matches[3])
+		if err != nil {
+			return 0, false
+		}
+	}
+
+	hour := 0
+	minute := 0
+	if matches[4] != "" {
+		hour, err = strconv.Atoi(matches[4])
+		if err != nil {
+			return 0, false
+		}
+	}
+	if matches[5] != "" {
+		minute, err = strconv.Atoi(matches[5])
+		if err != nil {
+			return 0, false
+		}
+	}
+
+	return (((year*100)+month)*100+day)*10000 + hour*100 + minute, true
+}
+
+func polishMonthIndex(value string) (int, bool) {
+	switch strings.ToLower(normalizeWhitespace(value)) {
+	case "stycznia":
+		return 1, true
+	case "lutego":
+		return 2, true
+	case "marca":
+		return 3, true
+	case "kwietnia":
+		return 4, true
+	case "maja":
+		return 5, true
+	case "czerwca":
+		return 6, true
+	case "lipca":
+		return 7, true
+	case "sierpnia":
+		return 8, true
+	case "wrzesnia", "września":
+		return 9, true
+	case "pazdziernika", "października":
+		return 10, true
+	case "listopada":
+		return 11, true
+	case "grudnia":
+		return 12, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -6,16 +6,15 @@ import (
 )
 
 type leagueRoundExpectation struct {
-	firstRoundName      string
-	firstRoundFixtures  int
-	firstFixtureMatchID string
+	firstRoundName     string
+	firstRoundFixtures int
 }
 
 func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 	m := loadManifest(t)
 	expected := map[string]leagueRoundExpectation{
-		"league_14072": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9, firstFixtureMatchID: "2022730"},
-		"league_14073": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9, firstFixtureMatchID: "2023371"},
+		"league_14072": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9},
+		"league_14073": {firstRoundName: "Kolejka 1 - 19-20 lipca", firstRoundFixtures: 9},
 	}
 	leagues := fixturesByKind(m, "league")
 	if len(leagues) < 6 {
@@ -49,6 +48,7 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 				if len(round.Fixtures) == 0 {
 					t.Fatalf("round %q has no fixtures in %s", round.Name, fixture.Name)
 				}
+				assertFixturesSortedByDate(t, fixture.Name, round)
 			}
 
 			totalFixtures := 0
@@ -91,9 +91,6 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 				if len(firstRound.Fixtures) != want.firstRoundFixtures {
 					t.Fatalf("unexpected first round fixture count in %s: got %d want %d", fixture.Name, len(firstRound.Fixtures), want.firstRoundFixtures)
 				}
-				if firstRound.Fixtures[0].MatchID != want.firstFixtureMatchID {
-					t.Fatalf("unexpected first fixture id in %s: got %q want %q", fixture.Name, firstRound.Fixtures[0].MatchID, want.firstFixtureMatchID)
-				}
 			}
 
 			if fixture.Name == "league_14072" || fixture.Name == "league_14073" {
@@ -102,6 +99,32 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func assertFixturesSortedByDate(t *testing.T, fixtureName string, round Round) {
+	t.Helper()
+
+	lastKey := 0
+	lastWhenInfo := ""
+	seenDate := false
+	seenUndated := false
+
+	for _, fixture := range round.Fixtures {
+		dateKey, ok := fixtureDateKey(fixture.WhenInfo)
+		if !ok {
+			seenUndated = true
+			continue
+		}
+		if seenUndated {
+			t.Fatalf("dated fixture %q appears after undated fixture in %s round %q", fixture.MatchID, fixtureName, round.Name)
+		}
+		if seenDate && dateKey < lastKey {
+			t.Fatalf("fixtures not sorted by date in %s round %q: %q before %q", fixtureName, round.Name, fixture.WhenInfo, lastWhenInfo)
+		}
+		lastKey = dateKey
+		lastWhenInfo = fixture.WhenInfo
+		seenDate = true
 	}
 }
 

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -194,6 +194,84 @@ func TestRoundNameFromTableSkipsNavigationBlocks(t *testing.T) {
 	}
 }
 
+func TestParseLeaguePageNormalizesRoundsByRoundNumber(t *testing.T) {
+	html := `
+	<html><head><title>Test League</title></head><body>
+	<table><tr><td><u>3. kolejka</u></td></tr></table>
+	<table>
+	<tr><td>Team E</td><td><a href="/mecz.php?id_mecz=3">1-0</a></td><td>Team F</td><td>3 sierpnia, 18:00</td></tr>
+	</table>
+	<table><tr><td><u>1. kolejka</u></td></tr></table>
+	<table>
+	<tr><td>Team A</td><td><a href="/mecz.php?id_mecz=1">1-0</a></td><td>Team B</td><td>20 lipca, 18:00</td></tr>
+	</table>
+	<table><tr><td><u>2. kolejka</u></td></tr></table>
+	<table>
+	<tr><td>Team C</td><td><a href="/mecz.php?id_mecz=2">2-1</a></td><td>Team D</td><td>27 lipca, 18:00</td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga-test.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+	if len(page.Rounds) != 3 {
+		t.Fatalf("expected 3 rounds, got %d", len(page.Rounds))
+	}
+
+	got := []string{page.Rounds[0].Name, page.Rounds[1].Name, page.Rounds[2].Name}
+	want := []string{"1. kolejka", "2. kolejka", "3. kolejka"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected round order: got %#v want %#v", got, want)
+		}
+	}
+}
+
+func TestParseLeaguePageNormalizesFixturesByDate(t *testing.T) {
+	html := `
+	<html><head><title>Test League</title></head><body>
+	<table><tr><td><u>1. kolejka</u></td></tr></table>
+	<table>
+	<tr><td>Team C</td><td><a href="/mecz.php?id_mecz=3">1-0</a></td><td>Team D</td><td>24 lipca, 20:30</td></tr>
+	<tr><td>Team A</td><td><a href="/mecz.php?id_mecz=1">2-1</a></td><td>Team B</td><td>20 lipca, 18:00</td></tr>
+	<tr><td>Team E</td><td><a href="/mecz.php?id_mecz=5">0-0</a></td><td>Team F</td><td>odwołany</td></tr>
+	<tr><td>Team G</td><td><a href="/mecz.php?id_mecz=7">3-2</a></td><td>Team H</td><td>24 lipca, 18:00</td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga-test.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+	if len(page.Rounds) != 1 {
+		t.Fatalf("expected 1 round, got %d", len(page.Rounds))
+	}
+
+	fixtures := page.Rounds[0].Fixtures
+	if len(fixtures) != 4 {
+		t.Fatalf("expected 4 fixtures, got %d", len(fixtures))
+	}
+
+	got := []string{fixtures[0].MatchID, fixtures[1].MatchID, fixtures[2].MatchID, fixtures[3].MatchID}
+	want := []string{"1", "7", "3", "5"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected fixture order: got %#v want %#v", got, want)
+		}
+	}
+}
+
 func TestValidateMatchPageAllowsPartialWhenTeamsPresent(t *testing.T) {
 	page := &MatchPage{
 		Title:    "Match",

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -36,6 +36,9 @@ func (s *Service) LoadArchive(ctx context.Context, archiveURL string) ([]Season,
 	return seasons, selectedIdx, competitions, nil
 }
 
+// LoadLeague fetches and parses a league page into a normalized LeaguePage.
+// Rounds are ordered by detected round number when available, and fixtures
+// inside each round are ordered by parsed date/time in the site layer.
 func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage, error) {
 	doc, err := s.client.Document(ctx, leagueURL)
 	if err != nil {


### PR DESCRIPTION
## Summary
- normalize league rounds in the site layer by detected round number so every caller sees the same sequence
- normalize fixtures within each round by parsed `WhenInfo` date/time, keeping undated fixtures stable at the end
- document the new ordering contract and add regression coverage for normalized rounds and fixtures

## Testing
- go test ./...

closes #20