### PR TITLE
Remove dead archive tier wrapper functions

### DIFF
--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -383,14 +383,6 @@ func archiveCompetitionMenuKey(archiveURL, key string, spec archiveGroupSpec) st
 	return spec.keyPrefix + ":" + canonicalURLKey(archiveURL) + ":" + key
 }
 
-func isWomenTierMenuURL(raw string) bool {
-	return archiveCompetitionMenuFromURL(raw, archiveGroupSpecs[0]) != ""
-}
-
-func isFutsalTierMenuURL(raw string) bool {
-	return archiveCompetitionMenuFromURL(raw, archiveGroupSpecs[1]) != ""
-}
-
 func archiveCompetitionMenuFromURL(raw string, spec archiveGroupSpec) string {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Fragment == "" {
@@ -409,32 +401,8 @@ func womenTierMenuURL(archiveURL, key string) string {
 	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[0])
 }
 
-func womenTierMenuKey(archiveURL, key string) string {
-	return archiveCompetitionMenuKey(archiveURL, key, archiveGroupSpecs[0])
-}
-
-func womenTierMenuMeta(name string) (string, string, bool) {
-	return archiveCompetitionMenuMeta(name, archiveGroupSpecs[0])
-}
-
-func womenTierMenuFromURL(raw string) string {
-	return archiveCompetitionMenuFromURL(raw, archiveGroupSpecs[0])
-}
-
 func futsalTierMenuURL(archiveURL, key string) string {
 	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[1])
-}
-
-func futsalTierMenuKey(archiveURL, key string) string {
-	return archiveCompetitionMenuKey(archiveURL, key, archiveGroupSpecs[1])
-}
-
-func futsalTierMenuMeta(name string) (string, string, bool) {
-	return archiveCompetitionMenuMeta(name, archiveGroupSpecs[1])
-}
-
-func futsalTierMenuFromURL(raw string) string {
-	return archiveCompetitionMenuFromURL(raw, archiveGroupSpecs[1])
 }
 
 func parseIIIligaMenu(doc *goquery.Document, resolvedURL string, c *Client) *CompetitionMenu {


### PR DESCRIPTION
## Summary

- 8 of the 10 `archiveGroupSpec`-bound wrappers (`isWomenTierMenuURL`, `isFutsalTierMenuURL`, `womenTierMenuKey`, `womenTierMenuMeta`, `womenTierMenuFromURL`, `futsalTierMenuKey`, `futsalTierMenuMeta`, `futsalTierMenuFromURL`) had no call sites outside their own definitions
- These were leftovers from before the `archiveGroupSpec` abstraction was introduced — the old named API that never got cleaned up
- The two survivors (`womenTierMenuURL`, `futsalTierMenuURL`) are used in tests as URL constructors and are kept

## Test plan

- [ ] `go test ./...` passes (all existing tests cover the affected paths)