### PR TITLE
Redesign TUI and polish layout alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Terminal UI for browsing `90minut.pl` (Polish football archive) without an API.
 - Match details view with:
   - centered score line with scorer rows anchored to a shared minute column
   - side-aware timeline with halftime/full-time dividers
-  - compact event markers: `⚽` goal, `↕` substitution, `🟨` yellow, `🟥` red, plus status markers like `HT`, `FT`, `AET`, `PPD`, and `OFF`
-  - side-by-side lineups aligned around the same center axis
-  - match metadata grouped into a separate `Details` block
+  - compact event markers: `⚽` goal plus color-coded card blocks for yellow/red cards, alongside status markers like `HT`, `FT`, `AET`, `PPD`, and `OFF`
+  - side-by-side lineups aligned around the same center axis, with substitutions shown inline in lineup annotations rather than as separate timeline markers
+  - match date/details rendered directly under the score header
   - persistent standings/fixture context beside match details
 
 ## Run

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -1034,9 +1034,8 @@ func renderMatchDetailRow(left, middle, right string, width int) string {
 		return renderSideBySide(left, middle, right, width)
 	}
 
-	// midWidth=7 with gap=0: padCenter of a 3-char minute leaves exactly 2 leading
-	// spaces between the icon and the first digit, while keeping the minute centre
-	// aligned with the dash in the HT/FT divider (which uses midWidth=11, gap=1).
+	// Keep the minute column visually centered and close to the HT/FT score dash,
+	// even as left/right event labels vary in width.
 	midWidth := 7
 	gap := 0
 	sideWidth := max(8, (width-midWidth-(gap*2))/2)

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -91,8 +91,12 @@ func renderFixtureWindow(fixtures []site.Fixture, cursor, maxItems, width int, c
 
 	start, end := windowBounds(len(fixtures), cursor, maxItems)
 	whenWidth := 0
+	scoreWidth := 0
+	suffixWidth := 0
 	for i := start; i < end; i++ {
 		whenWidth = max(whenWidth, len([]rune(formatFixtureWhenInfo(fixtures[i].WhenInfo))))
+		scoreWidth = max(scoreWidth, ansi.StringWidth(normalizeScore(fixtures[i].Score)))
+		suffixWidth = max(suffixWidth, ansi.StringWidth(fixtureAvailabilitySuffix(&fixtures[i], width-2, compact)))
 	}
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
@@ -107,9 +111,11 @@ func renderFixtureWindow(fixtures []site.Fixture, cursor, maxItems, width int, c
 
 		lineWidth := width - 2 // 2-char prefix in both cases
 		suffix := fixtureAvailabilitySuffix(&fixtures[i], lineWidth, compact)
-		line := prefix + fixtureLine(&fixtures[i], lineWidth-ansi.StringWidth(suffix), whenWidth, compact)
+		line := prefix + fixtureLine(&fixtures[i], lineWidth-suffixWidth, whenWidth, scoreWidth, compact)
 		if suffix != "" {
 			line += styleDim.Render(suffix)
+		} else if suffixWidth > 0 {
+			line += strings.Repeat(" ", suffixWidth)
 		}
 		if whenInfo := formatFixtureWhenInfo(fixtures[i].WhenInfo); whenInfo != "" {
 			line += styleDim.Render("  " + whenInfo)
@@ -129,10 +135,11 @@ func renderStandingsWindow(rows []site.StandingRow, fixture *site.Fixture, width
 	}
 
 	start, end := anchoredWindowBounds(len(rows), standingSelectionIndices(rows, fixture), maxItems)
+	teamWidth := standingsTeamWidth(rows, width)
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
 		selected := fixture != nil && (strings.EqualFold(rows[i].Team, fixture.Home) || strings.EqualFold(rows[i].Team, fixture.Away))
-		lines = append(lines, formatStandingRow(rows[i], selected, width))
+		lines = append(lines, formatStandingRow(rows[i], selected, teamWidth, width))
 	}
 
 	return lines
@@ -359,9 +366,9 @@ func eventPrefix(kind string) string {
 	case "SUB":
 		return "↕"
 	case "YC":
-		return "🟨"
+		return styleYellow.Render("■")
 	case "RC":
-		return "🟥"
+		return styleRed.Render("■")
 	default:
 		return "•"
 	}
@@ -874,7 +881,7 @@ func lineupPlayerWidth(width int) int {
 		return max(8, (width-3-2)/2)
 	}
 
-	const eventWidth = 2
+	const eventWidth = 1
 	const gap = 0
 	return max(8, (width-1-2*eventWidth-2*gap)/2)
 }
@@ -895,7 +902,7 @@ func renderAnnotatedLineupRow(homePlayer, homeEvents, awayPlayer, awayEvents str
 		return renderLineupRow(home, away, width)
 	}
 
-	const eventWidth = 2 // one emoji wide (YC/RC or empty)
+	const eventWidth = 1 // one char wide (YC/RC block or empty)
 	const gap = 0        // names sit directly against the event column
 	playerWidth := lineupPlayerWidth(width)
 
@@ -985,7 +992,10 @@ func matchMetaParts(meta, weather string) []string {
 			remainder = strings.TrimSpace(strings.TrimPrefix(remainder, matches[0]))
 		}
 		if remainder != "" {
-			parts = append(parts, "Ref. "+translatePolishDateText(remainder))
+			translated := translatePolishDateText(remainder)
+			// Drop trailing "(City)" — only venue/city name, not part of the ref's identity.
+			refName := strings.TrimSpace(trailingParenRe.ReplaceAllString(translated, "$1"))
+			parts = append(parts, "Ref. "+refName)
 		}
 		if len(parts) == 0 {
 			parts = append(parts, translatePolishDateText(cleanedMeta))
@@ -1193,17 +1203,18 @@ func abbreviateTeamName(name string) string {
 	return padRight(string(letters), 3)
 }
 
-func abbreviatedFixtureLine(fixture *site.Fixture) string {
+func abbreviatedFixtureLine(fixture *site.Fixture, scoreWidth int) string {
 	if fixture == nil {
-		return "--- ?-? ---"
+		return "--- " + padCenter("?-?", scoreWidth) + " ---"
 	}
 
-	return fmt.Sprintf("%s %s %s", abbreviateTeamName(fixture.Home), normalizeScore(fixture.Score), abbreviateTeamName(fixture.Away))
+	score := padCenter(normalizeScore(fixture.Score), scoreWidth)
+	return fmt.Sprintf("%s %s %s", abbreviateTeamName(fixture.Home), score, abbreviateTeamName(fixture.Away))
 }
 
-func fixtureLine(fixture *site.Fixture, width, whenWidth int, compact bool) string {
+func fixtureLine(fixture *site.Fixture, width, whenWidth, scoreWidth int, compact bool) string {
 	if compact {
-		return abbreviatedFixtureLine(fixture)
+		return abbreviatedFixtureLine(fixture, scoreWidth)
 	}
 	if fixture == nil {
 		return "--- ?-? ---"
@@ -1212,8 +1223,8 @@ func fixtureLine(fixture *site.Fixture, width, whenWidth int, compact bool) stri
 		return fmt.Sprintf("%s %s %s", fixture.Home, normalizeScore(fixture.Score), fixture.Away)
 	}
 
-	score := normalizeScore(fixture.Score)
-	reserved := len([]rune(score)) + 2
+	score := padCenter(normalizeScore(fixture.Score), scoreWidth)
+	reserved := scoreWidth + 2
 	if whenWidth > 0 {
 		reserved += 3 + whenWidth
 	}
@@ -1255,8 +1266,26 @@ func formatFetchTime(ts time.Time) string {
 	return ts.Format("15:04:05")
 }
 
-func formatStandingRow(row site.StandingRow, selected bool, width int) string {
-	line := fmt.Sprintf("  %2d %-18s %2d %2d %2d %2d %3d", row.Position, truncate(row.Team, 18), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
+func standingsTeamWidth(rows []site.StandingRow, width int) int {
+	const reserved = 21
+	minWidth := ansi.StringWidth("Team")
+	maxWidth := max(minWidth, width-reserved)
+	if maxWidth <= minWidth {
+		return minWidth
+	}
+
+	teamWidth := minWidth
+	for _, row := range rows {
+		teamWidth = max(teamWidth, ansi.StringWidth(row.Team))
+	}
+	if teamWidth > maxWidth {
+		return maxWidth
+	}
+	return teamWidth
+}
+
+func formatStandingRow(row site.StandingRow, selected bool, teamWidth, width int) string {
+	line := fmt.Sprintf("  %2d %-*s %2d %2d %2d %2d %3d", row.Position, teamWidth, truncate(row.Team, teamWidth), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
 	line = truncate(line, max(12, width))
 	if selected {
 		return styleBold.Render(line)
@@ -1330,6 +1359,24 @@ func displayRoundLabel(name string, fallback int) string {
 
 func displayMatchMeta(meta, weather string) string {
 	return strings.Join(matchMetaParts(meta, weather), " | ")
+}
+
+// matchMetaDisplay splits meta parts into a prominent date line and a secondary
+// details line (attendance, ref, weather). Returns empty strings when absent.
+func matchMetaDisplay(meta, weather string) (date, details string) {
+	parts := matchMetaParts(meta, weather)
+	if len(parts) == 0 {
+		return "", ""
+	}
+	if matchDatePrefixRe.MatchString(parts[0]) {
+		date = parts[0]
+		if len(parts) > 1 {
+			details = strings.Join(parts[1:], "  ·  ")
+		}
+		return
+	}
+	details = strings.Join(parts, "  ·  ")
+	return
 }
 
 func trimEventMinute(event site.MatchEvent) string {

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -96,19 +96,23 @@ func renderFixtureWindow(fixtures []site.Fixture, cursor, maxItems, width int, c
 	}
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		prefix := "  "
-		if i == cursor {
-			prefix = "> "
+		isCursor := i == cursor
+		// "› " and "  " are both 2 visible chars; accent marker on cursor row.
+		var prefix string
+		if isCursor {
+			prefix = styleAccent.Render("›") + " "
+		} else {
+			prefix = "  "
 		}
 
-		lineWidth := width - len([]rune(prefix))
+		lineWidth := width - 2 // 2-char prefix in both cases
 		suffix := fixtureAvailabilitySuffix(&fixtures[i], lineWidth, compact)
 		line := prefix + fixtureLine(&fixtures[i], lineWidth-ansi.StringWidth(suffix), whenWidth, compact)
 		if suffix != "" {
-			line += suffix
+			line += styleDim.Render(suffix)
 		}
 		if whenInfo := formatFixtureWhenInfo(fixtures[i].WhenInfo); whenInfo != "" {
-			line += " | " + whenInfo
+			line += styleDim.Render("  " + whenInfo)
 		}
 		lines = append(lines, line)
 	}
@@ -463,7 +467,7 @@ func formatMatchMinute(minute string) string {
 func renderDividerLabel(label string, width int) string {
 	cleaned := normalizeDisplayText(label)
 	if cleaned == "" {
-		cleaned = "-"
+		cleaned = "─"
 	}
 	if width <= len([]rune(cleaned))+2 {
 		return cleaned
@@ -472,7 +476,7 @@ func renderDividerLabel(label string, width int) string {
 	pad := width - len([]rune(cleaned)) - 2
 	left := pad / 2
 	right := pad - left
-	return strings.Repeat("-", left) + " " + cleaned + " " + strings.Repeat("-", right)
+	return strings.Repeat("─", left) + " " + cleaned + " " + strings.Repeat("─", right)
 }
 
 // Align the divider score dash with the event-minute column when width allows.
@@ -482,7 +486,11 @@ func renderMatchDividerRow(label string, width int) string {
 	}
 
 	label = truncate(label, max(1, width-2))
-	dashOffset := strings.Index(label, " - ") + 1
+	dashOffset := strings.Index(label, " – ") + 1
+	if dashOffset < 1 {
+		// Fall back to ASCII dash for labels that don't contain an en-dash.
+		dashOffset = strings.Index(label, " - ") + 1
+	}
 	if dashOffset < 1 {
 		return renderDividerLabel(label, width)
 	}
@@ -491,7 +499,7 @@ func renderMatchDividerRow(label string, width int) string {
 	leftWidth := max(0, minuteAxis-1-dashOffset)
 	rightWidth := max(0, width-leftWidth-ansi.StringWidth(label)-2)
 
-	return strings.Repeat("-", leftWidth) + " " + label + " " + strings.Repeat("-", rightWidth)
+	return strings.Repeat("─", leftWidth) + " " + label + " " + strings.Repeat("─", rightWidth)
 }
 
 func matchStatus(page *site.MatchPage) string {
@@ -927,7 +935,7 @@ func halftimeScore(events []site.MatchEvent) string {
 		return ""
 	}
 
-	return fmt.Sprintf("HT %d - %d", homeGoals, awayGoals)
+	return fmt.Sprintf("HT %d – %d", homeGoals, awayGoals)
 }
 
 func finalScoreLine(page *site.MatchPage) string {
@@ -960,7 +968,7 @@ func dividerScore(score string) string {
 		return normalizeScore(trimmed)
 	}
 
-	return left + " - " + right
+	return left + " – " + right
 }
 
 func matchMetaParts(meta, weather string) []string {
@@ -1248,13 +1256,12 @@ func formatFetchTime(ts time.Time) string {
 }
 
 func formatStandingRow(row site.StandingRow, selected bool, width int) string {
-	prefix := "  "
+	line := fmt.Sprintf("  %2d %-18s %2d %2d %2d %2d %3d", row.Position, truncate(row.Team, 18), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
+	line = truncate(line, max(12, width))
 	if selected {
-		prefix = "> "
+		return styleBold.Render(line)
 	}
-
-	line := fmt.Sprintf("%s%2d %-18s %2d %2d %2d %2d %3d", prefix, row.Position, truncate(row.Team, 18), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
-	return truncate(line, max(12, width))
+	return line
 }
 
 func parseRoundNumber(name string, fallback int) string {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -8,14 +8,14 @@ var (
 	colorDim    = lipgloss.Color("240") // dark grey
 	colorSubtle = lipgloss.Color("243") // mid grey
 
-	// Semantic card colors — only used for YC/RC lineup markers.
+	// Semantic card colors for YC/RC markers across match detail views.
 	colorYellow = lipgloss.Color("226")
 	colorRed    = lipgloss.Color("196")
 
-	styleAccent  = lipgloss.NewStyle().Foreground(colorAccent)
-	styleDim     = lipgloss.NewStyle().Foreground(colorDim)
-	styleSubtle  = lipgloss.NewStyle().Foreground(colorSubtle)
-	styleBold    = lipgloss.NewStyle().Bold(true)
-	styleYellow  = lipgloss.NewStyle().Foreground(colorYellow)
-	styleRed     = lipgloss.NewStyle().Foreground(colorRed)
+	styleAccent = lipgloss.NewStyle().Foreground(colorAccent)
+	styleDim    = lipgloss.NewStyle().Foreground(colorDim)
+	styleSubtle = lipgloss.NewStyle().Foreground(colorSubtle)
+	styleBold   = lipgloss.NewStyle().Bold(true)
+	styleYellow = lipgloss.NewStyle().Foreground(colorYellow)
+	styleRed    = lipgloss.NewStyle().Foreground(colorRed)
 )

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -5,11 +5,17 @@ import "github.com/charmbracelet/lipgloss"
 var (
 	// Three-color palette. accent = cursor/focus, dim = chrome, subtle = secondary labels.
 	colorAccent = lipgloss.Color("39")  // bright azure
-	colorDim    = lipgloss.Color("238") // near-black grey
+	colorDim    = lipgloss.Color("240") // dark grey
 	colorSubtle = lipgloss.Color("243") // mid grey
 
-	styleAccent = lipgloss.NewStyle().Foreground(colorAccent)
-	styleDim    = lipgloss.NewStyle().Foreground(colorDim)
-	styleSubtle = lipgloss.NewStyle().Foreground(colorSubtle)
-	styleBold   = lipgloss.NewStyle().Bold(true)
+	// Semantic card colors — only used for YC/RC lineup markers.
+	colorYellow = lipgloss.Color("226")
+	colorRed    = lipgloss.Color("196")
+
+	styleAccent  = lipgloss.NewStyle().Foreground(colorAccent)
+	styleDim     = lipgloss.NewStyle().Foreground(colorDim)
+	styleSubtle  = lipgloss.NewStyle().Foreground(colorSubtle)
+	styleBold    = lipgloss.NewStyle().Bold(true)
+	styleYellow  = lipgloss.NewStyle().Foreground(colorYellow)
+	styleRed     = lipgloss.NewStyle().Foreground(colorRed)
 )

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -1,0 +1,15 @@
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Three-color palette. accent = cursor/focus, dim = chrome, subtle = secondary labels.
+	colorAccent = lipgloss.Color("39")  // bright azure
+	colorDim    = lipgloss.Color("238") // near-black grey
+	colorSubtle = lipgloss.Color("243") // mid grey
+
+	styleAccent = lipgloss.NewStyle().Foreground(colorAccent)
+	styleDim    = lipgloss.NewStyle().Foreground(colorDim)
+	styleSubtle = lipgloss.NewStyle().Foreground(colorSubtle)
+	styleBold   = lipgloss.NewStyle().Bold(true)
+)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -9,10 +10,10 @@ import (
 
 func (m Model) View() string {
 	if m.width == 0 {
-		return "Loading terminal size..."
+		return "Loading..."
 	}
 
-	topBar := m.topContextBarView()
+	topBar := m.topBarView()
 	body := m.leagueSketchView()
 	if m.matchView {
 		body = m.matchSketchView()
@@ -21,11 +22,64 @@ func (m Model) View() string {
 		body = m.selectorOverlayView(body)
 	}
 	body = fitLines(body, m.bodyHeightLimit())
+
 	if topBar != "" {
 		return topBar + "\n" + body + "\n" + m.statusBarView()
 	}
-
 	return body + "\n" + m.statusBarView()
+}
+
+func (m Model) bodyHeightLimit() int {
+	reserved := 1 // status bar
+	if bar := m.topBarView(); bar != "" {
+		reserved += strings.Count(bar, "\n") + 1
+	}
+	if m.height <= reserved {
+		return 0
+	}
+	return m.height - reserved
+}
+
+// topBarView renders a two-line header: competition + round on line 1, a dim
+// separator on line 2. Returns "" when the bar should be suppressed.
+func (m Model) topBarView() string {
+	if m.suppressTopBar || m.league == nil {
+		return ""
+	}
+
+	label := displayCompetitionLabel(m.league.Title)
+	if label == "" {
+		return ""
+	}
+
+	right := ""
+	if round := m.currentRound(); round != nil {
+		roundLabel := displayRoundLabel(round.Name, m.roundCursor+1)
+		right = fmt.Sprintf("%s / %d", roundLabel, len(m.league.Rounds))
+	}
+
+	titleLine := barLine(label, right, m.width)
+	sep := styleDim.Render(strings.Repeat("─", m.width))
+	return titleLine + "\n" + sep
+}
+
+// barLine builds a fixed-width line: bold left label + subtle right label, space-padded.
+func barLine(left, right string, width int) string {
+	inner := width - 2 // 1 leading + 1 trailing space
+	if inner <= 0 {
+		return ""
+	}
+	if right == "" {
+		text := truncate(left, inner)
+		pad := max(0, inner-ansi.StringWidth(text))
+		return " " + styleBold.Render(text) + strings.Repeat(" ", pad) + " "
+	}
+	rightW := ansi.StringWidth(right)
+	leftMax := max(0, inner-rightW-1)
+	leftText := truncate(left, leftMax)
+	leftW := ansi.StringWidth(leftText)
+	gap := max(1, inner-leftW-rightW)
+	return " " + styleBold.Render(leftText) + strings.Repeat(" ", gap) + styleSubtle.Render(right) + " "
 }
 
 func (m Model) selectorOverlayView(body string) string {
@@ -75,45 +129,61 @@ func overlayLine(base, overlay string, leftWidth int) string {
 }
 
 func (m Model) selectorPopupView(width int) string {
-	title := lipgloss.NewStyle().Bold(true)
-	focusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
-	panel := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(0, 1)
-	content := lipgloss.NewStyle().Width(max(24, width-4))
 	innerWidth := max(24, width-4)
 	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
 	leftWidth, rightWidth := selectorPaneWidths(innerWidth, seasonLines)
 
-	var b strings.Builder
-	b.WriteString(title.Render("Season + league"))
-	b.WriteString("\n\n")
-	left := selectorPaneView(leftWidth, "Season", m.focus == focusSeasons, seasonLines, title, focusStyle)
 	rightHeading := "Leagues"
 	if strings.TrimSpace(m.competitionTitle) != "" {
 		rightHeading = m.competitionTitle
 	}
-	right := selectorPaneView(rightWidth, rightHeading, m.focus == focusCompetitions, renderCompetitionWindow(m.competitions, m.competitionCursor), title, focusStyle)
-	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, left, right))
+
+	left := selectorPaneView(leftWidth, "Season", m.focus == focusSeasons, seasonLines)
+	right := selectorPaneView(rightWidth, rightHeading, m.focus == focusCompetitions, renderCompetitionWindow(m.competitions, m.competitionCursor))
+
+	// Vertical divider — height matches the taller pane.
+	leftLines := strings.Split(left, "\n")
+	rightLines := strings.Split(right, "\n")
+	divH := max(len(leftLines), len(rightLines))
+	divParts := make([]string, divH)
+	for i := range divParts {
+		divParts[i] = styleDim.Render("│")
+	}
+	divider := strings.Join(divParts, "\n")
+
+	var b strings.Builder
+	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, left, divider, right))
 
 	if m.loading {
-		b.WriteString("\nLoading...")
+		b.WriteString("\n")
+		b.WriteString(styleSubtle.Render("Loading…"))
 	}
 	if m.err != "" {
-		b.WriteString("\nError: ")
-		b.WriteString(m.err)
+		b.WriteString("\n")
+		b.WriteString(styleSubtle.Render("Error: " + m.err))
 	}
+
+	panel := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorDim).
+		Padding(0, 1)
+	content := lipgloss.NewStyle().Width(innerWidth)
 
 	return panel.Render(content.Render(strings.TrimRight(b.String(), "\n")))
 }
 
-func selectorPaneView(width int, heading string, focused bool, lines []string, title, focusStyle lipgloss.Style) string {
+func selectorPaneView(width int, heading string, focused bool, lines []string) string {
 	base := lipgloss.NewStyle().Width(width)
 
-	var b strings.Builder
-	b.WriteString(title.Render(truncate(heading, width)))
+	var headingStyle lipgloss.Style
 	if focused {
-		b.WriteString(" ")
-		b.WriteString(focusStyle.Render("[focus]"))
+		headingStyle = styleBold.Copy().Foreground(colorAccent)
+	} else {
+		headingStyle = styleSubtle
 	}
+
+	var b strings.Builder
+	b.WriteString(headingStyle.Render(truncate(heading, width)))
 	b.WriteString("\n")
 	for _, line := range lines {
 		b.WriteString(truncate(line, width))
@@ -130,10 +200,10 @@ func selectorPaneWidths(total int, seasonLines []string) (int, int) {
 	}
 
 	leftWidth := clamp(seasonWidth+1, 14, 18)
-	rightWidth := total - leftWidth - 2
+	rightWidth := total - leftWidth - 1 // 1 for the │ divider
 	if rightWidth < 16 {
 		rightWidth = 16
-		leftWidth = max(14, total-rightWidth-2)
+		leftWidth = max(14, total-rightWidth-1)
 	}
 
 	return leftWidth, rightWidth
@@ -147,9 +217,24 @@ func (m Model) leagueSketchView() string {
 	}
 
 	standings := m.standingsPaneView(leftWidth)
-	return lipgloss.JoinHorizontal(lipgloss.Top, standings, fixtures)
+	divider := m.verticalDivider()
+	return lipgloss.JoinHorizontal(lipgloss.Top, standings, divider, fixtures)
 }
 
+func (m Model) verticalDivider() string {
+	h := m.bodyHeightLimit()
+	if h <= 0 {
+		return styleDim.Render("│")
+	}
+	parts := make([]string, h)
+	for i := range parts {
+		parts[i] = styleDim.Render("│")
+	}
+	return strings.Join(parts, "\n")
+}
+
+// standingsPaneView renders the league table without a title header —
+// the column header acts as the first row.
 func (m Model) standingsPaneView(width int) string {
 	return m.standingsPaneViewBounded(width)
 }
@@ -159,18 +244,16 @@ func (m Model) standingsPaneViewBounded(width int) string {
 	if limit := m.bodyHeightLimit(); limit > 0 {
 		base = base.MaxHeight(limit)
 	}
-	title := lipgloss.NewStyle().Bold(true)
 
 	var b strings.Builder
-	b.WriteString(title.Render("Standings"))
-	b.WriteString("\n")
 
 	if m.league == nil || len(m.league.Standings) == 0 {
-		b.WriteString("Standings unavailable")
+		b.WriteString(styleSubtle.Render("no standings"))
 		return base.Render(b.String())
 	}
 
-	b.WriteString(truncate("   # Team                P  W  D  L Pts", width-2))
+	colHeader := styleSubtle.Render(truncate("  # Team                P  W  D  L Pts", width-2))
+	b.WriteString(colHeader)
 	b.WriteString("\n")
 	for _, line := range renderStandingsWindow(m.league.Standings, m.currentFixture(), width-2, m.standingsRowLimit()) {
 		b.WriteString(line)
@@ -180,28 +263,25 @@ func (m Model) standingsPaneViewBounded(width int) string {
 	return base.Render(strings.TrimRight(b.String(), "\n"))
 }
 
+// leagueFixturesPaneView renders the fixture list. The round label is the only
+// header line — no "Fixtures" title, no focus indicator.
 func (m Model) leagueFixturesPaneView(width int) string {
 	base := lipgloss.NewStyle().Width(width).Padding(0, 1)
 	if limit := m.bodyHeightLimit(); limit > 0 {
 		base = base.MaxHeight(limit)
 	}
-	title := lipgloss.NewStyle().Bold(true)
-	focusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
 
 	round := m.currentRound()
 	if m.league == nil || round == nil {
-		return base.Render("No league loaded yet")
+		return base.Render(styleSubtle.Render("no league loaded"))
 	}
 
 	var b strings.Builder
-	b.WriteString(title.Render("Fixtures"))
-	if m.focus == focusFixtures {
-		b.WriteString(" ")
-		b.WriteString(focusStyle.Render("[focus]"))
-	}
+
+	roundLabel := displayRoundLabel(round.Name, m.roundCursor+1)
+	total := len(m.league.Rounds)
+	b.WriteString(styleSubtle.Render(truncate(fmt.Sprintf("%s / %d", roundLabel, total), width-2)))
 	b.WriteString("\n")
-	b.WriteString(displayRoundLabel(round.Name, m.roundCursor+1))
-	b.WriteString("\n\n")
 
 	for _, line := range renderFixtureWindow(round.Fixtures, m.fixtureCursor, m.fixtureRowLimit(), width-2, false) {
 		b.WriteString(truncate(line, width-2))
@@ -209,11 +289,12 @@ func (m Model) leagueFixturesPaneView(width int) string {
 	}
 
 	if m.loading {
-		b.WriteString("\nLoading...")
+		b.WriteString("\n")
+		b.WriteString(styleSubtle.Render("Loading…"))
 	}
 	if m.err != "" {
-		b.WriteString("\nError: ")
-		b.WriteString(m.err)
+		b.WriteString("\n")
+		b.WriteString(styleSubtle.Render(m.err))
 	}
 
 	return base.Render(strings.TrimRight(b.String(), "\n"))
@@ -226,66 +307,9 @@ func (m Model) matchSketchView() string {
 	}
 
 	sidebar := m.matchSidebarView(leftWidth)
+	divider := m.verticalDivider()
 	detail := m.matchDetailPaneView(centerWidth)
-	return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, detail)
-}
-
-func (m Model) bodyHeightLimit() int {
-	reserved := 1
-	if m.topContextBarView() != "" {
-		reserved++
-	}
-	if m.height <= reserved {
-		return 0
-	}
-
-	return m.height - reserved
-}
-
-func (m Model) topContextBarView() string {
-	if m.suppressTopBar {
-		return ""
-	}
-
-	if m.league != nil {
-		if label := displayCompetitionLabel(m.league.Title); label != "" {
-			style := lipgloss.NewStyle().Width(m.width).Padding(0, 1).Bold(true)
-			return style.Render(truncate(label, m.width-2))
-		}
-	}
-
-	return ""
-}
-
-func (m Model) standingsRowLimit() int {
-	limit := m.bodyHeightLimit()
-	if limit == 0 {
-		return len(m.league.Standings)
-	}
-
-	reserved := 2
-	return max(0, limit-reserved)
-}
-
-func (m Model) fixtureRowLimit() int {
-	limit := m.bodyHeightLimit()
-	if limit == 0 {
-		round := m.currentRound()
-		if round == nil {
-			return 0
-		}
-		return len(round.Fixtures)
-	}
-
-	reserved := 3
-	if m.loading {
-		reserved += 2
-	}
-	if m.err != "" {
-		reserved += 2
-	}
-
-	return max(0, limit-reserved)
+	return lipgloss.JoinHorizontal(lipgloss.Top, sidebar, divider, detail)
 }
 
 func (m Model) matchSidebarView(width int) string {
@@ -343,17 +367,14 @@ func (m Model) matchFixtureRailView(width int) string {
 	if limit := m.bodyHeightLimit(); limit > 0 {
 		base = base.Height(limit).MaxHeight(limit)
 	}
-	title := lipgloss.NewStyle().Bold(true)
 
 	round := m.currentRound()
 	if round == nil {
-		return base.Render(title.Render("Fixtures") + "\nNo fixtures in selected round")
+		return base.Render(styleSubtle.Render("no fixtures"))
 	}
 
 	var b strings.Builder
-	b.WriteString(title.Render("Fixtures"))
-	b.WriteString("\n")
-	b.WriteString(truncate(displayRoundLabel(round.Name, m.roundCursor+1), width-2))
+	b.WriteString(styleSubtle.Render(truncate(displayRoundLabel(round.Name, m.roundCursor+1), width-2)))
 	b.WriteString("\n")
 
 	for _, line := range renderFixtureWindow(round.Fixtures, m.fixtureCursor, m.matchFixtureRowLimit(), width-2, true) {
@@ -362,7 +383,8 @@ func (m Model) matchFixtureRailView(width int) string {
 	}
 
 	if m.loading && m.match == nil {
-		b.WriteString("\nLoading...")
+		b.WriteString("\n")
+		b.WriteString(styleSubtle.Render("Loading…"))
 	}
 
 	return base.Render(strings.TrimRight(b.String(), "\n"))
@@ -378,7 +400,7 @@ func (m Model) matchFixtureRowLimit() int {
 		return len(round.Fixtures)
 	}
 
-	reserved := 2
+	reserved := 1 // round label
 	if m.loading && m.match == nil {
 		reserved += 2
 	}
@@ -394,8 +416,36 @@ func (m Model) standingsContentHeight() int {
 	if m.league == nil || len(m.league.Standings) == 0 {
 		return 2
 	}
+	return 1 + len(m.league.Standings) // col header + rows
+}
 
-	return 2 + len(m.league.Standings)
+func (m Model) standingsRowLimit() int {
+	limit := m.bodyHeightLimit()
+	if limit == 0 {
+		return len(m.league.Standings)
+	}
+	return max(0, limit-1) // 1 for col header
+}
+
+func (m Model) fixtureRowLimit() int {
+	limit := m.bodyHeightLimit()
+	if limit == 0 {
+		round := m.currentRound()
+		if round == nil {
+			return 0
+		}
+		return len(round.Fixtures)
+	}
+
+	reserved := 1 // round label
+	if m.loading {
+		reserved += 2
+	}
+	if m.err != "" {
+		reserved += 2
+	}
+
+	return max(0, limit-reserved)
 }
 
 func (m Model) matchDetailPaneView(width int) string {
@@ -403,18 +453,17 @@ func (m Model) matchDetailPaneView(width int) string {
 	if limit := m.matchViewportHeight(); limit > 0 {
 		base = base.MaxHeight(limit)
 	}
-	title := lipgloss.NewStyle().Bold(true)
 
 	if m.loading && m.match == nil {
-		return base.Render(title.Render("Match") + "\nLoading match details...")
+		return base.Render(styleSubtle.Render("Loading…"))
 	}
 
 	if m.err != "" && m.match == nil {
-		return base.Render(title.Render("Match") + "\nError: " + m.err)
+		return base.Render(styleSubtle.Render("Error: " + m.err))
 	}
 
 	if m.match == nil {
-		return base.Render("No match loaded")
+		return base.Render(styleSubtle.Render("no match loaded"))
 	}
 
 	content := m.matchDetailContent(width)
@@ -422,32 +471,51 @@ func (m Model) matchDetailPaneView(width int) string {
 }
 
 func (m Model) statusBarView() string {
-	enterHint := "enter: unavailable"
-	if m.currentFixtureDrillable() {
-		enterHint = "enter: details"
-	}
-	parts := []string{"j/k: move", "left/right: round", enterHint, "esc: selector", "q: quit"}
-	if m.matchView {
-		parts = []string{"h/l: round", "j/k: fixture", "pgup/pgdn: scroll", "ctrl+u/d: scroll", "esc: league", "r: reload", "q: quit"}
-	}
-	if m.selectorActive() {
-		parts = []string{"tab: focus", "j/k: move", "enter: load", "q: quit"}
-		if m.league != nil {
-			parts = []string{"tab: focus", "j/k: move", "enter: load", "esc: close", "q: quit"}
-		}
+	var parts []string
+
+	switch {
+	case m.selectorActive():
+		parts = []string{"j/k: move", "tab: focus", "enter: load"}
 		if len(m.competitionStack) > 0 {
-			parts = []string{"tab: focus", "j/k: move", "enter: open", "esc: back", "q: quit"}
+			parts[2] = "enter: open"
+			parts = append(parts, "esc: back")
+		} else if m.league != nil {
+			parts = append(parts, "esc: close")
 		}
+		parts = append(parts, "q: quit")
+
+	case m.matchView:
+		parts = []string{"j/k: fixture", "h/l: round", "pgup/pgdn: scroll", "esc: back", "r: reload", "q: quit"}
+
+	default:
+		enterHint := "enter: details"
+		if !m.currentFixtureDrillable() {
+			enterHint = "enter: unavail"
+		}
+		parts = []string{"j/k: move", "h/l: round", enterHint, "esc: selector", "q: quit"}
 	}
 
-	status := strings.Join(parts, "  ") + "  |  fetched: " + formatFetchTime(m.lastFetchAt)
+	left := strings.Join(parts, "  ·  ")
+
+	right := formatFetchTime(m.lastFetchAt)
 	if m.loading {
-		status += "  |  loading"
+		right = "loading…"
 	}
-	if m.err != "" {
-		status += "  |  error"
+	if m.err != "" && !m.loading {
+		right = "error  " + right
 	}
 
+	inner := m.width - 2
+	leftW := ansi.StringWidth(left)
+	rightW := ansi.StringWidth(right)
+	gap := max(2, inner-leftW-rightW)
+	if leftW+gap+rightW > inner {
+		left = truncate(left, inner-rightW-2)
+		leftW = ansi.StringWidth(left)
+		gap = max(1, inner-leftW-rightW)
+	}
+
+	status := left + strings.Repeat(" ", gap) + right
 	return lipgloss.NewStyle().Width(m.width).Padding(0, 1).Reverse(true).Render(truncate(status, m.width-2))
 }
 
@@ -455,14 +523,16 @@ func selectorPopupWidth(total int) int {
 	if total <= 0 {
 		return 36
 	}
-
 	return clamp(total/2+4, 40, 68)
 }
 
 func (m Model) matchDetailContent(width int) string {
-	title := lipgloss.NewStyle().Bold(true)
 	var b strings.Builder
-	b.WriteString(title.Render(renderMatchDetailRow(m.match.HomeTeam, normalizeScore(m.match.Score), m.match.AwayTeam, width-4)))
+
+	// Score header — one blank line of breathing room above.
+	b.WriteString("\n")
+	scoreText := matchDetailScore(m.match.Score)
+	b.WriteString(styleBold.Render(renderMatchDetailRow(m.match.HomeTeam, scoreText, m.match.AwayTeam, width-4)))
 	b.WriteString("\n")
 
 	status := matchStatus(m.match)
@@ -477,7 +547,7 @@ func (m Model) matchDetailContent(width int) string {
 		}
 		for _, row := range headerEvents {
 			if row.isDivider {
-				b.WriteString(renderMatchDividerRow(row.label, width-4))
+				b.WriteString(styleDim.Render(renderMatchDividerRow(row.label, width-4)))
 				b.WriteString("\n")
 				continue
 			}
@@ -491,19 +561,19 @@ func (m Model) matchDetailContent(width int) string {
 			b.WriteString("\n")
 		}
 		if ftDivider != "" {
-			b.WriteString(renderMatchDividerRow(ftDivider, width-4))
+			b.WriteString(styleDim.Render(renderMatchDividerRow(ftDivider, width-4)))
 			b.WriteString("\n")
 		}
 	}
 
 	if len(m.match.HomeLineup) > 0 || len(m.match.AwayLineup) > 0 {
 		b.WriteString("\n")
-		b.WriteString(title.Render(renderCenteredText("Lineups", width-4)))
+		b.WriteString(styleSubtle.Render(renderDividerLabel("Lineups", width-4)))
 		b.WriteString("\n")
 		b.WriteString(renderLineupRowWithMarker(
-			title.Render(m.match.HomeTeam),
-			title.Render(m.match.AwayTeam),
-			" ",
+			styleBold.Render(m.match.HomeTeam),
+			styleBold.Render(m.match.AwayTeam),
+			"│",
 			width-4,
 		))
 		b.WriteString("\n")
@@ -534,17 +604,30 @@ func (m Model) matchDetailContent(width int) string {
 			))
 			b.WriteString("\n")
 		}
-
 	}
 
 	if metaLine := displayMatchMeta(m.match.Meta, m.match.Weather); metaLine != "" {
 		b.WriteString("\n")
-		b.WriteString(title.Render(renderCenteredText("Details", width-4)))
+		b.WriteString(styleSubtle.Render(renderDividerLabel("Details", width-4)))
 		b.WriteString("\n")
-		b.WriteString(metaLine)
+		b.WriteString(styleDim.Render(metaLine))
 	}
 
 	return strings.TrimRight(b.String(), "\n")
+}
+
+// matchDetailScore formats the score for the match header with an en-dash,
+// giving it more visual weight than the compact fixture list format.
+func matchDetailScore(score string) string {
+	trimmed := strings.TrimSpace(score)
+	if trimmed == "" {
+		return "? – ?"
+	}
+	parts := strings.SplitN(trimmed, "-", 2)
+	if len(parts) == 2 {
+		return strings.TrimSpace(parts[0]) + " – " + strings.TrimSpace(parts[1])
+	}
+	return trimmed
 }
 
 func (m Model) matchViewportHeight() int {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/adrunkhuman/90minuTUI/internal/site"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -83,7 +84,13 @@ func barLine(left, right string, width int) string {
 }
 
 func (m Model) selectorOverlayView(body string) string {
-	popup := m.selectorPopupView(selectorPopupWidth(m.width))
+	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
+	rightHeading := "Leagues"
+	if strings.TrimSpace(m.competitionTitle) != "" {
+		rightHeading = m.competitionTitle
+	}
+	competitionLines := selectorCompetitionWidthLines(m.competitions)
+	popup := m.selectorPopupView(selectorPopupWidth(m.width, seasonLines, rightHeading, competitionLines))
 	bodyLines := strings.Split(body, "\n")
 	totalHeight := max(len(bodyLines), max(1, m.bodyHeightLimit()))
 	for len(bodyLines) < totalHeight {
@@ -131,6 +138,7 @@ func overlayLine(base, overlay string, leftWidth int) string {
 func (m Model) selectorPopupView(width int) string {
 	innerWidth := max(24, width-4)
 	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
+	competitionLines := renderCompetitionWindow(m.competitions, m.competitionCursor)
 	leftWidth, rightWidth := selectorPaneWidths(innerWidth, seasonLines)
 
 	rightHeading := "Leagues"
@@ -139,7 +147,7 @@ func (m Model) selectorPopupView(width int) string {
 	}
 
 	left := selectorPaneView(leftWidth, "Season", m.focus == focusSeasons, seasonLines)
-	right := selectorPaneView(rightWidth, rightHeading, m.focus == focusCompetitions, renderCompetitionWindow(m.competitions, m.competitionCursor))
+	right := selectorPaneView(rightWidth, rightHeading, m.focus == focusCompetitions, competitionLines)
 
 	// Vertical divider — height matches the taller pane.
 	leftLines := strings.Split(left, "\n")
@@ -252,7 +260,11 @@ func (m Model) standingsPaneViewBounded(width int) string {
 		return base.Render(b.String())
 	}
 
-	colHeader := styleSubtle.Render(truncate("  # Team                P  W  D  L Pts", width-2))
+	teamWidth := standingsTeamWidth(m.league.Standings, width-2)
+	colHeader := styleSubtle.Render(truncate(
+		fmt.Sprintf("  %2s %-*s %2s %2s %2s %2s %3s", "#", teamWidth, "Team", "P", "W", "D", "L", "Pts"),
+		width-2,
+	))
 	b.WriteString(colHeader)
 	b.WriteString("\n")
 	for _, line := range renderStandingsWindow(m.league.Standings, m.currentFixture(), width-2, m.standingsRowLimit()) {
@@ -519,11 +531,42 @@ func (m Model) statusBarView() string {
 	return lipgloss.NewStyle().Width(m.width).Padding(0, 1).Reverse(true).Render(truncate(status, m.width-2))
 }
 
-func selectorPopupWidth(total int) int {
+func selectorPopupWidth(total int, seasonLines []string, rightHeading string, competitionLines []string) int {
 	if total <= 0 {
 		return 36
 	}
-	return clamp(total/2+4, 40, 68)
+
+	leftWidth, rightWidth := selectorContentWidths(seasonLines, rightHeading, competitionLines)
+	desired := leftWidth + 1 + rightWidth + 4 // divider + panel border/padding
+	return clamp(desired, 40, max(40, total-2))
+}
+
+func selectorContentWidths(seasonLines []string, rightHeading string, competitionLines []string) (int, int) {
+	seasonWidth := lipgloss.Width("Season")
+	for _, line := range seasonLines {
+		seasonWidth = max(seasonWidth, lipgloss.Width(line))
+	}
+	leftWidth := clamp(seasonWidth+1, 14, 18)
+
+	rightWidth := lipgloss.Width(rightHeading)
+	for _, line := range competitionLines {
+		rightWidth = max(rightWidth, lipgloss.Width(line))
+	}
+	rightWidth = max(16, rightWidth+1)
+
+	return leftWidth, rightWidth
+}
+
+func selectorCompetitionWidthLines(items []site.Competition) []string {
+	if len(items) == 0 {
+		return nil
+	}
+
+	lines := make([]string, 0, len(items))
+	for _, item := range items {
+		lines = append(lines, "  "+item.Name)
+	}
+	return lines
 }
 
 func (m Model) matchDetailContent(width int) string {
@@ -534,6 +577,17 @@ func (m Model) matchDetailContent(width int) string {
 	scoreText := matchDetailScore(m.match.Score)
 	b.WriteString(styleBold.Render(renderMatchDetailRow(m.match.HomeTeam, scoreText, m.match.AwayTeam, width-4)))
 	b.WriteString("\n")
+
+	// Date and match details sit directly under the score.
+	metaDate, metaDetails := matchMetaDisplay(m.match.Meta, m.match.Weather)
+	if metaDate != "" {
+		b.WriteString(styleSubtle.Render(padCenter(truncate(metaDate, width-4), width-4)))
+		b.WriteString("\n")
+	}
+	if metaDetails != "" {
+		b.WriteString(styleDim.Render(padCenter(truncate(metaDetails, width-4), width-4)))
+		b.WriteString("\n")
+	}
 
 	status := matchStatus(m.match)
 	headerEvents := headerEventRows(m.match.Events)
@@ -573,7 +627,7 @@ func (m Model) matchDetailContent(width int) string {
 		b.WriteString(renderLineupRowWithMarker(
 			styleBold.Render(m.match.HomeTeam),
 			styleBold.Render(m.match.AwayTeam),
-			"│",
+			" ",
 			width-4,
 		))
 		b.WriteString("\n")
@@ -604,13 +658,6 @@ func (m Model) matchDetailContent(width int) string {
 			))
 			b.WriteString("\n")
 		}
-	}
-
-	if metaLine := displayMatchMeta(m.match.Meta, m.match.Weather); metaLine != "" {
-		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render(renderDividerLabel("Details", width-4)))
-		b.WriteString("\n")
-		b.WriteString(styleDim.Render(metaLine))
 	}
 
 	return strings.TrimRight(b.String(), "\n")

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -133,8 +133,10 @@ func TestMatchDetailRemovesRedundantMetadata(t *testing.T) {
 		"17'",
 		"62'",
 		"FT 1 – 2",
-		"Details",
-		"13 March 2026, 18:00 | Attendance 3542 | Ref. Damian Kos | Weather 15 C",
+		"13 March 2026, 18:00",
+		"Attendance 3542",
+		"Ref. Damian Kos",
+		"Weather 15 C",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected match view to contain %q\n%s", want, view)
@@ -201,7 +203,7 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		"❌", "52'", // away missed penalty row
 		"Szkurin", "60'", // second home goal row
 		"K. Czubak", "70'", // away goal row
-		"🟥", "85'", // away red card row
+		"■", "85'", // away red card row
 		"FT 2 – 1", // FT divider with score
 	} {
 		if !strings.Contains(plainView, want) {
@@ -241,7 +243,7 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 	for _, want := range []string{
 		"46'",      // sub minute visible at outer edge of player name
 		"D. Nowak", // sub-on player visible immediately after sub-off
-		"🟥",        // red card badge in event column
+		"■",        // red card badge in event column
 	} {
 		if !strings.Contains(plainView, want) {
 			t.Fatalf("expected lineup section to contain %q\n%s", want, view)
@@ -411,7 +413,7 @@ func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
 	// to the minute center used by event rows.
 	// divider uses '─' (multi-byte), so normalise to '-' before byte-indexing.
 	dividerASCII := strings.ReplaceAll(divider, "─", "-")
-	rowMid := strings.Index(row, "39'") + 1              // '9' = middle char of "39'"
+	rowMid := strings.Index(row, "39'") + 1                // '9' = middle char of "39'"
 	dividerMid := strings.Index(dividerASCII, "1 - 0") + 2 // '-' at offset 2 within "1 - 0"
 	if diff := rowMid - dividerMid; diff < -2 || diff > 2 {
 		t.Fatalf("expected divider score dash to align with minute centre\nrow: %q\ndiv: %q", row, divider)
@@ -491,8 +493,8 @@ func TestHeaderEventRowsIncludesRedCardsAndHTDivider(t *testing.T) {
 	if strings.TrimSpace(rows[0].minute) != "39'" {
 		t.Fatalf("expected first goal minute 39' in center, got %q", rows[0].minute)
 	}
-	if !strings.Contains(ansi.Strip(rows[3].label), "🟥") {
-		t.Fatalf("expected red card row to contain 🟥, got %q", ansi.Strip(rows[3].label))
+	if !strings.Contains(ansi.Strip(rows[3].label), "■") {
+		t.Fatalf("expected red card row to contain ■, got %q", ansi.Strip(rows[3].label))
 	}
 	if rows[3].minute != "85'" {
 		t.Fatalf("expected red card minute 85', got %q", rows[3].minute)
@@ -876,6 +878,46 @@ func TestRenderFixtureWindowAlignsFullFixtureColumns(t *testing.T) {
 	}
 }
 
+func TestRenderFixtureWindowKeepsColumnsAlignedWhenDetailsUnavailable(t *testing.T) {
+	fixtures := []site.Fixture{
+		{Home: "Cracovia", Away: "Arka Gdynia", Score: "-", WhenInfo: "12 kwietnia, 12:15"},
+		{Home: "Legia Warszawa", Away: "Gornik Zabrze", Score: "1-1", WhenInfo: "11 kwietnia, 20:15", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=3"},
+	}
+	lines := renderFixtureWindow(fixtures, 0, 5, 84, false)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	norm := func(s string) string { return strings.Replace(ansi.Strip(s), "›", " ", 1) }
+	n0, n1 := norm(lines[0]), norm(lines[1])
+	if strings.Index(n0[2:], "Arka Gdynia") != strings.Index(n1[2:], "Gornik Zabrze") {
+		t.Fatalf("expected aligned away-team column, got %q and %q", lines[0], lines[1])
+	}
+	if strings.Index(n0[2:], "12/04") != strings.Index(n1[2:], "11/04") {
+		t.Fatalf("expected aligned date column, got %q and %q", lines[0], lines[1])
+	}
+	if !strings.Contains(lines[0], "[no details]") {
+		t.Fatalf("expected unavailable-details marker, got %q", lines[0])
+	}
+}
+
+func TestStandingsTeamWidthUsesAvailableSpaceWithoutOverexpanding(t *testing.T) {
+	rows := []site.StandingRow{
+		{Team: "Legia Warszawa"},
+		{Team: "Bruk-Bet Termalica Nieciecza"},
+	}
+
+	if got := standingsTeamWidth(rows, 60); got != ansi.StringWidth("Bruk-Bet Termalica Nieciecza") {
+		t.Fatalf("expected long team to fit when space allows, got %d", got)
+	}
+	if got := standingsTeamWidth(rows, 80); got != ansi.StringWidth("Bruk-Bet Termalica Nieciecza") {
+		t.Fatalf("expected width to stop at longest team, got %d", got)
+	}
+	if got := standingsTeamWidth(rows, 40); got != 19 {
+		t.Fatalf("expected width capped by available space, got %d", got)
+	}
+}
+
 func TestLeagueViewCanShowSelectorPopup(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
@@ -921,6 +963,53 @@ func TestSelectorPaneWidthsFavorLeagues(t *testing.T) {
 	left, right := selectorPaneWidths(40, renderSeasonsWindow(sketchModel().seasons, 0))
 	if left >= right {
 		t.Fatalf("expected leagues pane wider than seasons pane, got left=%d right=%d", left, right)
+	}
+}
+
+func TestSelectorPopupWidthExpandsForVisibleLeagueNames(t *testing.T) {
+	seasonLines := renderSeasonsWindow(sketchModel().seasons, 0)
+	competitionLines := []string{
+		"Decathlon IV liga 2025/2026, grupa: mazowiecka",
+		"Keeza Liga okregowa 2025/2026, grupa: Ciechanow-Ostroleka",
+	}
+
+	got := selectorPopupWidth(120, seasonLines, "Ligi regionalne 2025/26 - Mazowiecki ZPN", competitionLines)
+	if got <= 68 {
+		t.Fatalf("expected popup wider than legacy cap for long visible league names, got %d", got)
+	}
+
+	short := selectorPopupWidth(120, seasonLines, "Leagues", []string{"Ekstraklasa", "I liga"})
+	if short >= got {
+		t.Fatalf("expected short content popup narrower than long-content popup, got short=%d long=%d", short, got)
+	}
+}
+
+func TestSelectorPopupWidthDoesNotDependOnCurrentScrollWindow(t *testing.T) {
+	m := sketchModel()
+	m.competitions = make([]site.Competition, 0, 24)
+	for i := 0; i < 24; i++ {
+		name := fmt.Sprintf("League %02d", i)
+		if i == 22 {
+			name = "Ligi regionalne 2025/26 - Mazowiecki ZPN, grupa: Ciechanow-Ostroleka i okolice"
+		}
+		m.competitions = append(m.competitions, site.Competition{Name: name})
+	}
+
+	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
+	rightHeading := "Leagues"
+	allLines := selectorCompetitionWidthLines(m.competitions)
+	widthFromAll := selectorPopupWidth(120, seasonLines, rightHeading, allLines)
+
+	visibleNearTop := renderCompetitionWindow(m.competitions, 0)
+	visibleNearBottom := renderCompetitionWindow(m.competitions, len(m.competitions)-1)
+	widthTop := selectorPopupWidth(120, seasonLines, rightHeading, visibleNearTop)
+	widthBottom := selectorPopupWidth(120, seasonLines, rightHeading, visibleNearBottom)
+
+	if widthFromAll < widthTop || widthFromAll < widthBottom {
+		t.Fatalf("expected all-items width to cover every scroll window, got all=%d top=%d bottom=%d", widthFromAll, widthTop, widthBottom)
+	}
+	if widthTop == widthBottom {
+		t.Fatalf("expected visible-window widths to differ in this fixture setup, got top=%d bottom=%d", widthTop, widthBottom)
 	}
 }
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -47,7 +47,7 @@ func TestLeagueSketchViewShowsLeagueTitleOnlyOnce(t *testing.T) {
 	}
 }
 
-func TestLeagueViewUsesTopContextBar(t *testing.T) {
+func TestLeagueViewUsesTwoLineTopBar(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
 	m.height = 18
@@ -374,10 +374,10 @@ func TestMatchDetailKeepsSubstitutionsOnlyInLineups(t *testing.T) {
 }
 
 func TestMatchDetailRowsAnchorTowardCenteredMinuteColumn(t *testing.T) {
-	line := renderMatchDetailRow("Wdowiak ⚽", "39'", "↕ Pllana (4)", 76)
+	line := renderMatchDetailRow("Wdowiak ⚽", "39'", "Pllana ■", 76)
 	minuteIdx := strings.Index(line, "39'")
 	leftIdx := strings.Index(line, "Wdowiak ⚽")
-	rightIdx := strings.Index(line, "↕ Pllana (4)")
+	rightIdx := strings.Index(line, "Pllana ■")
 	if minuteIdx <= 0 || leftIdx < 0 || rightIdx < 0 {
 		t.Fatalf("expected all columns rendered, got %q", line)
 	}
@@ -411,10 +411,10 @@ func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
 	divider := renderMatchDividerRow("HT 1 - 0", 76)
 	// The divider label stays visually centered, and its score dash should remain close
 	// to the minute center used by event rows.
-	// divider uses '─' (multi-byte), so normalise to '-' before byte-indexing.
+	// Divider fill uses '─', so normalise it to '-' before byte-indexing.
 	dividerASCII := strings.ReplaceAll(divider, "─", "-")
 	rowMid := strings.Index(row, "39'") + 1                // '9' = middle char of "39'"
-	dividerMid := strings.Index(dividerASCII, "1 - 0") + 2 // '-' at offset 2 within "1 - 0"
+	dividerMid := strings.Index(dividerASCII, "1 - 0") + 2 // score dash within the divider label
 	if diff := rowMid - dividerMid; diff < -2 || diff > 2 {
 		t.Fatalf("expected divider score dash to align with minute centre\nrow: %q\ndiv: %q", row, divider)
 	}
@@ -422,7 +422,7 @@ func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
 
 func TestMatchDividerFillsCenterPaddingWithDashes(t *testing.T) {
 	divider := renderMatchDividerRow("HT 0 - 0", 76)
-	// Padding chars are '─'; label uses ASCII ' - '.
+	// Padding chars are '─'; the test label stays ASCII so byte positions are stable.
 	if strings.Contains(divider, "HT 0 - 0   ") {
 		t.Fatalf("expected divider to avoid wide trailing spaces after label, got %q", divider)
 	}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -22,15 +22,12 @@ func TestLeagueSketchViewShowsStandingsFixturesAndStatus(t *testing.T) {
 	view := m.View()
 	for _, want := range []string{
 		"PKO Bank Polski Ekstraklasa 2025/2026",
-		"Standings",
 		"# Team",
 		"Legia Warszawa",
-		"Fixtures",
 		"Round 1",
-		"Legia Warszawa",
 		"Lech Poznan",
-		"| 24/01 20:30",
-		"fetched: 21:15:00",
+		"24/01 20:30",
+		"21:15:00",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q\n%s", want, view)
@@ -87,10 +84,10 @@ func TestMatchSketchViewShowsLoadingState(t *testing.T) {
 
 	view := m.View()
 	for _, want := range []string{
-		"Standings",
-		"Fixtures",
+		"# Team",
+		"Round 1",
 		"LEG 2-1 LEC",
-		"Loading match details...",
+		"Loading…",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q\n%s", want, view)
@@ -129,13 +126,13 @@ func TestMatchDetailRemovesRedundantMetadata(t *testing.T) {
 	for _, want := range []string{
 		"PKO Bank Polski Ekstraklasa 2025/2026",
 		"Bruk-Bet Termalica Nieciecza",
-		"1-2",
+		"1 – 2",
 		"Motor Lublin",
 		"K. Kubica",
 		"S. Mraz",
 		"17'",
 		"62'",
-		"FT 1 - 2",
+		"FT 1 – 2",
 		"Details",
 		"13 March 2026, 18:00 | Attendance 3542 | Ref. Damian Kos | Weather 15 C",
 	} {
@@ -192,7 +189,7 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 	plainView := ansi.Strip(view)
 	_, centerWidth, _ := matchLayoutWidths(m.width)
 	content := ansi.Strip(m.matchDetailContent(centerWidth))
-	scoreHeader := renderMatchDetailRow("GKS Katowice", "2-1", "Lechia Gdansk", centerWidth-4)
+	scoreHeader := renderMatchDetailRow("GKS Katowice", matchDetailScore("2-1"), "Lechia Gdansk", centerWidth-4)
 	spacerRow := renderMatchDetailRow("", "", "", centerWidth-4)
 	if !strings.Contains(content, scoreHeader+"\n"+spacerRow+"\n") {
 		t.Fatalf("expected spacer row between score header and event log\n%s", content)
@@ -200,12 +197,12 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 
 	for _, want := range []string{
 		"Wdowiak", "39'", "⚽", // home goal row (minute in center, icon adjacent)
-		"HT 1 - 0", // HT divider with score
+		"HT 1 – 0", // HT divider with score
 		"❌", "52'", // away missed penalty row
 		"Szkurin", "60'", // second home goal row
 		"K. Czubak", "70'", // away goal row
 		"🟥", "85'", // away red card row
-		"FT 2 - 1", // FT divider with score
+		"FT 2 – 1", // FT divider with score
 	} {
 		if !strings.Contains(plainView, want) {
 			t.Fatalf("expected match view to contain %q\n%s", want, view)
@@ -223,12 +220,12 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 
 	headerIndexes := []int{
 		strings.Index(plainView, "39'"),
-		strings.Index(plainView, "HT 1 - 0"),
+		strings.Index(plainView, "HT 1 – 0"),
 		strings.Index(plainView, "52'"),
 		strings.Index(plainView, "60'"),
 		strings.Index(plainView, "70'"),
 		strings.Index(plainView, "85'"),
-		strings.Index(plainView, "FT 2 - 1"),
+		strings.Index(plainView, "FT 2 – 1"),
 	}
 	for _, idx := range headerIndexes {
 		if idx < 0 {
@@ -412,8 +409,10 @@ func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
 	divider := renderMatchDividerRow("HT 1 - 0", 76)
 	// The divider label stays visually centered, and its score dash should remain close
 	// to the minute center used by event rows.
-	rowMid := strings.Index(row, "39'") + 1           // '9' = middle char of "39'"
-	dividerMid := strings.Index(divider, "1 - 0") + 2 // '-' at offset 2 within "1 - 0"
+	// divider uses '─' (multi-byte), so normalise to '-' before byte-indexing.
+	dividerASCII := strings.ReplaceAll(divider, "─", "-")
+	rowMid := strings.Index(row, "39'") + 1              // '9' = middle char of "39'"
+	dividerMid := strings.Index(dividerASCII, "1 - 0") + 2 // '-' at offset 2 within "1 - 0"
 	if diff := rowMid - dividerMid; diff < -2 || diff > 2 {
 		t.Fatalf("expected divider score dash to align with minute centre\nrow: %q\ndiv: %q", row, divider)
 	}
@@ -421,11 +420,15 @@ func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
 
 func TestMatchDividerFillsCenterPaddingWithDashes(t *testing.T) {
 	divider := renderMatchDividerRow("HT 0 - 0", 76)
+	// Padding chars are '─'; label uses ASCII ' - '.
 	if strings.Contains(divider, "HT 0 - 0   ") {
 		t.Fatalf("expected divider to avoid wide trailing spaces after label, got %q", divider)
 	}
 	if !strings.Contains(divider, " HT 0 - 0 ") {
 		t.Fatalf("expected divider to keep single spaces around label, got %q", divider)
+	}
+	if !strings.Contains(divider, "─") {
+		t.Fatalf("expected divider to use box-drawing fill character, got %q", divider)
 	}
 }
 
@@ -479,8 +482,8 @@ func TestHeaderEventRowsIncludesRedCardsAndHTDivider(t *testing.T) {
 	if !rows[1].isDivider {
 		t.Fatalf("expected row 1 to be HT divider, got %#v", rows[1])
 	}
-	if rows[1].label != "HT 1 - 0" {
-		t.Fatalf("expected HT divider label %q, got %q", "HT 1 - 0", rows[1].label)
+	if rows[1].label != "HT 1 – 0" {
+		t.Fatalf("expected HT divider label %q, got %q", "HT 1 – 0", rows[1].label)
 	}
 	if ansi.Strip(rows[0].label) != "Wdowiak ⚽" {
 		t.Fatalf("unexpected first goal label: %q", ansi.Strip(rows[0].label))
@@ -507,8 +510,8 @@ func TestHeaderEventRowsIncludesGoallessHTDividerBeforeSecondHalfEvents(t *testi
 	if !rows[0].isDivider {
 		t.Fatalf("expected row 0 to be HT divider, got %#v", rows[0])
 	}
-	if rows[0].label != "HT 0 - 0" {
-		t.Fatalf("expected HT divider label %q, got %q", "HT 0 - 0", rows[0].label)
+	if rows[0].label != "HT 0 – 0" {
+		t.Fatalf("expected HT divider label %q, got %q", "HT 0 – 0", rows[0].label)
 	}
 	if rows[1].minute != "60'" {
 		t.Fatalf("expected second-half event minute 60', got %q", rows[1].minute)
@@ -528,7 +531,7 @@ func TestHeaderEventRowsKeepsHTDividerWhenSecondHalfHasOnlyHiddenEvents(t *testi
 	if rows[0].isDivider {
 		t.Fatalf("expected first row to be visible event, got %#v", rows[0])
 	}
-	if !rows[1].isDivider || rows[1].label != "HT 1 - 0" {
+	if !rows[1].isDivider || rows[1].label != "HT 1 – 0" {
 		t.Fatalf("expected final row to be HT divider, got %#v", rows[1])
 	}
 }
@@ -747,7 +750,7 @@ func TestMatchDetailContentShowsFTDividerWithoutVisibleHeaderEvents(t *testing.T
 	}
 
 	content := ansi.Strip(m.matchDetailContent(80))
-	if !strings.Contains(content, "FT 1 - 0") {
+	if !strings.Contains(content, "FT 1 – 0") {
 		t.Fatalf("expected FT divider even without visible header events\n%s", content)
 	}
 }
@@ -766,7 +769,7 @@ func TestRenderCenteredTextCentersSectionLabels(t *testing.T) {
 
 func TestFinalScoreLineUsesMatchScore(t *testing.T) {
 	got := finalScoreLine(&site.MatchPage{Score: "2-0"})
-	if got != "FT 2 - 0" {
+	if got != "FT 2 – 0" {
 		t.Fatalf("unexpected final score line: %q", got)
 	}
 }
@@ -801,7 +804,7 @@ func TestRenderFixtureWindowUsesFullNamesOutsideMatchSidebar(t *testing.T) {
 		MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1",
 	}}, 0, 5, 80, false)
 
-	if len(lines) != 1 || !strings.Contains(lines[0], "Legia Warszawa") || !strings.Contains(lines[0], "Lech Poznan") || !strings.Contains(lines[0], "| 24/01 20:30") {
+	if len(lines) != 1 || !strings.Contains(ansi.Strip(lines[0]), "Legia Warszawa") || !strings.Contains(ansi.Strip(lines[0]), "Lech Poznan") || !strings.Contains(ansi.Strip(lines[0]), "24/01 20:30") {
 		t.Fatalf("expected full fixture line, got %v", lines)
 	}
 }
@@ -815,7 +818,9 @@ func TestRenderFixtureWindowUsesCompactNamesInMatchSidebar(t *testing.T) {
 		MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1",
 	}}, 0, 5, 40, true)
 
-	if len(lines) != 1 || !strings.Contains(lines[0], "LEG 2-1 LEC | 24/01 20:30") {
+	// Compact fixture: abbreviated names + score, then when-info separated by two spaces (no pipe).
+	stripped := ansi.Strip(lines[0])
+	if len(lines) != 1 || !strings.Contains(stripped, "LEG 2-1 LEC") || !strings.Contains(stripped, "24/01 20:30") {
 		t.Fatalf("expected compact fixture line, got %v", lines)
 	}
 }
@@ -845,7 +850,7 @@ func TestStatusBarViewReflectsFixtureDrillability(t *testing.T) {
 	m.league.Rounds[0].Fixtures[0].MatchURL = ""
 	m.league.Rounds[0].Fixtures[0].MatchID = ""
 	status = m.statusBarView()
-	if !strings.Contains(status, "enter: unavailable") {
+	if !strings.Contains(status, "enter: unavail") {
 		t.Fatalf("expected non-drillable status hint, got %q", status)
 	}
 }
@@ -859,10 +864,14 @@ func TestRenderFixtureWindowAlignsFullFixtureColumns(t *testing.T) {
 	if len(lines) != 2 {
 		t.Fatalf("expected 2 lines, got %d", len(lines))
 	}
-	if strings.Index(lines[0][2:], "|") != strings.Index(lines[1][2:], "|") {
+	// Normalise: strip ANSI then replace the multi-byte cursor marker '›' with a space
+	// so both lines have the same 2-byte prefix and byte positions match visual positions.
+	norm := func(s string) string { return strings.Replace(ansi.Strip(s), "›", " ", 1) }
+	n0, n1 := norm(lines[0]), norm(lines[1])
+	if strings.Index(n0[2:], "13/03") != strings.Index(n1[2:], "14/03") {
 		t.Fatalf("expected aligned date column, got %q and %q", lines[0], lines[1])
 	}
-	if strings.Index(lines[0][2:], "1-2") != strings.Index(lines[1][2:], "1-2") {
+	if strings.Index(n0[2:], "1-2") != strings.Index(n1[2:], "1-2") {
 		t.Fatalf("expected score column alignment, got %q and %q", lines[0], lines[1])
 	}
 }
@@ -876,11 +885,11 @@ func TestLeagueViewCanShowSelectorPopup(t *testing.T) {
 
 	view := m.View()
 	for _, want := range []string{
-		"Standings",
+		"# Team",
 		"Legia Warszawa",
 		"Lech Poznan",
-		"| 24/01 20:30",
-		"Season + league",
+		"24/01 20:30",
+		"Season",
 		"2024/2025",
 		"Ekstraklasa",
 		"esc: close",
@@ -933,7 +942,7 @@ func TestSelectorPopupHandlesShortTerminal(t *testing.T) {
 	m.focus = focusCompetitions
 
 	view := m.View()
-	for _, want := range []string{"Season + league", "Fixtures"} {
+	for _, want := range []string{"Season", "Round"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q\n%s", want, view)
 		}
@@ -991,7 +1000,7 @@ func TestMatchViewScrollsLongContent(t *testing.T) {
 	if !strings.Contains(view, "Player01") {
 		t.Fatalf("expected initial match view to show top content\n%s", view)
 	}
-	for _, want := range []string{"Standings", "Fixtures", "LEG 2-1 LEC"} {
+	for _, want := range []string{"# Team", "Round", "LEG 2-1 LEC"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected match view to keep sidebar content %q visible\n%s", want, view)
 		}
@@ -1005,7 +1014,7 @@ func TestMatchViewScrollsLongContent(t *testing.T) {
 	if !strings.Contains(view, "Player20") {
 		t.Fatalf("expected scrolled match view to show later content\n%s", view)
 	}
-	for _, want := range []string{"Standings", "Fixtures", "LEG 2-1 LEC"} {
+	for _, want := range []string{"# Team", "Round", "LEG 2-1 LEC"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected scrolled match view to keep sidebar content %q visible\n%s", want, view)
 		}


### PR DESCRIPTION
## Summary
- redesign the TUI around a cleaner visual hierarchy, top context bar, simplified panes, and tighter match detail presentation
- align fixture rows consistently across score, suffix, and date columns, including linkless matches with `[no details]`
- make standings and selector widths adapt to available content without resizing while scrolling

## Testing
- go test ./...

## Issues
- no direct matching open issue found; this is redesign branch polish rather than a targeted issue fix