### PR TITLE
Make selector state explicit instead of partly implicit

### DIFF
--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -23,6 +23,9 @@ type recordingLoader struct {
 	menus        map[string]*site.CompetitionMenu
 	league       *site.LeaguePage
 	match        *site.MatchPage
+
+	// compErr, when non-nil, is returned by LoadCompetition instead of the league.
+	compErr error
 }
 
 func (l *recordingLoader) LoadArchive(context.Context, string) ([]site.Season, int, []site.Competition, error) {
@@ -37,6 +40,9 @@ func (l *recordingLoader) LoadLeague(context.Context, string) (*site.LeaguePage,
 
 func (l *recordingLoader) LoadCompetition(_ context.Context, rawURL string) (*site.CompetitionMenu, *site.LeaguePage, error) {
 	l.menuCalls++
+	if l.compErr != nil {
+		return nil, nil, l.compErr
+	}
 	if menu, ok := l.menus[rawURL]; ok {
 		return menu, nil, nil
 	}
@@ -599,6 +605,97 @@ func TestAnchoredWindowBoundsKeepsSelectedStandingVisible(t *testing.T) {
 	start, end := anchoredWindowBounds(30, []int{1, 18}, 6)
 	if !(start <= 1 && 1 < end) {
 		t.Fatalf("expected anchored window to include at least one selected row, got start=%d end=%d", start, end)
+	}
+}
+
+func TestSelectorNotVisibleAfterSuccessfulStartup(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+
+	if m.selectorVisible {
+		t.Fatalf("expected selector to be closed after successful league load")
+	}
+	if m.focus != focusFixtures {
+		t.Fatalf("expected fixtures focus after startup, got %v", m.focus)
+	}
+}
+
+func TestSelectorBecomesVisibleAfterCompetitionLoadError(t *testing.T) {
+	loader := newRecordingLoader()
+	loader.compErr = fmt.Errorf("network error")
+
+	m := NewModel(loader)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected init command")
+	}
+
+	// Drain the startup chain to completion.
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd == nil {
+		t.Fatalf("expected archive load to schedule competition load")
+	}
+	for cmd != nil {
+		m, cmd = updateModelWithMsg(t, m, cmd())
+	}
+
+	if m.league != nil {
+		t.Fatalf("expected no league after competition load error")
+	}
+	if !m.selectorVisible {
+		t.Fatalf("expected selector to be open after competition load error")
+	}
+	if m.err == "" {
+		t.Fatalf("expected error message to be set")
+	}
+}
+
+func TestSelectorBecomesVisibleWhenArchiveHasNoCompetitions(t *testing.T) {
+	loader := newRecordingLoader()
+	loader.competitions = nil
+
+	m := NewModel(loader)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected init command")
+	}
+
+	// Drain the startup chain; archive loads but no competition load follows.
+	for cmd != nil {
+		m, cmd = updateModelWithMsg(t, m, cmd())
+	}
+
+	if m.league != nil {
+		t.Fatalf("expected no league when archive has no competitions")
+	}
+	if !m.selectorVisible {
+		t.Fatalf("expected selector to be open when archive has no competitions")
+	}
+}
+
+func TestToggleFocusCyclesBetweenSeasonsAndCompetitions(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+
+	// Open the selector popup.
+	m, _ = updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyEsc})
+	if !m.selectorVisible {
+		t.Fatalf("expected selector open after escape")
+	}
+	if m.focus != focusCompetitions {
+		t.Fatalf("expected competitions focus after opening selector, got %v", m.focus)
+	}
+
+	// Tab cycles to seasons.
+	m, _ = updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.focus != focusSeasons {
+		t.Fatalf("expected seasons focus after first tab, got %v", m.focus)
+	}
+
+	// Tab cycles back to competitions.
+	m, _ = updateModelWithMsg(t, m, tea.KeyMsg{Type: tea.KeyTab})
+	if m.focus != focusCompetitions {
+		t.Fatalf("expected competitions focus after second tab, got %v", m.focus)
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -102,9 +102,8 @@ func NewModel(svc archiveLoader) Model {
 	return Model{service: svc, focus: focusCompetitions, loading: true}
 }
 
-// The selector is implicit on first load, then explicit once a league is open.
 func (m Model) selectorActive() bool {
-	return m.selectorVisible || (m.league == nil && !m.loading && len(m.seasons) > 0)
+	return m.selectorVisible
 }
 
 func (m *Model) openSelector() {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -101,6 +101,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.resetCompetitionMenu("Competitions", msg.competitions)
 
 		if len(m.competitions) == 0 {
+			m.openSelector()
 			return m, nil
 		}
 
@@ -108,6 +109,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		competition := m.currentCompetition()
 		if competition == nil {
 			m.loading = false
+			m.openSelector()
 			return m, nil
 		}
 		return m, m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
@@ -116,6 +118,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loading = false
 		if msg.err != nil {
 			m.err = msg.err.Error()
+			m.openSelector()
 			return m, nil
 		}
 
@@ -133,6 +136,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.matchScroll = 0
 
 		if len(m.competitions) == 0 {
+			m.openSelector()
 			return m, nil
 		}
 
@@ -140,6 +144,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		competition := m.currentCompetition()
 		if competition == nil {
 			m.loading = false
+			m.openSelector()
 			return m, nil
 		}
 		return m, m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
@@ -154,6 +159,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if msg.err != nil {
 			m.err = msg.err.Error()
+			m.openSelector()
 			return m, nil
 		}
 
@@ -170,6 +176,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.league == nil {
 			m.err = "competition parse: empty result"
+			m.openSelector()
 			return m, nil
 		}
 
@@ -243,8 +250,6 @@ func (m *Model) toggleFocus() {
 		m.focus = order[(i+1)%len(order)]
 		return
 	}
-
-	m.focus = focusSeasons
 }
 
 func (m *Model) moveCursor(delta int) {


### PR DESCRIPTION
## Summary

- `selectorActive()` previously had a dual signal: `selectorVisible == true` OR an implicit fallback when `league == nil && !loading && len(seasons) > 0`. That made `openSelector`/`closeSelector` incomplete owners of selector behaviour and left a dead fallback branch in `toggleFocus()`.
- All paths that previously relied on the implicit condition now call `openSelector()` explicitly: archive load with empty competitions, nil current competition, competition load error, and `competitionMenuLoadedMsg` parse error.
- Dead fallback branch removed from `toggleFocus()`.
- `compErr` injection field added to `recordingLoader` for error-path tests.

Fixes #27

## Test plan

- [ ] `TestSelectorNotVisibleAfterSuccessfulStartup` — selector is closed after a clean startup.
- [ ] `TestSelectorBecomesVisibleAfterCompetitionLoadError` — selector opens when competition load returns an error.
- [ ] `TestSelectorBecomesVisibleWhenArchiveHasNoCompetitions` — selector opens when archive returns empty competitions list.
- [ ] `TestToggleFocusCyclesBetweenSeasonsAndCompetitions` — tab key cycles `focusCompetitions → focusSeasons → focusCompetitions` with no dead path.
- [ ] All 50+ existing navigation and view tests pass unchanged.