### PR TITLE
Add r: reload hint to league view status bar

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -504,7 +504,7 @@ func (m Model) statusBarView() string {
 		if !m.currentFixtureDrillable() {
 			enterHint = "enter: unavail"
 		}
-		parts = []string{"j/k: move", "h/l: round", enterHint, "esc: selector", "q: quit"}
+		parts = []string{"j/k: move", "h/l: round", enterHint, "esc: selector", "r: reload", "q: quit"}
 	}
 
 	left := strings.Join(parts, "  ·  ")

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -857,6 +857,16 @@ func TestStatusBarViewReflectsFixtureDrillability(t *testing.T) {
 	}
 }
 
+func TestStatusBarViewLeagueViewIncludesReloadHint(t *testing.T) {
+	m := sketchModel()
+	m.width = 120
+
+	status := m.statusBarView()
+	if !strings.Contains(status, "r: reload") {
+		t.Fatalf("expected reload hint in league status bar, got %q", status)
+	}
+}
+
 func TestRenderFixtureWindowAlignsFullFixtureColumns(t *testing.T) {
 	fixtures := []site.Fixture{
 		{Home: "Bruk-Bet Termalica Nieciecza", Away: "Motor Lublin", Score: "1-2", WhenInfo: "13 marca, 18:00 (3542)", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1"},


### PR DESCRIPTION
## Summary

- `r` is bound to `handleReload()` in all views but the status bar only showed the hint in match view.
- Adds `r: reload` to the default branch of `statusBarView()` so users see it in the league/fixture list view, especially after a failed fetch.

Fixes #32

## Test plan

- [ ] `TestStatusBarViewLeagueViewIncludesReloadHint` — status bar in default view contains `r: reload`.