### PR TITLE
Drain startup commands to nil in bootstrapLeagueLoadedModel

### DIFF
--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -616,8 +616,7 @@ func bootstrapLeagueLoadedModel(t *testing.T, loader *recordingLoader) Model {
 		t.Fatalf("expected archive loaded flow to schedule league load")
 	}
 
-	m, cmd = updateModelWithMsg(t, m, cmd())
-	for i := 0; i < 4 && cmd != nil; i++ {
+	for cmd != nil {
 		m, cmd = updateModelWithMsg(t, m, cmd())
 	}
 


### PR DESCRIPTION
## Summary

- Replaces the magic `for i < 4` iteration bound with a nil-drain loop so the helper stays correct when startup gains or loses an async step.
- The old bound was 4+1 iterations; only 1 did any work. The nil-drain is functionally equivalent.

Fixes #28

## Test plan

- [ ] All existing navigation tests pass unchanged — verified locally.
- [ ] `bootstrapLeagueLoadedModel` still asserts `leagueCalls == 1`, `league != nil`, and `focus == focusFixtures` after the drain.