### PR TITLE
Centralise hardcoded constants into named symbols

### DIFF
--- a/internal/site/client.go
+++ b/internal/site/client.go
@@ -7,13 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"golang.org/x/net/html/charset"
 )
-
-const defaultBaseURL = "http://www.90minut.pl"
 
 type Client struct {
 	baseURL *url.URL
@@ -21,12 +18,12 @@ type Client struct {
 }
 
 func NewClient() *Client {
-	base, _ := url.Parse(defaultBaseURL)
+	base, _ := url.Parse(BaseURL)
 
 	return &Client{
 		baseURL: base,
 		http: &http.Client{
-			Timeout: 15 * time.Second,
+			Timeout: HTTPTimeout,
 		},
 	}
 }

--- a/internal/site/config.go
+++ b/internal/site/config.go
@@ -1,0 +1,12 @@
+package site
+
+import "time"
+
+const (
+	BaseURL    = "http://www.90minut.pl"
+	ArchiveURL = BaseURL + "/archsezon.php"
+
+	// HTTPTimeout caps individual HTTP round-trips; kept short to surface
+	// connectivity failures quickly without blocking the TUI.
+	HTTPTimeout = 15 * time.Second
+)

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -10,9 +10,12 @@ import (
 	"github.com/adrunkhuman/90minuTUI/internal/site"
 )
 
+// cmdTimeout is generous enough for slow archive pages without blocking the TUI indefinitely.
+const cmdTimeout = 20 * time.Second
+
 func (m Model) loadArchiveCmd(url string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		seasons, selectedIdx, competitions, err := m.service.LoadArchive(ctx, url)
 		return archiveLoadedMsg{seasons: seasons, selectedIdx: selectedIdx, competitions: competitions, err: err}
@@ -21,7 +24,7 @@ func (m Model) loadArchiveCmd(url string) tea.Cmd {
 
 func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		_, _, competitions, err := m.service.LoadArchive(ctx, url)
 		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, err: err}
@@ -30,7 +33,7 @@ func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string) tea.Cmd {
 
 func (m Model) loadCompetitionCmd(url, competitionKey string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		menu, league, err := m.service.LoadCompetition(ctx, url)
 		return competitionMenuLoadedMsg{competitionKey: competitionKey, menu: menu, league: league, err: err}
@@ -39,7 +42,7 @@ func (m Model) loadCompetitionCmd(url, competitionKey string) tea.Cmd {
 
 func (m Model) loadLeagueCmd(url, competitionKey string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		league, err := m.service.LoadLeague(ctx, url)
 		return leagueLoadedMsg{competitionKey: competitionKey, league: league, err: err}
@@ -48,7 +51,7 @@ func (m Model) loadLeagueCmd(url, competitionKey string) tea.Cmd {
 
 func (m Model) loadMatchCmd(url, fixtureKey string) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		match, err := m.service.LoadMatch(ctx, url)
 		return matchLoadedMsg{fixtureKey: fixtureKey, match: match, err: err}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -4,10 +4,12 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
 )
 
 func (m Model) Init() tea.Cmd {
-	return m.loadArchiveCmd("http://www.90minut.pl/archsezon.php")
+	return m.loadArchiveCmd(site.ArchiveURL)
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -391,7 +393,7 @@ func (m *Model) handleReload() tea.Cmd {
 
 	m.match = nil
 	if len(m.seasons) == 0 {
-		return m.loadArchiveCmd("http://www.90minut.pl/archsezon.php")
+		return m.loadArchiveCmd(site.ArchiveURL)
 	}
 
 	if m.selectorActive() && m.focus == focusSeasons {


### PR DESCRIPTION
## Summary

- Creates `internal/site/config.go` with `BaseURL`, `ArchiveURL`, and `HTTPTimeout` to replace scattered magic strings and literals in the transport layer.
- Adds `cmdTimeout` in `internal/ui/commands.go` (kept near the command layer per the issue guidance) and replaces all 5 inline `20*time.Second` literals.
- `client.go` and `update.go` now reference the named constants instead of inline literals.

Fixes #31

## Test plan

- [ ] `go build ./...` — no import errors, all constants resolve correctly.
- [ ] `go test ./...` — all existing tests pass unchanged.