### PR TITLE
Refine pitch dark UI redesign

### DIFF
--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -34,6 +34,8 @@ var roundSuffixRe = regexp.MustCompile(`(?i)\s*-\s*(?:kolejka|runda)\s+(\d+)\s*$
 var matchDatePrefixRe = regexp.MustCompile(`^\d{1,2}\s+\p{L}+\s+\d{4},\s+\d{1,2}:\d{2}`)
 var leadingAttendanceRe = regexp.MustCompile(`^(\d[\d ]*)\b`)
 var fixtureWhenInfoRe = regexp.MustCompile(`(?i)^(\d{1,2})\s+([\p{L}]+)(?:\s+\d{4})?,\s*(\d{1,2}:\d{2})`)
+var fixtureDateTimeRe = regexp.MustCompile(`(?i)(\d{1,2})\s+([\p{L}]+)(?:\s+(\d{4}))?,\s*(\d{1,2}:\d{2})`)
+var leagueSeasonYearsRe = regexp.MustCompile(`(\d{4})\s*/\s*(\d{2,4})`)
 var playerNumberPrefixRe = regexp.MustCompile(`^\(\d+\)\s*`)
 var playerNumberSuffixRe = regexp.MustCompile(`\s+\(\d+\)$`)
 var trailingParenRe = regexp.MustCompile(`^(.*?)(\s+\([^)]*\))$`)
@@ -47,17 +49,7 @@ func renderSeasonsWindow(seasons []site.Season, cursor int) []string {
 	start, end := windowBounds(len(seasons), cursor, 10)
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		prefix := "  "
-		if i == cursor {
-			prefix = "> "
-		}
-
-		marker := ""
-		if seasons[i].Current {
-			marker = " *"
-		}
-
-		lines = append(lines, fmt.Sprintf("%s%s%s", prefix, seasons[i].Label, marker))
+		lines = append(lines, seasons[i].Label)
 	}
 
 	return lines
@@ -71,11 +63,7 @@ func renderCompetitionWindow(items []site.Competition, cursor int) []string {
 	start, end := windowBounds(len(items), cursor, 18)
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		prefix := "  "
-		if i == cursor {
-			prefix = "> "
-		}
-		lines = append(lines, prefix+items[i].Name)
+		lines = append(lines, items[i].Name)
 	}
 
 	return lines
@@ -668,13 +656,8 @@ func cardAnnotation(player site.PlayerLine, idx map[string][]site.MatchEvent) st
 }
 
 func cardAnnotationName(name string, idx map[string][]site.MatchEvent) string {
-	key := playerMatchKey(name)
-	if key == "" {
-		return ""
-	}
-
-	matched, ok := idx[key]
-	if !ok {
+	matched := matchingPlayerEvents(name, idx)
+	if len(matched) == 0 {
 		return ""
 	}
 
@@ -693,26 +676,165 @@ func cardAnnotationName(name string, idx map[string][]site.MatchEvent) string {
 	return ""
 }
 
+func matchingPlayerEvents(name string, idx map[string][]site.MatchEvent) []site.MatchEvent {
+	key := playerMatchKey(name)
+	if key == "" {
+		return nil
+	}
+	matched := append([]site.MatchEvent(nil), idx[key]...)
+
+	compact := playerCompactMatchKey(name)
+	if compact == "" {
+		return matched
+	}
+	if !isAbbreviatedPlayerName(name) {
+		return matched
+	}
+
+	var compactMatched []site.MatchEvent
+	for candidate, events := range idx {
+		if candidate == key {
+			continue
+		}
+		if playerCompactMatchKey(candidate) != compact {
+			continue
+		}
+		if compactMatched != nil {
+			return matched
+		}
+		compactMatched = events
+	}
+	return append(matched, compactMatched...)
+}
+
+func matchingPlayerEventsInRoster(name string, idx map[string][]site.MatchEvent, players []site.PlayerLine) []site.MatchEvent {
+	matched := exactPlayerEvents(name, idx)
+	if compactMatchCountForName(name, players) != 1 {
+		return matched
+	}
+
+	compact := playerCompactMatchKey(name)
+	var compactMatched []site.MatchEvent
+	for candidate, events := range idx {
+		if playerMatchKey(candidate) == playerMatchKey(name) || playerCompactMatchKey(candidate) != compact {
+			continue
+		}
+		if compactMatched != nil {
+			return matched
+		}
+		compactMatched = events
+	}
+	return append(matched, compactMatched...)
+}
+
+func exactPlayerEvents(name string, idx map[string][]site.MatchEvent) []site.MatchEvent {
+	key := playerMatchKey(name)
+	if key == "" {
+		return nil
+	}
+	return append([]site.MatchEvent(nil), idx[key]...)
+}
+
+func playerCompactMatchKey(name string) string {
+	return strings.ToLower(normalizeDisplayText(formatPlayerLabel(name)))
+}
+
+func matchingSubstituteCardEvents(name string, idx map[string][]site.MatchEvent) []site.MatchEvent {
+	matched := append([]site.MatchEvent(nil), matchingPlayerEvents(name, idx)...)
+	compact := playerCompactMatchKey(name)
+	if compact == "" {
+		return matched
+	}
+
+	var compactMatched []site.MatchEvent
+	for candidate, events := range idx {
+		if playerMatchKey(candidate) == playerMatchKey(name) || playerCompactMatchKey(candidate) != compact {
+			continue
+		}
+		cardEvents := filterCardEvents(events)
+		if len(cardEvents) == 0 {
+			continue
+		}
+		if compactMatched != nil {
+			return matched
+		}
+		compactMatched = cardEvents
+	}
+	return append(matched, compactMatched...)
+}
+
+func matchingSubstituteCardEventsInRoster(name string, idx map[string][]site.MatchEvent, players []site.PlayerLine) []site.MatchEvent {
+	matched := exactPlayerEvents(name, idx)
+	if compactMatchCountForName(name, players) != 1 {
+		return matched
+	}
+
+	compact := playerCompactMatchKey(name)
+	var compactMatched []site.MatchEvent
+	for candidate, events := range idx {
+		if playerMatchKey(candidate) == playerMatchKey(name) || playerCompactMatchKey(candidate) != compact {
+			continue
+		}
+		cardEvents := filterCardEvents(events)
+		if len(cardEvents) == 0 {
+			continue
+		}
+		if compactMatched != nil {
+			return matched
+		}
+		compactMatched = cardEvents
+	}
+	return append(matched, compactMatched...)
+}
+
+func filterCardEvents(events []site.MatchEvent) []site.MatchEvent {
+	filtered := make([]site.MatchEvent, 0, len(events))
+	for _, event := range events {
+		if event.Kind == "YC" || event.Kind == "RC" {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func isAbbreviatedPlayerName(name string) bool {
+	for _, field := range strings.Fields(canonicalPlayerName(name)) {
+		if strings.HasSuffix(field, ".") {
+			return true
+		}
+	}
+	return false
+}
+
 type lineupEntry struct {
 	player       site.PlayerLine
 	enteredAt    string
 	replaced     string
-	replacedYC   string
+	replacedYC   lineupCardMarker
 	leftAt       string
 	replacedBy   string
-	replacedByYC string
+	replacedByYC lineupCardMarker
 }
+
+const (
+	lineupYellowCardToken = "\ue000"
+	lineupRedCardToken    = "\ue001"
+)
 
 // A lineup row can carry both entry and exit notes for players who came on and were later replaced.
 func formatLineupPlayer(entry lineupEntry, side string, maxWidth int) string {
+	return formatLineupPlayerWithCards(entry, side, maxWidth, false)
+}
+
+func formatLineupPlayerWithCards(entry lineupEntry, side string, maxWidth int, tokens bool) string {
 	name := formatPlayerLabel(entry.player.Name)
 	if entry.enteredAt == "" && entry.replaced == "" && entry.leftAt == "" && entry.replacedBy == "" {
 		return name
 	}
 
-	label := lineupPlayerLabel(entry, side, name, false)
+	label := lineupPlayerLabel(entry, side, name, false, tokens)
 	if maxWidth > 0 && ansi.StringWidth(label) > maxWidth {
-		shortened := lineupPlayerLabel(entry, side, name, true)
+		shortened := lineupPlayerLabel(entry, side, name, true, tokens)
 		if ansi.StringWidth(shortened) < ansi.StringWidth(label) {
 			return shortened
 		}
@@ -721,8 +843,8 @@ func formatLineupPlayer(entry lineupEntry, side string, maxWidth int) string {
 	return label
 }
 
-func lineupPlayerLabel(entry lineupEntry, side, name string, shortenNotes bool) string {
-	notes := lineupNotes(entry, side, shortenNotes)
+func lineupPlayerLabel(entry lineupEntry, side, name string, shortenNotes, tokens bool) string {
+	notes := lineupNotes(entry, side, shortenNotes, tokens)
 	if len(notes) == 0 {
 		return name
 	}
@@ -736,65 +858,90 @@ func lineupPlayerLabel(entry lineupEntry, side, name string, shortenNotes bool) 
 	return strings.Join(parts, " ")
 }
 
-func lineupNotes(entry lineupEntry, side string, shortenNotes bool) []string {
+func lineupNotes(entry lineupEntry, side string, shortenNotes, tokens bool) []string {
 	notes := make([]string, 0, 2)
 
-	if note := entryNote(entry, side, shortenNotes); note != "" {
+	if note := entryNote(entry, side, shortenNotes, tokens); note != "" {
 		notes = append(notes, note)
 	}
-	if note := exitNote(entry, side, shortenNotes); note != "" {
+	if note := exitNote(entry, side, shortenNotes, tokens); note != "" {
 		notes = append(notes, note)
 	}
 
 	return notes
 }
 
-func entryNote(entry lineupEntry, side string, shortenNotes bool) string {
+func entryNote(entry lineupEntry, side string, shortenNotes, tokens bool) string {
 	if entry.enteredAt == "" {
 		return ""
 	}
 
 	replaced := formatSubNoteName(entry.replaced, shortenNotes)
+	card := lineupCardText(entry.replacedYC, tokens)
 	if side == "home" {
 		text := "(" + entry.enteredAt
 		if replaced != "" {
-			text += " for " + replaced
-			if entry.replacedYC != "" {
-				text += entry.replacedYC
-			}
+			text += " for " + replaced + card
 		}
-		return faintText(text + ")")
+		return substitutionNoteText(text+")", tokens)
 	}
 
 	text := "(for "
+	if card != "" {
+		text += card + " "
+	}
 	if replaced != "" {
 		text += replaced + " "
 	}
-	if entry.replacedYC != "" {
-		text += entry.replacedYC + " "
-	}
 	text += entry.enteredAt
-	return faintText(text + ")")
+	return substitutionNoteText(text+")", tokens)
 }
 
-func exitNote(entry lineupEntry, side string, shortenNotes bool) string {
+func exitNote(entry lineupEntry, side string, shortenNotes, tokens bool) string {
 	if entry.replacedBy == "" {
 		return ""
 	}
 
 	replacement := formatSubNoteName(entry.replacedBy, shortenNotes)
+	card := lineupCardText(entry.replacedByYC, tokens)
 	text := "("
 	if side == "home" && entry.leftAt != "" {
 		text += entry.leftAt + " "
 	}
+	if side != "home" && card != "" {
+		text += card + " "
+	}
 	text += replacement
-	if entry.replacedByYC != "" {
-		text += entry.replacedByYC
+	if side == "home" {
+		text += card
 	}
 	if side != "home" && entry.leftAt != "" {
 		text += " " + entry.leftAt
 	}
-	return faintText(text + ")")
+	return substitutionNoteText(text+")", tokens)
+}
+
+func substitutionNoteText(text string, tokens bool) string {
+	if tokens {
+		return text
+	}
+	return faintText(text)
+}
+
+func lineupCardText(card lineupCardMarker, tokens bool) string {
+	if !card.ok {
+		return ""
+	}
+	if card.color == colorRed {
+		if tokens {
+			return lineupRedCardToken
+		}
+		return "■"
+	}
+	if tokens {
+		return lineupYellowCardToken
+	}
+	return "■"
 }
 
 // Under width pressure, shorten only substitution-note names so the main player label stays stable.
@@ -819,28 +966,81 @@ func formatSubNoteName(name string, surnameOnly bool) string {
 
 // Players can collect both entry and exit notes when they are substituted on and off in one match.
 func annotateLineupPlayer(player site.PlayerLine, idx map[string][]site.MatchEvent) lineupEntry {
+	return annotateLineupPlayerInRoster(player, idx, nil)
+}
+
+func annotateLineupPlayerInRoster(player site.PlayerLine, idx map[string][]site.MatchEvent, players []site.PlayerLine) lineupEntry {
 	entry := lineupEntry{player: player}
-	key := playerMatchKey(player.Name)
-	for _, event := range sortedEvents(idx[key]) {
+	for _, event := range sortedEvents(matchingPlayerEventsInRoster(player.Name, idx, players)) {
 		if event.Kind != "SUB" {
 			continue
 		}
 
 		out, in := substitutionPlayers(event.Text)
 		minute := strings.TrimSpace(formatMatchMinute(event.MinuteText))
-		if playerMatchKey(in) == key {
+		if playerNameMatchesInRoster(in, player.Name, players) {
 			entry.enteredAt = minute
 			entry.replaced = out
-			entry.replacedYC = cardAnnotationName(out, idx)
+			entry.replacedYC = substituteCardMarkerAnnotationNameInRoster(out, idx, players)
 		}
-		if playerMatchKey(out) == key {
+		if playerNameMatchesInRoster(out, player.Name, players) {
 			entry.leftAt = minute
 			entry.replacedBy = in
-			entry.replacedByYC = cardAnnotationName(in, idx)
+			entry.replacedByYC = substituteCardMarkerAnnotationNameInRoster(in, idx, players)
 		}
 	}
 
 	return entry
+}
+
+func playerNameMatches(left, right string) bool {
+	leftKey := playerMatchKey(left)
+	rightKey := playerMatchKey(right)
+	if leftKey == "" || rightKey == "" {
+		return false
+	}
+	if leftKey == rightKey {
+		return true
+	}
+	return isAbbreviatedPlayerName(right) && playerCompactMatchKey(left) == playerCompactMatchKey(right)
+}
+
+func playerNameMatchesInRoster(left, right string, players []site.PlayerLine) bool {
+	leftKey := playerMatchKey(left)
+	rightKey := playerMatchKey(right)
+	if leftKey != "" && leftKey == rightKey {
+		return true
+	}
+	if playerCompactMatchKey(left) == "" || playerCompactMatchKey(left) != playerCompactMatchKey(right) {
+		return false
+	}
+	if !isAbbreviatedPlayerName(left) && !isAbbreviatedPlayerName(right) {
+		return false
+	}
+	return compactMatchCountForName(right, players) == 1
+}
+
+func compactMatchCountForName(name string, players []site.PlayerLine) int {
+	compact := playerCompactMatchKey(name)
+	if compact == "" {
+		return 0
+	}
+
+	count := 0
+	foundQuery := false
+	for _, player := range players {
+		if playerCompactMatchKey(player.Name) != compact {
+			continue
+		}
+		count++
+		if playerNameMatches(name, player.Name) || playerNameMatches(player.Name, name) {
+			foundQuery = true
+		}
+	}
+	if !foundQuery {
+		count++
+	}
+	return count
 }
 
 // Synthetic entrant rows are only added when a substitute was later replaced again.
@@ -857,27 +1057,50 @@ func annotatedLineup(players []site.PlayerLine, idx map[string][]site.MatchEvent
 	entries := make([]lineupEntry, 0, len(players))
 	addedSynthetic := make(map[string]bool)
 	for _, player := range players {
-		entry := annotateLineupPlayer(player, idx)
+		entry := annotateLineupPlayerInRoster(player, idx, players)
 		entries = append(entries, entry)
 
 		inKey := playerMatchKey(entry.replacedBy)
-		if inKey == "" || addedSynthetic[inKey] {
+		syntheticKey := playerSyntheticKey(entry.replacedBy)
+		if inKey == "" || addedSynthetic[syntheticKey] {
 			continue
 		}
-		if _, exists := byKey[inKey]; exists {
+		if _, exists := byKey[inKey]; exists || lineupContainsPlayer(players, entry.replacedBy) {
 			continue
 		}
 
-		synthetic := annotateLineupPlayer(site.PlayerLine{Name: entry.replacedBy}, idx)
+		synthetic := annotateLineupPlayerInRoster(site.PlayerLine{Name: entry.replacedBy}, idx, players)
 		if synthetic.replacedBy == "" {
 			continue
 		}
 
 		entries = append(entries, synthetic)
-		addedSynthetic[inKey] = true
+		addedSynthetic[syntheticKey] = true
 	}
 
 	return entries
+}
+
+func lineupContainsPlayer(players []site.PlayerLine, name string) bool {
+	for _, player := range players {
+		if playerNameMatches(name, player.Name) || playerNameMatches(player.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func playerSyntheticKey(name string) string {
+	if isAbbreviatedPlayerName(name) {
+		return playerCompactMatchKey(name)
+	}
+	if key := playerMatchKey(name); key != "" {
+		return key
+	}
+	if compact := playerCompactMatchKey(name); compact != "" {
+		return compact
+	}
+	return ""
 }
 
 // Narrow layouts fall back to the generic lineup row, which reserves a smaller per-side text budget.
@@ -1158,12 +1381,14 @@ func layoutWidths(total int, collapsed, emphasizeRight bool) (int, int) {
 	return leftWidth, rightWidth
 }
 
+const leftPaneWidth = 54
+
 func leagueLayoutWidths(total int) (int, int) {
 	if total < 88 {
 		return 0, total
 	}
 
-	leftWidth := clamp(total/3+8, 42, 58)
+	leftWidth := leftPaneWidth
 	rightWidth := total - leftWidth - 1
 	if rightWidth < 36 {
 		rightWidth = 36
@@ -1178,7 +1403,7 @@ func matchLayoutWidths(total int) (int, int, int) {
 		return 0, total, 0
 	}
 
-	leftWidth := clamp(total/3+4, 38, 54)
+	leftWidth := leftPaneWidth
 	centerWidth := total - leftWidth - 1
 	if centerWidth >= 40 {
 		return leftWidth, centerWidth, 0
@@ -1453,6 +1678,59 @@ func formatFixtureWhenInfo(value string) string {
 	}
 
 	return translatePolishDateText(cleaned)
+}
+
+func formatFixtureDateTime(value, leagueTitle string) string {
+	cleaned := normalizeDisplayText(value)
+	if cleaned == "" {
+		return ""
+	}
+
+	matches := fixtureDateTimeRe.FindStringSubmatch(cleaned)
+	if len(matches) != 5 {
+		return formatFixtureWhenInfo(cleaned)
+	}
+
+	month := polishMonthNumber(matches[2])
+	if month == "" {
+		return formatFixtureWhenInfo(cleaned)
+	}
+
+	day := atoiOrNeg(matches[1])
+	monthNum := atoiOrNeg(month)
+	year := atoiOrNeg(matches[3])
+	if year < 0 {
+		year = inferFixtureYear(monthNum, leagueTitle)
+	}
+	if day <= 0 || monthNum <= 0 || year <= 0 {
+		return fmt.Sprintf("%02d/%02d %s", max(0, day), max(0, monthNum), matches[4])
+	}
+
+	clock, err := time.Parse("15:04", matches[4])
+	if err != nil {
+		return fmt.Sprintf("%02d/%02d %s", day, monthNum, matches[4])
+	}
+	when := time.Date(year, time.Month(monthNum), day, clock.Hour(), clock.Minute(), 0, 0, time.Local)
+	return when.Format("Mon 02/01 15:04")
+}
+
+func inferFixtureYear(month int, leagueTitle string) int {
+	matches := leagueSeasonYearsRe.FindStringSubmatch(leagueTitle)
+	if len(matches) != 3 {
+		return 0
+	}
+	startYear := atoiOrNeg(matches[1])
+	endYear := atoiOrNeg(matches[2])
+	if endYear >= 0 && endYear < 100 {
+		endYear += (startYear / 100) * 100
+		if endYear < startYear {
+			endYear += 100
+		}
+	}
+	if month >= 7 {
+		return startYear
+	}
+	return endYear
 }
 
 func polishMonthNumber(value string) string {

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -940,13 +940,6 @@ func matchMetaParts(meta, weather string) []string {
 	return parts
 }
 
-func renderCenteredText(text string, width int) string {
-	if width <= 0 {
-		return text
-	}
-	return padCenter(truncate(text, width), width)
-}
-
 func truncate(value string, maxLen int) string {
 	if maxLen <= 0 {
 		return ""

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -55,84 +55,6 @@ func renderSeasonsWindow(seasons []site.Season, cursor int) []string {
 	return lines
 }
 
-func renderCompetitionWindow(items []site.Competition, cursor int) []string {
-	if len(items) == 0 {
-		return []string{"(none)"}
-	}
-
-	start, end := windowBounds(len(items), cursor, 18)
-	lines := make([]string, 0, end-start)
-	for i := start; i < end; i++ {
-		lines = append(lines, items[i].Name)
-	}
-
-	return lines
-}
-
-func renderFixtureWindow(fixtures []site.Fixture, cursor, maxItems, width int, compact bool) []string {
-	if len(fixtures) == 0 {
-		return nil
-	}
-	if maxItems <= 0 {
-		return nil
-	}
-
-	start, end := windowBounds(len(fixtures), cursor, maxItems)
-	whenWidth := 0
-	scoreWidth := 0
-	suffixWidth := 0
-	for i := start; i < end; i++ {
-		whenWidth = max(whenWidth, len([]rune(formatFixtureWhenInfo(fixtures[i].WhenInfo))))
-		scoreWidth = max(scoreWidth, ansi.StringWidth(normalizeScore(fixtures[i].Score)))
-		suffixWidth = max(suffixWidth, ansi.StringWidth(fixtureAvailabilitySuffix(&fixtures[i], width-2, compact)))
-	}
-	lines := make([]string, 0, end-start)
-	for i := start; i < end; i++ {
-		isCursor := i == cursor
-		// "› " and "  " are both 2 visible chars; accent marker on cursor row.
-		var prefix string
-		if isCursor {
-			prefix = styleAccent.Render("›") + " "
-		} else {
-			prefix = "  "
-		}
-
-		lineWidth := width - 2 // 2-char prefix in both cases
-		suffix := fixtureAvailabilitySuffix(&fixtures[i], lineWidth, compact)
-		line := prefix + fixtureLine(&fixtures[i], lineWidth-suffixWidth, whenWidth, scoreWidth, compact)
-		if suffix != "" {
-			line += styleDim.Render(suffix)
-		} else if suffixWidth > 0 {
-			line += strings.Repeat(" ", suffixWidth)
-		}
-		if whenInfo := formatFixtureWhenInfo(fixtures[i].WhenInfo); whenInfo != "" {
-			line += styleDim.Render("  " + whenInfo)
-		}
-		lines = append(lines, line)
-	}
-
-	return lines
-}
-
-func renderStandingsWindow(rows []site.StandingRow, fixture *site.Fixture, width, maxItems int) []string {
-	if len(rows) == 0 {
-		return nil
-	}
-	if maxItems <= 0 {
-		return nil
-	}
-
-	start, end := anchoredWindowBounds(len(rows), standingSelectionIndices(rows, fixture), maxItems)
-	teamWidth := standingsTeamWidth(rows, width)
-	lines := make([]string, 0, end-start)
-	for i := start; i < end; i++ {
-		selected := fixture != nil && (strings.EqualFold(rows[i].Team, fixture.Home) || strings.EqualFold(rows[i].Team, fixture.Away))
-		lines = append(lines, formatStandingRow(rows[i], selected, teamWidth, width))
-	}
-
-	return lines
-}
-
 func standingSelectionIndices(rows []site.StandingRow, fixture *site.Fixture) []int {
 	if fixture == nil {
 		return nil
@@ -329,22 +251,6 @@ func faintPenaltySuffix(text string) string {
 	return strings.ReplaceAll(text, "(pen)", faintText("(pen)"))
 }
 
-func formatLeftEventLabel(kind, text string) string {
-	prefix := eventPrefix(kind)
-	if text == "" {
-		return prefix
-	}
-	return text + " " + prefix
-}
-
-func formatRightEventLabel(kind, text string) string {
-	prefix := eventPrefix(kind)
-	if text == "" {
-		return prefix
-	}
-	return prefix + " " + text
-}
-
 func eventPrefix(kind string) string {
 	switch kind {
 	case "GOAL":
@@ -459,44 +365,6 @@ func formatMatchMinute(minute string) string {
 	return formatted
 }
 
-func renderDividerLabel(label string, width int) string {
-	cleaned := normalizeDisplayText(label)
-	if cleaned == "" {
-		cleaned = "─"
-	}
-	if width <= len([]rune(cleaned))+2 {
-		return cleaned
-	}
-
-	pad := width - len([]rune(cleaned)) - 2
-	left := pad / 2
-	right := pad - left
-	return strings.Repeat("─", left) + " " + cleaned + " " + strings.Repeat("─", right)
-}
-
-// Align the divider score dash with the event-minute column when width allows.
-func renderMatchDividerRow(label string, width int) string {
-	if width < 30 {
-		return renderDividerLabel(label, width)
-	}
-
-	label = truncate(label, max(1, width-2))
-	dashOffset := strings.Index(label, " – ") + 1
-	if dashOffset < 1 {
-		// Fall back to ASCII dash for labels that don't contain an en-dash.
-		dashOffset = strings.Index(label, " - ") + 1
-	}
-	if dashOffset < 1 {
-		return renderDividerLabel(label, width)
-	}
-
-	minuteAxis := max(0, (width-7)/2+3)
-	leftWidth := max(0, minuteAxis-1-dashOffset)
-	rightWidth := max(0, width-leftWidth-ansi.StringWidth(label)-2)
-
-	return strings.Repeat("─", leftWidth) + " " + label + " " + strings.Repeat("─", rightWidth)
-}
-
 func matchStatus(page *site.MatchPage) string {
 	if page == nil {
 		return ""
@@ -513,106 +381,6 @@ func matchStatus(page *site.MatchPage) string {
 	default:
 		return ""
 	}
-}
-
-type scorerLine struct {
-	label     string
-	minute    string
-	side      string
-	isDivider bool
-}
-
-// Return visible score-header events in minute order; insert HT when play continues after halftime.
-func headerEventRows(events []site.MatchEvent) []scorerLine {
-	ordered := sortedEvents(events)
-	htLabel := halftimeScore(events)
-	firstSecondHalfKey := 0
-	hasSecondHalfEvent := false
-	for _, event := range ordered {
-		key, ok := minuteSortKey(event.MinuteText)
-		if !ok || key <= 4599 {
-			continue
-		}
-		firstSecondHalfKey = key
-		hasSecondHalfEvent = true
-		break
-	}
-
-	insertedHT := false
-	lines := make([]scorerLine, 0, 8)
-
-	for _, event := range ordered {
-		key, ok := minuteSortKey(event.MinuteText)
-		if !ok {
-			continue
-		}
-		if !insertedHT && htLabel != "" && hasSecondHalfEvent && key >= firstSecondHalfKey {
-			lines = append(lines, scorerLine{label: htLabel, isDivider: true})
-			insertedHT = true
-		}
-
-		switch event.Kind {
-		case "GOAL", "MISS", "RC":
-		default:
-			continue
-		}
-		if strings.TrimSpace(event.MinuteText) == "" {
-			continue
-		}
-
-		name := trimEventMinute(event)
-		switch event.Kind {
-		case "GOAL":
-			if name == "" {
-				continue
-			}
-			lines = append(lines, scorerLine{
-				label:  formatGoalLabel(name, event.TeamSide),
-				minute: formatMatchMinute(event.MinuteText),
-				side:   event.TeamSide,
-			})
-		case "MISS":
-			var label string
-			if event.TeamSide == "home" {
-				label = formatLeftEventLabel("MISS", name)
-			} else {
-				label = formatRightEventLabel("MISS", name)
-			}
-			lines = append(lines, scorerLine{
-				label:  label,
-				minute: formatMatchMinute(event.MinuteText),
-				side:   event.TeamSide,
-			})
-		case "RC":
-			var label string
-			if event.TeamSide == "home" {
-				label = formatLeftEventLabel("RC", name)
-			} else {
-				label = formatRightEventLabel("RC", name)
-			}
-			lines = append(lines, scorerLine{
-				label:  label,
-				minute: formatMatchMinute(event.MinuteText),
-				side:   event.TeamSide,
-			})
-		}
-	}
-
-	if !insertedHT && htLabel != "" && hasSecondHalfEvent {
-		lines = append(lines, scorerLine{label: htLabel, isDivider: true})
-	}
-
-	return lines
-}
-
-// formatGoalLabel builds a goal side-label with the icon adjacent to the center column.
-// "Name ⚽" (home, icon on right nearest center) or "⚽ Name" (away, icon on left nearest center).
-func formatGoalLabel(name, side string) string {
-	glyph := eventPrefix("GOAL")
-	if side == "home" {
-		return name + " " + glyph
-	}
-	return glyph + " " + name
 }
 
 func playerMatchKey(label string) string {
@@ -647,33 +415,6 @@ func playerEventIndex(events []site.MatchEvent, side string) map[string][]site.M
 		}
 	}
 	return idx
-}
-
-// cardAnnotation returns the YC/RC badge string for a lineup player, intended
-// for the dedicated event column next to the centre separator. Empty when clean.
-func cardAnnotation(player site.PlayerLine, idx map[string][]site.MatchEvent) string {
-	return cardAnnotationName(player.Name, idx)
-}
-
-func cardAnnotationName(name string, idx map[string][]site.MatchEvent) string {
-	matched := matchingPlayerEvents(name, idx)
-	if len(matched) == 0 {
-		return ""
-	}
-
-	hasYellow := false
-	for _, e := range matched {
-		switch e.Kind {
-		case "RC":
-			return eventPrefix("RC")
-		case "YC":
-			hasYellow = true
-		}
-	}
-	if hasYellow {
-		return eventPrefix("YC")
-	}
-	return ""
 }
 
 func matchingPlayerEvents(name string, idx map[string][]site.MatchEvent) []site.MatchEvent {
@@ -1103,51 +844,6 @@ func playerSyntheticKey(name string) string {
 	return ""
 }
 
-// Narrow layouts fall back to the generic lineup row, which reserves a smaller per-side text budget.
-func lineupPlayerWidth(width int) int {
-	if width <= 0 {
-		return 0
-	}
-	if width < 30 {
-		return 0
-	}
-	if width < 36 {
-		return max(8, (width-3-2)/2)
-	}
-
-	const eventWidth = 1
-	const gap = 0
-	return max(8, (width-1-2*eventWidth-2*gap)/2)
-}
-
-// Keep a dedicated event column next to the centre separator:
-//
-//	[home name →right] [home events →right] | [away events ←left] [away name ←left]
-func renderAnnotatedLineupRow(homePlayer, homeEvents, awayPlayer, awayEvents string, width int) string {
-	if width < 36 {
-		home := homePlayer
-		if homeEvents != "" {
-			home += " " + homeEvents
-		}
-		away := awayPlayer
-		if awayEvents != "" {
-			away = awayEvents + " " + away
-		}
-		return renderLineupRow(home, away, width)
-	}
-
-	const eventWidth = 1 // one char wide (YC/RC block or empty)
-	const gap = 0        // names sit directly against the event column
-	playerWidth := lineupPlayerWidth(width)
-
-	leftPlayer := padLeft(truncate(homePlayer, playerWidth), playerWidth)
-	leftEvents := padLeft(truncate(homeEvents, eventWidth), eventWidth)
-	rightEvents := padRight(truncate(awayEvents, eventWidth), eventWidth)
-	rightPlayer := truncate(awayPlayer, playerWidth)
-
-	return leftPlayer + strings.Repeat(" ", gap) + leftEvents + "|" + rightEvents + strings.Repeat(" ", gap) + rightPlayer
-}
-
 func halftimeScore(events []site.MatchEvent) string {
 	homeGoals := 0
 	awayGoals := 0
@@ -1244,63 +940,6 @@ func matchMetaParts(meta, weather string) []string {
 	return parts
 }
 
-func renderSideBySide(left, middle, right string, width int) string {
-	if width < 30 {
-		if middle == "" {
-			return left + " | " + right
-		}
-		return left + " | " + middle + " | " + right
-	}
-
-	midWidth := 9
-	gap := 1
-	sideWidth := max(8, (width-midWidth-(gap*2))/2)
-
-	leftText := padRight(truncate(left, sideWidth), sideWidth)
-	midText := padCenter(truncate(middle, midWidth), midWidth)
-	rightText := truncate(right, sideWidth)
-
-	return leftText + strings.Repeat(" ", gap) + midText + strings.Repeat(" ", gap) + rightText
-}
-
-func renderMatchDetailRow(left, middle, right string, width int) string {
-	if width < 30 {
-		return renderSideBySide(left, middle, right, width)
-	}
-
-	// Keep the minute column visually centered and close to the HT/FT score dash,
-	// even as left/right event labels vary in width.
-	midWidth := 7
-	gap := 0
-	sideWidth := max(8, (width-midWidth-(gap*2))/2)
-
-	leftText := padLeft(truncate(left, sideWidth), sideWidth)
-	midText := padCenter(truncate(middle, midWidth), midWidth)
-	rightText := truncate(right, sideWidth)
-
-	return leftText + strings.Repeat(" ", gap) + midText + strings.Repeat(" ", gap) + rightText
-}
-
-func renderLineupRowWithMarker(left, right, marker string, width int) string {
-	if width < 30 {
-		return renderSideBySide(left, marker, right, width)
-	}
-
-	midWidth := 3
-	gap := 1
-	sideWidth := max(8, (width-midWidth-(gap*2))/2)
-
-	leftText := padLeft(truncate(left, sideWidth), sideWidth)
-	midText := padCenter(truncate(marker, midWidth), midWidth)
-	rightText := truncate(right, sideWidth)
-
-	return leftText + strings.Repeat(" ", gap) + midText + strings.Repeat(" ", gap) + rightText
-}
-
-func renderLineupRow(left, right string, width int) string {
-	return renderLineupRowWithMarker(left, right, "|", width)
-}
-
 func renderCenteredText(text string, width int) string {
 	if width <= 0 {
 		return text
@@ -1349,36 +988,6 @@ func padCenter(value string, width int) string {
 	left := pad / 2
 	right := pad - left
 	return strings.Repeat(" ", left) + value + strings.Repeat(" ", right)
-}
-
-func layoutWidths(total int, collapsed, emphasizeRight bool) (int, int) {
-	if total < 40 {
-		return 0, total
-	}
-
-	if collapsed {
-		return 0, total
-	}
-
-	leftWidth := 36
-	if emphasizeRight {
-		leftWidth = clamp(total/4, 28, 42)
-	} else {
-		leftWidth = clamp(total/3, 32, 50)
-	}
-
-	rightWidth := total - leftWidth - 1
-	if rightWidth < 40 {
-		rightWidth = 40
-		leftWidth = max(0, total-rightWidth-1)
-	}
-
-	if leftWidth < 24 {
-		leftWidth = 0
-		rightWidth = total
-	}
-
-	return leftWidth, rightWidth
 }
 
 const leftPaneWidth = 54
@@ -1447,28 +1056,6 @@ func abbreviatedFixtureLine(fixture *site.Fixture, scoreWidth int) string {
 	return fmt.Sprintf("%s %s %s", abbreviateTeamName(fixture.Home), score, abbreviateTeamName(fixture.Away))
 }
 
-func fixtureLine(fixture *site.Fixture, width, whenWidth, scoreWidth int, compact bool) string {
-	if compact {
-		return abbreviatedFixtureLine(fixture, scoreWidth)
-	}
-	if fixture == nil {
-		return "--- ?-? ---"
-	}
-	if width <= 0 {
-		return fmt.Sprintf("%s %s %s", fixture.Home, normalizeScore(fixture.Score), fixture.Away)
-	}
-
-	score := padCenter(normalizeScore(fixture.Score), scoreWidth)
-	reserved := scoreWidth + 2
-	if whenWidth > 0 {
-		reserved += 3 + whenWidth
-	}
-	nameWidth := max(12, (width-reserved-1)/2)
-	home := padLeft(truncate(fixture.Home, nameWidth), nameWidth)
-	away := padRight(truncate(fixture.Away, nameWidth), nameWidth)
-	return home + " " + score + " " + away
-}
-
 func fixtureAvailabilitySuffix(fixture *site.Fixture, width int, compact bool) string {
 	if fixture == nil || strings.TrimSpace(fixture.MatchURL) != "" {
 		return ""
@@ -1517,15 +1104,6 @@ func standingsTeamWidth(rows []site.StandingRow, width int) int {
 		return maxWidth
 	}
 	return teamWidth
-}
-
-func formatStandingRow(row site.StandingRow, selected bool, teamWidth, width int) string {
-	line := fmt.Sprintf("  %2d %-*s %2d %2d %2d %2d %3d", row.Position, teamWidth, truncate(row.Team, teamWidth), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
-	line = truncate(line, max(12, width))
-	if selected {
-		return styleBold.Render(line)
-	}
-	return line
 }
 
 func parseRoundNumber(name string, fallback int) string {
@@ -1590,28 +1168,6 @@ func displayRoundLabel(name string, fallback int) string {
 	}
 
 	return translatePolishDateText(cleaned)
-}
-
-func displayMatchMeta(meta, weather string) string {
-	return strings.Join(matchMetaParts(meta, weather), " | ")
-}
-
-// matchMetaDisplay splits meta parts into a prominent date line and a secondary
-// details line (attendance, ref, weather). Returns empty strings when absent.
-func matchMetaDisplay(meta, weather string) (date, details string) {
-	parts := matchMetaParts(meta, weather)
-	if len(parts) == 0 {
-		return "", ""
-	}
-	if matchDatePrefixRe.MatchString(parts[0]) {
-		date = parts[0]
-		if len(parts) > 1 {
-			details = strings.Join(parts[1:], "  ·  ")
-		}
-		return
-	}
-	details = strings.Join(parts, "  ·  ")
-	return
 }
 
 func trimEventMinute(event site.MatchEvent) string {

--- a/internal/ui/theme.go
+++ b/internal/ui/theme.go
@@ -3,19 +3,40 @@ package ui
 import "github.com/charmbracelet/lipgloss"
 
 var (
-	// Three-color palette. accent = cursor/focus, dim = chrome, subtle = secondary labels.
-	colorAccent = lipgloss.Color("39")  // bright azure
-	colorDim    = lipgloss.Color("240") // dark grey
-	colorSubtle = lipgloss.Color("243") // mid grey
+	colorBg            = lipgloss.Color("#0d0f0e")
+	colorBgPanel       = lipgloss.Color("#121510")
+	colorBgPane        = lipgloss.Color("#0f1210")
+	colorBgHeader      = lipgloss.Color("#161b14")
+	colorBgSelected    = lipgloss.Color("#1a2118")
+	colorBgHover       = lipgloss.Color("#151a13")
+	colorBgModal       = lipgloss.Color("#0e1210")
+	colorStatusBar     = lipgloss.Color("#0a0d09")
+	colorBorder        = lipgloss.Color("#2a3028")
+	colorBorderStrong  = lipgloss.Color("#3d4d38")
+	colorAccent        = lipgloss.Color("#b8f000")
+	colorAccentDim     = lipgloss.Color("#7aaa00")
+	colorTextPrimary   = lipgloss.Color("#e8edd4")
+	colorTextSecondary = lipgloss.Color("#7a8a72")
+	colorTextMuted     = lipgloss.Color("#4a5a44")
+	colorWin           = colorAccent
+	colorDraw          = lipgloss.Color("#f0b800")
+	colorLoss          = lipgloss.Color("#e04040")
+	colorRowOdd        = lipgloss.Color("#0f1210")
+	colorRowEven       = lipgloss.Color("#111410")
 
-	// Semantic card colors for YC/RC markers across match detail views.
-	colorYellow = lipgloss.Color("226")
-	colorRed    = lipgloss.Color("196")
+	// Backward-compatible names for helpers that still provide semantic markers.
+	colorDim    = colorTextMuted
+	colorSubtle = colorTextSecondary
+	colorYellow = colorDraw
+	colorRed    = colorLoss
 
-	styleAccent = lipgloss.NewStyle().Foreground(colorAccent)
-	styleDim    = lipgloss.NewStyle().Foreground(colorDim)
-	styleSubtle = lipgloss.NewStyle().Foreground(colorSubtle)
-	styleBold   = lipgloss.NewStyle().Bold(true)
-	styleYellow = lipgloss.NewStyle().Foreground(colorYellow)
-	styleRed    = lipgloss.NewStyle().Foreground(colorRed)
+	styleAccent    = lipgloss.NewStyle().Foreground(colorAccent)
+	styleAccentDim = lipgloss.NewStyle().Foreground(colorAccentDim)
+	styleDim       = lipgloss.NewStyle().Foreground(colorTextMuted)
+	styleSubtle    = lipgloss.NewStyle().Foreground(colorTextSecondary)
+	stylePrimary   = lipgloss.NewStyle().Foreground(colorTextPrimary)
+	styleBold      = lipgloss.NewStyle().Bold(true).Foreground(colorTextPrimary)
+	styleHeader    = lipgloss.NewStyle().Foreground(colorAccent).Background(colorBgHeader).Bold(true)
+	styleYellow    = lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel)
+	styleRed       = lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel)
 )

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -87,22 +87,6 @@ func topBarRoundMeta(roundName string, roundIdx, total int) string {
 	return fmt.Sprintf("%s · %s / %d", roundPart, strings.TrimSpace(datePart), total)
 }
 
-func renderTopBarMeta(meta string) string {
-	roundPart, rest, ok := strings.Cut(meta, " · ")
-	if !ok {
-		roundOnly, totalPart, hasTotal := strings.Cut(meta, " / ")
-		if !hasTotal {
-			return styleBold.Copy().Foreground(colorTextPrimary).Render(meta)
-		}
-		return styleBold.Copy().Foreground(colorTextPrimary).Render(roundOnly) + " " + styleDim.Render("/") + " " + styleDim.Render(totalPart)
-	}
-	datePart, totalPart, ok := strings.Cut(rest, " / ")
-	if !ok {
-		return styleBold.Copy().Foreground(colorTextPrimary).Render(roundPart) + " " + styleDim.Render("·") + " " + styleSubtle.Render(rest)
-	}
-	return styleBold.Copy().Foreground(colorTextPrimary).Render(roundPart) + " " + styleDim.Render("·") + " " + styleSubtle.Render(datePart) + " " + styleDim.Render("/") + " " + styleDim.Render(totalPart)
-}
-
 func (m Model) selectorSketchView() string {
 	leftWidth, rightWidth := leagueLayoutWidths(m.width)
 	if leftWidth == 0 {
@@ -288,27 +272,6 @@ func selectorModalDivider(height int) string {
 		parts[i] = lipgloss.NewStyle().Foreground(colorBorder).Background(colorBgModal).Render("│")
 	}
 	return strings.Join(parts, "\n")
-}
-
-func selectorPaneView(width int, heading string, focused bool, lines []string) string {
-	base := lipgloss.NewStyle().Width(width)
-
-	var headingStyle lipgloss.Style
-	if focused {
-		headingStyle = styleBold.Copy().Foreground(colorAccent)
-	} else {
-		headingStyle = styleSubtle
-	}
-
-	var b strings.Builder
-	b.WriteString(headingStyle.Render(truncate(heading, width)))
-	b.WriteString("\n")
-	for _, line := range lines {
-		b.WriteString(truncate(line, width))
-		b.WriteString("\n")
-	}
-
-	return base.Render(strings.TrimRight(b.String(), "\n"))
 }
 
 func selectorPaneWidths(total int, seasonLines []string) (int, int) {
@@ -552,13 +515,6 @@ func formatFixtureGridRow(fixture *site.Fixture, selected bool, width int, leagu
 		line += strings.Repeat(" ", gap) + date
 	}
 	return renderFullLine(line, width, bg, rowColor, selected)
-}
-
-func fixtureScoreColor(score string) lipgloss.Color {
-	if fixtureResultRe.MatchString(strings.TrimSpace(score)) {
-		return colorWin
-	}
-	return colorTextMuted
 }
 
 func displayFixtureScore(score string) string {
@@ -1045,14 +1001,6 @@ func axisPlainLine(left, center, right string, width int) string {
 	return padLeft(truncate(left, leftWidth), leftWidth) + center + padRight(truncate(right, rightWidth), rightWidth)
 }
 
-func matchMetaLine(meta, weather string) string {
-	parts := matchMetaDisplayParts(meta, weather)
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, "  ·  ")
-}
-
 func renderMatchMetaPanelLine(meta, weather string, width int) string {
 	parts := matchMetaDisplayParts(meta, weather)
 	if len(parts) == 0 {
@@ -1213,11 +1161,6 @@ func halftimeScoreDisplay(page *site.MatchPage) string {
 	return halftimeScoreAlways(page.Events)
 }
 
-type goalTimelineRow struct {
-	home string
-	away string
-}
-
 type timelineRow struct {
 	home   string
 	away   string
@@ -1271,51 +1214,6 @@ func timelineMarker(kind string) (string, lipgloss.Color, bool) {
 	}
 }
 
-func goalTimelineRows(events []site.MatchEvent) []goalTimelineRow {
-	firstHalf, secondHalf := splitGoalTimelineRows(events)
-	rows := append(firstHalf, secondHalf...)
-	if len(rows) == 0 {
-		return []goalTimelineRow{{home: "—", away: "—"}}
-	}
-	return rows
-}
-
-func splitGoalTimelineRows(events []site.MatchEvent) ([]goalTimelineRow, []goalTimelineRow) {
-	firstHalf := make([]goalTimelineRow, 0, 4)
-	secondHalf := make([]goalTimelineRow, 0, 4)
-	for _, event := range sortedEvents(events) {
-		if event.Kind != "GOAL" {
-			continue
-		}
-		label := goalTimelineLabel(event)
-		if label == "" {
-			continue
-		}
-		row := goalTimelineRow{home: "—", away: "—"}
-		switch event.TeamSide {
-		case "home":
-			row.home = label
-		case "away":
-			row.away = label
-		default:
-			continue
-		}
-
-		minute, ok := minuteSortKey(event.MinuteText)
-		if ok && minute <= 4599 {
-			firstHalf = append(firstHalf, row)
-		} else {
-			secondHalf = append(secondHalf, row)
-		}
-	}
-
-	return firstHalf, secondHalf
-}
-
-func goalTimelineLabel(event site.MatchEvent) string {
-	return timelineEventLabel(event)
-}
-
 func timelineEventLabel(event site.MatchEvent) string {
 	name := ansi.Strip(trimEventMinute(event))
 	minute := formatMatchMinute(event.MinuteText)
@@ -1341,21 +1239,6 @@ func renderTimelineRow(row timelineRow, width int) string {
 		right = row.away
 	}
 	return renderFullLine(axisPlainLine(left, " "+row.marker+" ", right, width), width, colorBgPanel, row.color, false)
-}
-
-func renderGoalTimelineRow(home, away string, width int) string {
-	if home == "—" && away == "—" {
-		return renderCenteredPanelLine("—", width, colorTextMuted, false)
-	}
-	left := ""
-	right := ""
-	if home != "—" {
-		left = home
-	}
-	if away != "—" {
-		right = away
-	}
-	return renderFullLine(axisPlainLine(left, " ⚽ ", right, width), width, colorBgPanel, colorAccent, false)
 }
 
 func renderLineupsLabel(width int) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -1076,6 +1076,7 @@ func matchMetaAxisLine(parts []string, width int) string {
 	if len(parts) == 0 {
 		return ""
 	}
+	parts = fitMatchMetaParts(parts, width)
 	if len(parts) == 1 {
 		return padCenter(truncate(parts[0], width), width)
 	}
@@ -1090,6 +1091,59 @@ func matchMetaAxisLine(parts []string, width int) string {
 	left := strings.Join(parts[:middle], separator) + separator
 	right := separator + strings.Join(parts[middle+1:], separator)
 	return axisPlainLine(left, parts[middle], right, width)
+}
+
+func fitMatchMetaParts(parts []string, width int) []string {
+	if !matchMetaAxisTruncatesAttendance(parts, width) {
+		return parts
+	}
+
+	compact := append([]string(nil), parts...)
+	for i, part := range compact {
+		if date := compactMatchMetaDate(part); date != "" {
+			compact[i] = date
+			break
+		}
+	}
+	return compact
+}
+
+func matchMetaAxisTruncatesAttendance(parts []string, width int) bool {
+	for _, part := range parts {
+		if !strings.HasPrefix(part, "Att. ") {
+			continue
+		}
+		return !strings.Contains(matchMetaAxisLineRaw(parts, width), part)
+	}
+	return false
+}
+
+func matchMetaAxisLineRaw(parts []string, width int) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return padCenter(truncate(parts[0], width), width)
+	}
+
+	separator := "  ·  "
+	if len(parts)%2 == 0 {
+		half := len(parts) / 2
+		return axisPlainLine(strings.Join(parts[:half], separator), separator, strings.Join(parts[half:], separator), width)
+	}
+
+	middle := len(parts) / 2
+	left := strings.Join(parts[:middle], separator) + separator
+	right := separator + strings.Join(parts[middle+1:], separator)
+	return axisPlainLine(left, parts[middle], right, width)
+}
+
+func compactMatchMetaDate(value string) string {
+	parsed, err := time.Parse("Mon 2 January 2006, 15:04", value)
+	if err != nil {
+		return ""
+	}
+	return parsed.Format("Mon 02/01 15:04")
 }
 
 func compactMatchMetaPart(part string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -937,15 +937,15 @@ func (m Model) matchDetailContent(width int) string {
 	b.WriteString("\n")
 	b.WriteString(renderSectionLabel("TIMELINE", width))
 	b.WriteString("\n")
-	firstHalfGoals, secondHalfGoals := splitGoalTimelineRows(m.match.Events)
-	for _, row := range firstHalfGoals {
-		b.WriteString(renderGoalTimelineRow(row.home, row.away, width))
+	firstHalfEvents, secondHalfEvents := splitTimelineRows(m.match.Events)
+	for _, row := range firstHalfEvents {
+		b.WriteString(renderTimelineRow(row, width))
 		b.WriteString("\n")
 	}
 	b.WriteString(renderScoreAxisLine(halftimeScoreDisplay(m.match), width, colorTextMuted, false))
 	b.WriteString("\n")
-	for _, row := range secondHalfGoals {
-		b.WriteString(renderGoalTimelineRow(row.home, row.away, width))
+	for _, row := range secondHalfEvents {
+		b.WriteString(renderTimelineRow(row, width))
 		b.WriteString("\n")
 	}
 	if hasFinalScore(m.match.Score) {
@@ -1218,6 +1218,59 @@ type goalTimelineRow struct {
 	away string
 }
 
+type timelineRow struct {
+	home   string
+	away   string
+	marker string
+	color  lipgloss.Color
+}
+
+func splitTimelineRows(events []site.MatchEvent) ([]timelineRow, []timelineRow) {
+	firstHalf := make([]timelineRow, 0, 4)
+	secondHalf := make([]timelineRow, 0, 4)
+	for _, event := range sortedEvents(events) {
+		marker, color, ok := timelineMarker(event.Kind)
+		if !ok {
+			continue
+		}
+		label := timelineEventLabel(event)
+		if label == "" {
+			continue
+		}
+		row := timelineRow{home: "—", away: "—", marker: marker, color: color}
+		switch event.TeamSide {
+		case "home":
+			row.home = label
+		case "away":
+			row.away = label
+		default:
+			continue
+		}
+
+		minute, ok := minuteSortKey(event.MinuteText)
+		if ok && minute <= 4599 {
+			firstHalf = append(firstHalf, row)
+		} else {
+			secondHalf = append(secondHalf, row)
+		}
+	}
+
+	return firstHalf, secondHalf
+}
+
+func timelineMarker(kind string) (string, lipgloss.Color, bool) {
+	switch kind {
+	case "GOAL":
+		return "⚽", colorAccent, true
+	case "MISS":
+		return "❌", colorLoss, true
+	case "RC":
+		return "■", colorRed, true
+	default:
+		return "", colorTextMuted, false
+	}
+}
+
 func goalTimelineRows(events []site.MatchEvent) []goalTimelineRow {
 	firstHalf, secondHalf := splitGoalTimelineRows(events)
 	rows := append(firstHalf, secondHalf...)
@@ -1260,6 +1313,10 @@ func splitGoalTimelineRows(events []site.MatchEvent) ([]goalTimelineRow, []goalT
 }
 
 func goalTimelineLabel(event site.MatchEvent) string {
+	return timelineEventLabel(event)
+}
+
+func timelineEventLabel(event site.MatchEvent) string {
 	name := ansi.Strip(trimEventMinute(event))
 	minute := formatMatchMinute(event.MinuteText)
 	if name == "" || minute == "" {
@@ -1269,6 +1326,21 @@ func goalTimelineLabel(event site.MatchEvent) string {
 		return strings.TrimSpace(minute) + " " + name
 	}
 	return name + " " + minute
+}
+
+func renderTimelineRow(row timelineRow, width int) string {
+	if row.home == "—" && row.away == "—" {
+		return renderCenteredPanelLine("—", width, colorTextMuted, false)
+	}
+	left := ""
+	right := ""
+	if row.home != "—" {
+		left = row.home
+	}
+	if row.away != "—" {
+		right = row.away
+	}
+	return renderFullLine(axisPlainLine(left, " "+row.marker+" ", right, width), width, colorBgPanel, row.color, false)
 }
 
 func renderGoalTimelineRow(home, away string, width int) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -514,7 +514,7 @@ func formatFixtureGridRow(fixture *site.Fixture, selected bool, width int, leagu
 	contentWidth := max(1, width-2)
 	dateWidth := clamp(ansi.StringWidth("Thu 01/05 20:30"), 10, max(10, contentWidth/3))
 	markerDateWidth := ansi.StringWidth("[no details]") + gap + ansi.StringWidth("Thu 01/05 20:30")
-	if expandedDateWidth := max(dateWidth, markerDateWidth); (contentWidth-expandedDateWidth-scoreWidth-gap*3)/2 >= 6 {
+	if expandedDateWidth := max(dateWidth, markerDateWidth); (contentWidth-expandedDateWidth-scoreWidth-gap*3)/2 >= 12 {
 		dateWidth = expandedDateWidth
 	}
 	teamWidth := (contentWidth - dateWidth - scoreWidth - gap*3) / 2
@@ -1098,14 +1098,17 @@ func fitMatchMetaParts(parts []string, width int) []string {
 		return parts
 	}
 
-	compact := append([]string(nil), parts...)
-	for i, part := range compact {
-		if date := compactMatchMetaDate(part); date != "" {
-			compact[i] = date
-			break
+	withoutDate := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if isMatchMetaDate(part) {
+			continue
 		}
+		withoutDate = append(withoutDate, part)
 	}
-	return compact
+	if len(withoutDate) > 0 {
+		return withoutDate
+	}
+	return parts
 }
 
 func matchMetaAxisTruncatesAttendance(parts []string, width int) bool {
@@ -1138,12 +1141,9 @@ func matchMetaAxisLineRaw(parts []string, width int) string {
 	return axisPlainLine(left, parts[middle], right, width)
 }
 
-func compactMatchMetaDate(value string) string {
+func isMatchMetaDate(value string) bool {
 	parsed, err := time.Parse("Mon 2 January 2006, 15:04", value)
-	if err != nil {
-		return ""
-	}
-	return parsed.Format("Mon 02/01 15:04")
+	return err == nil && !parsed.IsZero()
 }
 
 func compactMatchMetaPart(part string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/adrunkhuman/90minuTUI/internal/site"
 	"github.com/charmbracelet/lipgloss"
@@ -20,7 +21,7 @@ func (m Model) View() string {
 		body = m.matchSketchView()
 	}
 	if m.selectorActive() {
-		body = m.selectorOverlayView(body)
+		body = m.selectorSketchView()
 	}
 	body = fitLines(body, m.bodyHeightLimit())
 
@@ -41,8 +42,6 @@ func (m Model) bodyHeightLimit() int {
 	return m.height - reserved
 }
 
-// topBarView renders a two-line header: competition + round on line 1, a dim
-// separator on line 2. Returns "" when the bar should be suppressed.
 func (m Model) topBarView() string {
 	if m.suppressTopBar || m.league == nil {
 		return ""
@@ -55,32 +54,91 @@ func (m Model) topBarView() string {
 
 	right := ""
 	if round := m.currentRound(); round != nil {
-		roundLabel := displayRoundLabel(round.Name, m.roundCursor+1)
-		right = fmt.Sprintf("%s / %d", roundLabel, len(m.league.Rounds))
+		right = topBarRoundMeta(round.Name, m.roundCursor+1, len(m.league.Rounds))
 	}
 
-	titleLine := barLine(label, right, m.width)
-	sep := styleDim.Render(strings.Repeat("─", m.width))
-	return titleLine + "\n" + sep
+	return renderFullLine(barLine(label, right, m.width), m.width, colorBgHeader, colorTextPrimary, true)
 }
 
-// barLine builds a fixed-width line: bold left label + subtle right label, space-padded.
 func barLine(left, right string, width int) string {
-	inner := width - 2 // 1 leading + 1 trailing space
+	inner := width - 2
 	if inner <= 0 {
 		return ""
 	}
 	if right == "" {
 		text := truncate(left, inner)
 		pad := max(0, inner-ansi.StringWidth(text))
-		return " " + styleBold.Render(text) + strings.Repeat(" ", pad) + " "
+		return " " + text + strings.Repeat(" ", pad) + " "
 	}
 	rightW := ansi.StringWidth(right)
 	leftMax := max(0, inner-rightW-1)
 	leftText := truncate(left, leftMax)
 	leftW := ansi.StringWidth(leftText)
 	gap := max(1, inner-leftW-rightW)
-	return " " + styleBold.Render(leftText) + strings.Repeat(" ", gap) + styleSubtle.Render(right) + " "
+	return " " + leftText + strings.Repeat(" ", gap) + right + " "
+}
+
+func topBarRoundMeta(roundName string, roundIdx, total int) string {
+	label := displayRoundLabel(roundName, roundIdx)
+	roundPart, datePart, ok := strings.Cut(label, " - ")
+	if !ok || strings.TrimSpace(datePart) == "" {
+		return fmt.Sprintf("%s / %d", label, total)
+	}
+	return fmt.Sprintf("%s · %s / %d", roundPart, strings.TrimSpace(datePart), total)
+}
+
+func renderTopBarMeta(meta string) string {
+	roundPart, rest, ok := strings.Cut(meta, " · ")
+	if !ok {
+		roundOnly, totalPart, hasTotal := strings.Cut(meta, " / ")
+		if !hasTotal {
+			return styleBold.Copy().Foreground(colorTextPrimary).Render(meta)
+		}
+		return styleBold.Copy().Foreground(colorTextPrimary).Render(roundOnly) + " " + styleDim.Render("/") + " " + styleDim.Render(totalPart)
+	}
+	datePart, totalPart, ok := strings.Cut(rest, " / ")
+	if !ok {
+		return styleBold.Copy().Foreground(colorTextPrimary).Render(roundPart) + " " + styleDim.Render("·") + " " + styleSubtle.Render(rest)
+	}
+	return styleBold.Copy().Foreground(colorTextPrimary).Render(roundPart) + " " + styleDim.Render("·") + " " + styleSubtle.Render(datePart) + " " + styleDim.Render("/") + " " + styleDim.Render(totalPart)
+}
+
+func (m Model) selectorSketchView() string {
+	leftWidth, rightWidth := leagueLayoutWidths(m.width)
+	if leftWidth == 0 {
+		return m.selectorOverlayView(m.leagueFixturesPaneViewStyled(rightWidth, true))
+	}
+
+	standings := m.standingsPaneView(leftWidth)
+	divider := m.verticalDivider()
+	fixtures := m.leagueFixturesPaneViewStyled(rightWidth, true)
+	body := lipgloss.JoinHorizontal(lipgloss.Top, standings, divider, fixtures)
+	bodyLines := strings.Split(body, "\n")
+	totalHeight := max(len(bodyLines), max(1, m.bodyHeightLimit()))
+	for len(bodyLines) < totalHeight {
+		bodyLines = append(bodyLines, "")
+	}
+
+	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
+	competitionLines := selectorCompetitionWidthLines(m.competitions)
+	rightHeading := selectorRightHeading(m.competitionTitle)
+	popup := m.selectorPopupView(selectorPopupWidth(rightWidth, seasonLines, rightHeading, competitionLines))
+	popupLines := strings.Split(popup, "\n")
+	top := 1
+	if totalHeight > len(popupLines)+2 {
+		top = (totalHeight - len(popupLines)) / 2
+	}
+	rightStart := leftWidth + 1
+	left := rightStart + max(0, (rightWidth-lipgloss.Width(popup))/2)
+
+	for i, line := range popupLines {
+		if top+i >= len(bodyLines) {
+			break
+		}
+		bodyLines[top+i] = overlayLine(bodyLines[top+i], line, left)
+	}
+
+	return strings.Join(bodyLines, "\n")
 }
 
 func (m Model) selectorOverlayView(body string) string {
@@ -136,48 +194,100 @@ func overlayLine(base, overlay string, leftWidth int) string {
 }
 
 func (m Model) selectorPopupView(width int) string {
-	innerWidth := max(24, width-4)
-	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
-	competitionLines := renderCompetitionWindow(m.competitions, m.competitionCursor)
-	leftWidth, rightWidth := selectorPaneWidths(innerWidth, seasonLines)
+	innerWidth := max(24, width-2)
+	leftWidth, rightWidth := selectorPaneWidths(innerWidth, renderSeasonsWindow(m.seasons, m.seasonCursor))
+	seasonRows := selectorSeasonRows(m.seasons, m.seasonCursor)
+	competitionRows := selectorCompetitionRows(m.competitions, m.competitionCursor)
+	visibleRows := max(len(seasonRows), len(competitionRows))
+	seasonStart, _ := windowBounds(len(m.seasons), m.seasonCursor, 10)
+	competitionStart, _ := windowBounds(len(m.competitions), m.competitionCursor, 18)
+	left := selectorModalPane(leftWidth, "SEASON", seasonRows, m.seasonCursor-seasonStart, visibleRows, m.focus == focusSeasons)
+	right := selectorModalPane(rightWidth, selectorRightHeading(m.competitionTitle), competitionRows, m.competitionCursor-competitionStart, visibleRows, m.focus == focusCompetitions)
+	divider := selectorModalDivider(max(strings.Count(left, "\n"), strings.Count(right, "\n")) + 1)
 
-	rightHeading := "Leagues"
-	if strings.TrimSpace(m.competitionTitle) != "" {
-		rightHeading = m.competitionTitle
-	}
-
-	left := selectorPaneView(leftWidth, "Season", m.focus == focusSeasons, seasonLines)
-	right := selectorPaneView(rightWidth, rightHeading, m.focus == focusCompetitions, competitionLines)
-
-	// Vertical divider — height matches the taller pane.
-	leftLines := strings.Split(left, "\n")
-	rightLines := strings.Split(right, "\n")
-	divH := max(len(leftLines), len(rightLines))
-	divParts := make([]string, divH)
-	for i := range divParts {
-		divParts[i] = styleDim.Render("│")
-	}
-	divider := strings.Join(divParts, "\n")
-
-	var b strings.Builder
-	b.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, left, divider, right))
+	content := lipgloss.JoinHorizontal(lipgloss.Top, left, divider, right)
 
 	if m.loading {
-		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render("Loading…"))
+		content += "\n" + renderPlainPaneLine(styleSubtle.Render("Loading…"), innerWidth, colorBgModal)
 	}
 	if m.err != "" {
-		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render("Error: " + m.err))
+		content += "\n" + renderPlainPaneLine(styleSubtle.Render("Error: "+m.err), innerWidth, colorBgModal)
 	}
 
 	panel := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(colorDim).
-		Padding(0, 1)
-	content := lipgloss.NewStyle().Width(innerWidth)
+		Width(innerWidth).
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(colorBorderStrong).
+		Background(colorBgModal)
 
-	return panel.Render(content.Render(strings.TrimRight(b.String(), "\n")))
+	return panel.Render(strings.TrimRight(content, "\n"))
+}
+
+func selectorRightHeading(title string) string {
+	cleaned := strings.TrimSpace(title)
+	if cleaned == "" || strings.EqualFold(cleaned, "Competitions") {
+		return "COMPETITIONS"
+	}
+	return strings.ToUpper(cleaned)
+}
+
+func selectorSeasonRows(seasons []site.Season, cursor int) []string {
+	if len(seasons) == 0 {
+		return []string{"(none)"}
+	}
+	start, end := windowBounds(len(seasons), cursor, 10)
+	rows := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		rows = append(rows, seasons[i].Label)
+	}
+	return rows
+}
+
+func selectorCompetitionRows(items []site.Competition, cursor int) []string {
+	if len(items) == 0 {
+		return []string{"(none)"}
+	}
+	start, end := windowBounds(len(items), cursor, 18)
+	rows := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		rows = append(rows, items[i].Name)
+	}
+	return rows
+}
+
+func selectorModalPane(width int, heading string, rows []string, cursor, visibleRows int, focused bool) string {
+	var b strings.Builder
+	b.WriteString(renderFullLine(" "+truncate(heading, max(1, width-1)), width, colorBgHeader, colorAccent, true))
+	for i := 0; i < visibleRows; i++ {
+		b.WriteString("\n")
+		row := ""
+		if i < len(rows) {
+			row = rows[i]
+		}
+		selected := focused && (i == cursor || (cursor >= len(rows) && i == len(rows)-1))
+		b.WriteString(selectorModalRow(row, selected, focused, width))
+	}
+	return b.String()
+}
+
+func selectorModalRow(text string, selected, focused bool, width int) string {
+	bg := colorBgModal
+	fg := colorTextSecondary
+	bar := "  "
+	if selected {
+		bg = colorBgSelected
+		fg = colorAccent
+		bar = "▌ "
+	}
+	return renderFullLine(bar+truncate(text, max(1, width-2)), width, bg, fg, selected)
+}
+
+func selectorModalDivider(height int) string {
+	parts := make([]string, max(1, height))
+	for i := range parts {
+		parts[i] = lipgloss.NewStyle().Foreground(colorBorder).Background(colorBgModal).Render("│")
+	}
+	return strings.Join(parts, "\n")
 }
 
 func selectorPaneView(width int, heading string, focused bool, lines []string) string {
@@ -202,12 +312,12 @@ func selectorPaneView(width int, heading string, focused bool, lines []string) s
 }
 
 func selectorPaneWidths(total int, seasonLines []string) (int, int) {
-	seasonWidth := lipgloss.Width("Season")
+	seasonWidth := lipgloss.Width("SEASON")
 	for _, line := range seasonLines {
 		seasonWidth = max(seasonWidth, lipgloss.Width(line))
 	}
 
-	leftWidth := clamp(seasonWidth+1, 14, 18)
+	leftWidth := clamp(seasonWidth+4, 18, 18)
 	rightWidth := total - leftWidth - 1 // 1 for the │ divider
 	if rightWidth < 16 {
 		rightWidth = 16
@@ -232,42 +342,38 @@ func (m Model) leagueSketchView() string {
 func (m Model) verticalDivider() string {
 	h := m.bodyHeightLimit()
 	if h <= 0 {
-		return styleDim.Render("│")
+		return lipgloss.NewStyle().Foreground(colorBorder).Background(colorBg).Render("│")
 	}
 	parts := make([]string, h)
 	for i := range parts {
-		parts[i] = styleDim.Render("│")
+		parts[i] = lipgloss.NewStyle().Foreground(colorBorder).Background(colorBg).Render("│")
 	}
 	return strings.Join(parts, "\n")
 }
 
-// standingsPaneView renders the league table without a title header —
-// the column header acts as the first row.
 func (m Model) standingsPaneView(width int) string {
 	return m.standingsPaneViewBounded(width)
 }
 
 func (m Model) standingsPaneViewBounded(width int) string {
-	base := lipgloss.NewStyle().Width(width).Padding(0, 1)
+	base := lipgloss.NewStyle().Width(width).Background(colorBgPane)
 	if limit := m.bodyHeightLimit(); limit > 0 {
-		base = base.MaxHeight(limit)
+		base = base.Height(limit).MaxHeight(limit)
 	}
 
 	var b strings.Builder
+	b.WriteString(paneHeader("STANDINGS", width))
+	b.WriteString("\n")
 
 	if m.league == nil || len(m.league.Standings) == 0 {
-		b.WriteString(styleSubtle.Render("no standings"))
+		b.WriteString(renderPlainPaneLine(" no standings", width, colorBgPane))
 		return base.Render(b.String())
 	}
 
 	teamWidth := standingsTeamWidth(m.league.Standings, width-2)
-	colHeader := styleSubtle.Render(truncate(
-		fmt.Sprintf("  %2s %-*s %2s %2s %2s %2s %3s", "#", teamWidth, "Team", "P", "W", "D", "L", "Pts"),
-		width-2,
-	))
-	b.WriteString(colHeader)
+	b.WriteString(formatStandingsColumns(teamWidth, width))
 	b.WriteString("\n")
-	for _, line := range renderStandingsWindow(m.league.Standings, m.currentFixture(), width-2, m.standingsRowLimit()) {
+	for _, line := range renderPitchStandingsWindow(m.league.Standings, m.currentFixture(), width, m.standingsRowLimit()) {
 		b.WriteString(line)
 		b.WriteString("\n")
 	}
@@ -275,41 +381,192 @@ func (m Model) standingsPaneViewBounded(width int) string {
 	return base.Render(strings.TrimRight(b.String(), "\n"))
 }
 
-// leagueFixturesPaneView renders the fixture list. The round label is the only
-// header line — no "Fixtures" title, no focus indicator.
+func paneHeader(label string, width int) string {
+	text := " " + strings.ToUpper(label)
+	return renderFullLine(text, width, colorBgHeader, colorAccent, true)
+}
+
+func renderPlainPaneLine(line string, width int, bg lipgloss.Color) string {
+	return renderFullLine(ansi.Strip(line), width, bg, colorTextSecondary, false)
+}
+
+func formatStandingsColumns(teamWidth, width int) string {
+	line := fmt.Sprintf("  %-3s %-*s %2s %2s %2s %2s %3s", "#", teamWidth, "Team", "P", "W", "D", "L", "Pts")
+	return renderFullLine(line, width, colorBgPane, colorTextMuted, false)
+}
+
+func renderFullLine(text string, width int, bg lipgloss.Color, fg lipgloss.Color, bold bool) string {
+	if width <= 0 {
+		return ""
+	}
+	line := padRight(truncate(text, width), width)
+	return lipgloss.NewStyle().Foreground(fg).Background(bg).Bold(bold).Render(line)
+}
+
+func renderPitchStandingsWindow(rows []site.StandingRow, fixture *site.Fixture, width, maxItems int) []string {
+	if len(rows) == 0 || maxItems <= 0 {
+		return nil
+	}
+
+	start, end := anchoredWindowBounds(len(rows), standingSelectionIndices(rows, fixture), maxItems)
+	teamWidth := standingsTeamWidth(rows, width-2)
+	lines := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		selected := fixture != nil && (strings.EqualFold(rows[i].Team, fixture.Home) || strings.EqualFold(rows[i].Team, fixture.Away))
+		relegated := isRelegationRow(rows[i], len(rows))
+		rowBg := colorRowOdd
+		if i%2 == 1 {
+			rowBg = colorRowEven
+		}
+		if selected {
+			rowBg = colorBgSelected
+		}
+		lines = append(lines, formatPitchStandingRow(rows[i], selected, relegated, teamWidth, width, rowBg))
+	}
+
+	return lines
+}
+
+func isRelegationRow(row site.StandingRow, total int) bool {
+	return total >= 6 && row.Position > total-3
+}
+
+func formatPitchStandingRow(row site.StandingRow, selected, relegated bool, teamWidth, width int, bg lipgloss.Color) string {
+	fg := colorTextPrimary
+	if relegated {
+		fg = colorLoss
+	}
+	if selected {
+		fg = colorAccent
+	}
+
+	bar := "  "
+	if selected {
+		bar = "▌ "
+	}
+	line := fmt.Sprintf("%s%-3d %-*s %2d %2d %2d %2d %3d", bar, row.Position, teamWidth, truncate(row.Team, teamWidth), row.Played, row.Won, row.Drawn, row.Lost, row.Points)
+	return renderFullLine(line, width, bg, fg, selected)
+}
+
 func (m Model) leagueFixturesPaneView(width int) string {
-	base := lipgloss.NewStyle().Width(width).Padding(0, 1)
+	return m.leagueFixturesPaneViewStyled(width, false)
+}
+
+func (m Model) leagueFixturesPaneViewStyled(width int, dim bool) string {
+	base := lipgloss.NewStyle().Width(width).Background(colorBgPanel)
 	if limit := m.bodyHeightLimit(); limit > 0 {
-		base = base.MaxHeight(limit)
+		base = base.Height(limit).MaxHeight(limit)
 	}
 
 	round := m.currentRound()
 	if m.league == nil || round == nil {
-		return base.Render(styleSubtle.Render("no league loaded"))
+		return base.Render(renderPlainPaneLine(styleSubtle.Render("no league loaded"), width, colorBgPanel))
 	}
 
 	var b strings.Builder
-
-	roundLabel := displayRoundLabel(round.Name, m.roundCursor+1)
-	total := len(m.league.Rounds)
-	b.WriteString(styleSubtle.Render(truncate(fmt.Sprintf("%s / %d", roundLabel, total), width-2)))
-	b.WriteString("\n")
-
-	for _, line := range renderFixtureWindow(round.Fixtures, m.fixtureCursor, m.fixtureRowLimit(), width-2, false) {
-		b.WriteString(truncate(line, width-2))
+	for _, line := range renderFixtureGridWindow(round.Fixtures, m.fixtureCursor, m.fixtureRowLimit(), width, m.league.Title, dim) {
+		b.WriteString(line)
 		b.WriteString("\n")
 	}
 
 	if m.loading {
 		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render("Loading…"))
+		b.WriteString(renderPlainPaneLine(styleSubtle.Render("Loading…"), width, colorBgPanel))
 	}
 	if m.err != "" {
 		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render(m.err))
+		b.WriteString(renderPlainPaneLine(styleSubtle.Render(m.err), width, colorBgPanel))
 	}
 
 	return base.Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func renderFixtureGridWindow(fixtures []site.Fixture, cursor, maxItems, width int, leagueTitle string, dim bool) []string {
+	if len(fixtures) == 0 || maxItems <= 0 {
+		return nil
+	}
+
+	start, end := windowBounds(len(fixtures), cursor, maxItems)
+	lines := make([]string, 0, end-start)
+	for i := start; i < end; i++ {
+		rowBg := colorBgPanel
+		if i%2 == 1 {
+			rowBg = colorBg
+		}
+		selected := i == cursor
+		if selected {
+			rowBg = colorBgSelected
+		}
+		lines = append(lines, formatFixtureGridRow(&fixtures[i], selected, width, leagueTitle, dim, rowBg))
+	}
+
+	return lines
+}
+
+func formatFixtureGridRow(fixture *site.Fixture, selected bool, width int, leagueTitle string, dim bool, bg lipgloss.Color) string {
+	if fixture == nil {
+		return renderFullLine("", width, bg, colorTextMuted, false)
+	}
+
+	scoreWidth := 7
+	gap := 2
+	detailMarker := strings.TrimSpace(fixtureAvailabilitySuffix(fixture, width, false))
+	contentWidth := max(1, width-2)
+	dateWidth := clamp(ansi.StringWidth("Thu 01/05 20:30"), 10, max(10, contentWidth/3))
+	markerDateWidth := ansi.StringWidth("[no details]") + gap + ansi.StringWidth("Thu 01/05 20:30")
+	if expandedDateWidth := max(dateWidth, markerDateWidth); (contentWidth-expandedDateWidth-scoreWidth-gap*3)/2 >= 6 {
+		dateWidth = expandedDateWidth
+	}
+	teamWidth := (contentWidth - dateWidth - scoreWidth - gap*3) / 2
+	if teamWidth < 6 {
+		dateWidth = 0
+		teamWidth = max(4, (contentWidth-scoreWidth-gap*2)/2)
+	}
+
+	rowColor := colorTextSecondary
+	if selected {
+		rowColor = colorAccent
+	}
+	if dim {
+		rowColor = colorTextMuted
+	}
+	bar := "  "
+	if selected {
+		bar = "▌ "
+	}
+
+	home := padLeft(truncate(fixture.Home, teamWidth), teamWidth)
+	score := padCenter(displayFixtureScore(fixture.Score), scoreWidth)
+	away := padRight(truncate(fixture.Away, teamWidth), teamWidth)
+	date := ""
+	if dateWidth > 0 {
+		dateText := truncate(formatFixtureDateTime(fixture.WhenInfo, leagueTitle), dateWidth)
+		if detailMarker != "" && ansi.StringWidth(detailMarker)+gap+ansi.StringWidth(dateText) <= dateWidth {
+			dateText = detailMarker + strings.Repeat(" ", gap) + dateText
+		}
+		date = padLeft(dateText, dateWidth)
+	}
+
+	line := bar + home + strings.Repeat(" ", gap) + score + strings.Repeat(" ", gap) + away
+	if dateWidth > 0 {
+		line += strings.Repeat(" ", gap) + date
+	}
+	return renderFullLine(line, width, bg, rowColor, selected)
+}
+
+func fixtureScoreColor(score string) lipgloss.Color {
+	if fixtureResultRe.MatchString(strings.TrimSpace(score)) {
+		return colorWin
+	}
+	return colorTextMuted
+}
+
+func displayFixtureScore(score string) string {
+	cleaned := strings.TrimSpace(score)
+	if cleaned == "" || cleaned == "-" || cleaned == "–" {
+		return "–"
+	}
+	return strings.ReplaceAll(cleaned, " - ", "-")
 }
 
 func (m Model) matchSketchView() string {
@@ -364,7 +621,7 @@ func (m Model) matchSidebarHeights() (int, int) {
 		return max(4, total/2), max(0, total-max(4, total/2))
 	}
 
-	standings := clamp(total/2, 8, 14)
+	standings := clamp(total/2, 8, 11)
 	fixtures := total - standings
 	if fixtures < minFixtures {
 		fixtures = minFixtures
@@ -375,31 +632,97 @@ func (m Model) matchSidebarHeights() (int, int) {
 }
 
 func (m Model) matchFixtureRailView(width int) string {
-	base := lipgloss.NewStyle().Width(width).Padding(0, 1)
+	base := lipgloss.NewStyle().Width(width).Background(colorBgPane)
 	if limit := m.bodyHeightLimit(); limit > 0 {
 		base = base.Height(limit).MaxHeight(limit)
 	}
 
 	round := m.currentRound()
 	if round == nil {
-		return base.Render(styleSubtle.Render("no fixtures"))
+		return base.Render(renderPlainPaneLine(styleSubtle.Render("no fixtures"), width, colorBgPane))
 	}
 
 	var b strings.Builder
-	b.WriteString(styleSubtle.Render(truncate(displayRoundLabel(round.Name, m.roundCursor+1), width-2)))
+	b.WriteString(paneHeader("FIXTURES", width))
 	b.WriteString("\n")
-
-	for _, line := range renderFixtureWindow(round.Fixtures, m.fixtureCursor, m.matchFixtureRowLimit(), width-2, true) {
-		b.WriteString(truncate(line, width-2))
+	for _, line := range renderRoundMiniGridWindow(round.Fixtures, m.fixtureCursor, m.matchFixtureRowLimit(), width, m.league.Title) {
+		b.WriteString(line)
 		b.WriteString("\n")
 	}
 
 	if m.loading && m.match == nil {
 		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render("Loading…"))
+		b.WriteString(renderPlainPaneLine(styleSubtle.Render("Loading…"), width, colorBgPane))
 	}
 
 	return base.Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func renderRoundMiniGridWindow(fixtures []site.Fixture, cursor, maxLines, width int, leagueTitle string) []string {
+	if len(fixtures) == 0 || maxLines <= 0 {
+		return nil
+	}
+	if len(fixtures)*2 <= maxLines {
+		lines := make([]string, 0, len(fixtures)*2)
+		for i := range fixtures {
+			top, bottom := formatRoundMiniCard(&fixtures[i], i == cursor, width, leagueTitle)
+			lines = append(lines, top, bottom)
+		}
+		return lines
+	}
+
+	const cols = 2
+	visibleRows := max(1, maxLines/2)
+	visibleItems := visibleRows * cols
+	start, end := windowBounds(len(fixtures), cursor, visibleItems)
+	end = min(len(fixtures), start+visibleItems)
+	colWidth := max(8, width/cols)
+	rows := max(1, (end-start+1)/cols)
+	lines := make([]string, 0, rows*2)
+
+	for row := 0; row < rows; row++ {
+		leftIdx := start + row
+		rightIdx := start + rows + row
+		firstTop, firstBottom := blankRoundMiniCard(colWidth, colorBgPane)
+		secondTop, secondBottom := blankRoundMiniCard(width-colWidth, colorBgPane)
+		if leftIdx < end {
+			firstTop, firstBottom = formatRoundMiniCard(&fixtures[leftIdx], leftIdx == cursor, colWidth, leagueTitle)
+		}
+		if rightIdx < end {
+			secondTop, secondBottom = formatRoundMiniCard(&fixtures[rightIdx], rightIdx == cursor, width-colWidth, leagueTitle)
+		}
+		lines = append(lines, firstTop+secondTop, firstBottom+secondBottom)
+	}
+
+	if len(lines) > maxLines {
+		return lines[:maxLines]
+	}
+	return lines
+}
+
+func blankRoundMiniCard(width int, bg lipgloss.Color) (string, string) {
+	blank := renderFullLine("", width, bg, colorTextMuted, false)
+	return blank, blank
+}
+
+func formatRoundMiniCard(fixture *site.Fixture, selected bool, width int, leagueTitle string) (string, string) {
+	bg := colorBgPane
+	teamColor := colorTextSecondary
+	dateColor := colorTextMuted
+	if selected {
+		bg = colorBgSelected
+		teamColor = colorAccent
+		dateColor = colorAccentDim
+	}
+	if fixture == nil {
+		return blankRoundMiniCard(width, bg)
+	}
+
+	code := abbreviatedFixtureLine(fixture, 3)
+	date := formatFixtureDateTime(fixture.WhenInfo, leagueTitle)
+	codeLine := renderFullLine(" "+code, width, bg, teamColor, selected)
+	dateLine := renderFullLine(" "+date, width, bg, dateColor, false)
+	return codeLine, dateLine
 }
 
 func (m Model) matchFixtureRowLimit() int {
@@ -412,7 +735,7 @@ func (m Model) matchFixtureRowLimit() int {
 		return len(round.Fixtures)
 	}
 
-	reserved := 1 // round label
+	reserved := 1 // fixtures pane header
 	if m.loading && m.match == nil {
 		reserved += 2
 	}
@@ -428,7 +751,7 @@ func (m Model) standingsContentHeight() int {
 	if m.league == nil || len(m.league.Standings) == 0 {
 		return 2
 	}
-	return 1 + len(m.league.Standings) // col header + rows
+	return 2 + len(m.league.Standings) // pane header + column header + rows
 }
 
 func (m Model) standingsRowLimit() int {
@@ -436,7 +759,7 @@ func (m Model) standingsRowLimit() int {
 	if limit == 0 {
 		return len(m.league.Standings)
 	}
-	return max(0, limit-1) // 1 for col header
+	return max(0, limit-2) // pane header + column header
 }
 
 func (m Model) fixtureRowLimit() int {
@@ -449,7 +772,7 @@ func (m Model) fixtureRowLimit() int {
 		return len(round.Fixtures)
 	}
 
-	reserved := 1 // round label
+	reserved := 0
 	if m.loading {
 		reserved += 2
 	}
@@ -461,53 +784,58 @@ func (m Model) fixtureRowLimit() int {
 }
 
 func (m Model) matchDetailPaneView(width int) string {
-	base := lipgloss.NewStyle().Width(width).Padding(0, 1)
+	base := lipgloss.NewStyle().Width(width).Background(colorBgPanel)
 	if limit := m.matchViewportHeight(); limit > 0 {
-		base = base.MaxHeight(limit)
+		base = base.Height(limit).MaxHeight(limit)
 	}
 
 	if m.loading && m.match == nil {
-		return base.Render(styleSubtle.Render("Loading…"))
+		return base.Render(renderPlainPaneLine(styleSubtle.Render("Loading…"), width, colorBgPanel))
 	}
 
 	if m.err != "" && m.match == nil {
-		return base.Render(styleSubtle.Render("Error: " + m.err))
+		return base.Render(renderPlainPaneLine(styleSubtle.Render("Error: "+m.err), width, colorBgPanel))
 	}
 
 	if m.match == nil {
-		return base.Render(styleSubtle.Render("no match loaded"))
+		return base.Render(renderPlainPaneLine(styleSubtle.Render("no match loaded"), width, colorBgPanel))
 	}
 
 	content := m.matchDetailContent(width)
 	return base.Render(clipLines(content, m.matchScroll, m.matchViewportHeight()))
 }
 
+type statusBarItem struct {
+	key   string
+	label string
+}
+
 func (m Model) statusBarView() string {
-	var parts []string
+	var parts []statusBarItem
 
 	switch {
 	case m.selectorActive():
-		parts = []string{"j/k: move", "tab: focus", "enter: load"}
+		parts = []statusBarItem{{"j/k", "move"}, {"tab", "focus"}, {"enter", "load"}}
 		if len(m.competitionStack) > 0 {
-			parts[2] = "enter: open"
-			parts = append(parts, "esc: back")
+			parts[2] = statusBarItem{"enter", "open"}
+			parts = append(parts, statusBarItem{"esc", "back"})
 		} else if m.league != nil {
-			parts = append(parts, "esc: close")
+			parts = append(parts, statusBarItem{"esc", "close"})
 		}
-		parts = append(parts, "q: quit")
+		parts = append(parts, statusBarItem{"q", "quit"})
 
 	case m.matchView:
-		parts = []string{"j/k: fixture", "h/l: round", "pgup/pgdn: scroll", "esc: back", "r: reload", "q: quit"}
+		parts = []statusBarItem{{"j/k", "fixture"}, {"h/l", "round"}, {"pgup/pgdn", "scroll"}, {"esc", "back"}, {"r", "reload"}, {"q", "quit"}}
 
 	default:
-		enterHint := "enter: details"
+		enterHint := "details"
 		if !m.currentFixtureDrillable() {
-			enterHint = "enter: unavail"
+			enterHint = "unavail"
 		}
-		parts = []string{"j/k: move", "h/l: round", enterHint, "esc: selector", "r: reload", "q: quit"}
+		parts = []statusBarItem{{"j/k", "move"}, {"h/l", "round"}, {"enter", enterHint}, {"esc", "selector"}, {"r", "reload"}, {"q", "quit"}}
 	}
 
-	left := strings.Join(parts, "  ·  ")
+	left := renderStatusItems(parts)
 
 	right := formatFetchTime(m.lastFetchAt)
 	if m.loading {
@@ -522,13 +850,36 @@ func (m Model) statusBarView() string {
 	rightW := ansi.StringWidth(right)
 	gap := max(2, inner-leftW-rightW)
 	if leftW+gap+rightW > inner {
-		left = truncate(left, inner-rightW-2)
+		left = ansi.Cut(left, 0, max(0, inner-rightW-2))
 		leftW = ansi.StringWidth(left)
 		gap = max(1, inner-leftW-rightW)
 	}
 
-	status := left + strings.Repeat(" ", gap) + right
-	return lipgloss.NewStyle().Width(m.width).Padding(0, 1).Reverse(true).Render(truncate(status, m.width-2))
+	status := statusSpace(1) + left + statusSpace(gap) + statusText(right) + statusSpace(1)
+	return status + statusSpace(max(0, m.width-ansi.StringWidth(status)))
+}
+
+func renderStatusItems(items []statusBarItem) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, renderStatusKey(item.key)+statusSpace(1)+statusText(item.label))
+	}
+	return strings.Join(parts, statusSpace(2))
+}
+
+func renderStatusKey(key string) string {
+	return lipgloss.NewStyle().Foreground(colorAccent).Background(colorBgSelected).Bold(true).Render(" " + key + " ")
+}
+
+func statusText(text string) string {
+	return styleDim.Copy().Background(colorStatusBar).Render(text)
+}
+
+func statusSpace(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	return lipgloss.NewStyle().Background(colorStatusBar).Render(strings.Repeat(" ", width))
 }
 
 func selectorPopupWidth(total int, seasonLines []string, rightHeading string, competitionLines []string) int {
@@ -537,16 +888,17 @@ func selectorPopupWidth(total int, seasonLines []string, rightHeading string, co
 	}
 
 	leftWidth, rightWidth := selectorContentWidths(seasonLines, rightHeading, competitionLines)
-	desired := leftWidth + 1 + rightWidth + 4 // divider + panel border/padding
-	return clamp(desired, 40, max(40, total-2))
+	desired := max(64, leftWidth+1+rightWidth+2) // divider + border
+	maxWidth := max(1, total-2)
+	return clamp(desired, min(40, maxWidth), maxWidth)
 }
 
 func selectorContentWidths(seasonLines []string, rightHeading string, competitionLines []string) (int, int) {
-	seasonWidth := lipgloss.Width("Season")
+	seasonWidth := lipgloss.Width("SEASON")
 	for _, line := range seasonLines {
 		seasonWidth = max(seasonWidth, lipgloss.Width(line))
 	}
-	leftWidth := clamp(seasonWidth+1, 14, 18)
+	leftWidth := clamp(seasonWidth+4, 18, 18)
 
 	rightWidth := lipgloss.Width(rightHeading)
 	for _, line := range competitionLines {
@@ -564,72 +916,52 @@ func selectorCompetitionWidthLines(items []site.Competition) []string {
 
 	lines := make([]string, 0, len(items))
 	for _, item := range items {
-		lines = append(lines, "  "+item.Name)
+		lines = append(lines, item.Name)
 	}
 	return lines
 }
 
 func (m Model) matchDetailContent(width int) string {
 	var b strings.Builder
+	width = max(20, width)
 
-	// Score header — one blank line of breathing room above.
+	b.WriteString(renderBlankPanelLine(width))
 	b.WriteString("\n")
-	scoreText := matchDetailScore(m.match.Score)
-	b.WriteString(styleBold.Render(renderMatchDetailRow(m.match.HomeTeam, scoreText, m.match.AwayTeam, width-4)))
+	b.WriteString(renderFullLine(matchTitleLine(m.match.HomeTeam, matchDetailScore(m.match.Score), m.match.AwayTeam, width), width, colorBgPanel, colorTextPrimary, true))
 	b.WriteString("\n")
-
-	// Date and match details sit directly under the score.
-	metaDate, metaDetails := matchMetaDisplay(m.match.Meta, m.match.Weather)
-	if metaDate != "" {
-		b.WriteString(styleSubtle.Render(padCenter(truncate(metaDate, width-4), width-4)))
+	if meta := renderMatchMetaPanelLine(m.match.Meta, m.match.Weather, width); meta != "" {
+		b.WriteString(meta)
 		b.WriteString("\n")
 	}
-	if metaDetails != "" {
-		b.WriteString(styleDim.Render(padCenter(truncate(metaDetails, width-4), width-4)))
+	b.WriteString(renderPanelRule(width))
+	b.WriteString("\n")
+	b.WriteString(renderSectionLabel("TIMELINE", width))
+	b.WriteString("\n")
+	firstHalfGoals, secondHalfGoals := splitGoalTimelineRows(m.match.Events)
+	for _, row := range firstHalfGoals {
+		b.WriteString(renderGoalTimelineRow(row.home, row.away, width))
+		b.WriteString("\n")
+	}
+	b.WriteString(renderScoreAxisLine(halftimeScoreDisplay(m.match), width, colorTextMuted, false))
+	b.WriteString("\n")
+	for _, row := range secondHalfGoals {
+		b.WriteString(renderGoalTimelineRow(row.home, row.away, width))
+		b.WriteString("\n")
+	}
+	if hasFinalScore(m.match.Score) {
+		b.WriteString(renderScoreAxisLine("FT "+matchDetailScore(m.match.Score), width, colorTextPrimary, true))
 		b.WriteString("\n")
 	}
 
-	status := matchStatus(m.match)
-	headerEvents := headerEventRows(m.match.Events)
-	ftDivider := finalScoreLine(m.match)
-	if len(headerEvents) > 0 || status != "" || ftDivider != "" {
-		b.WriteString(renderMatchDetailRow("", "", "", width-4))
+	if status := matchStatus(m.match); status != "" {
+		b.WriteString(renderCenteredPanelLine(status, width, colorTextMuted, false))
 		b.WriteString("\n")
-		if status != "" {
-			b.WriteString(renderMatchDetailRow("", status, "", width-4))
-			b.WriteString("\n")
-		}
-		for _, row := range headerEvents {
-			if row.isDivider {
-				b.WriteString(styleDim.Render(renderMatchDividerRow(row.label, width-4)))
-				b.WriteString("\n")
-				continue
-			}
-			homeText, awayText := "", ""
-			if row.side == "home" {
-				homeText = row.label
-			} else {
-				awayText = row.label
-			}
-			b.WriteString(renderMatchDetailRow(homeText, row.minute, awayText, width-4))
-			b.WriteString("\n")
-		}
-		if ftDivider != "" {
-			b.WriteString(styleDim.Render(renderMatchDividerRow(ftDivider, width-4)))
-			b.WriteString("\n")
-		}
 	}
 
 	if len(m.match.HomeLineup) > 0 || len(m.match.AwayLineup) > 0 {
+		b.WriteString(renderLineupsLabel(width))
 		b.WriteString("\n")
-		b.WriteString(styleSubtle.Render(renderDividerLabel("Lineups", width-4)))
-		b.WriteString("\n")
-		b.WriteString(renderLineupRowWithMarker(
-			styleBold.Render(m.match.HomeTeam),
-			styleBold.Render(m.match.AwayTeam),
-			" ",
-			width-4,
-		))
+		b.WriteString(renderLineupHeaderRow(m.match.HomeTeam, m.match.AwayTeam, width))
 		b.WriteString("\n")
 
 		homeIdx := playerEventIndex(m.match.Events, "home")
@@ -637,7 +969,7 @@ func (m Model) matchDetailContent(width int) string {
 		homeEntries := annotatedLineup(m.match.HomeLineup, homeIdx)
 		awayEntries := annotatedLineup(m.match.AwayLineup, awayIdx)
 		maxPlayers := max(len(homeEntries), len(awayEntries))
-		playerWidth := lineupPlayerWidth(width - 4)
+		playerWidth := lineupPlayerNameWidth(width)
 
 		for i := 0; i < maxPlayers; i++ {
 			var hEntry, aEntry lineupEntry
@@ -648,13 +980,10 @@ func (m Model) matchDetailContent(width int) string {
 				aEntry = awayEntries[i]
 			}
 
-			homeName := formatLineupPlayer(hEntry, "home", playerWidth)
-			awayName := formatLineupPlayer(aEntry, "away", playerWidth)
-
-			b.WriteString(renderAnnotatedLineupRow(
-				homeName, cardAnnotation(hEntry.player, homeIdx),
-				awayName, cardAnnotation(aEntry.player, awayIdx),
-				width-4,
+			b.WriteString(renderLineupPlayerRow(
+				lineupDisplayName(hEntry, "home", playerWidth), lineupCardForEntry(hEntry, homeIdx),
+				lineupDisplayName(aEntry, "away", playerWidth), lineupCardForEntry(aEntry, awayIdx),
+				width,
 			))
 			b.WriteString("\n")
 		}
@@ -663,18 +992,419 @@ func (m Model) matchDetailContent(width int) string {
 	return strings.TrimRight(b.String(), "\n")
 }
 
+func renderBlankPanelLine(width int) string {
+	return renderFullLine("", width, colorBgPanel, colorTextSecondary, false)
+}
+
+func renderPanelRule(width int) string {
+	return renderFullLine(strings.Repeat("─", max(0, width)), width, colorBgPanel, colorBorder, false)
+}
+
+func renderCenteredPanelLine(text string, width int, fg lipgloss.Color, bold bool) string {
+	return renderFullLine(padCenter(truncate(text, width), width), width, colorBgPanel, fg, bold)
+}
+
+func matchTitleLine(home, score, away string, width int) string {
+	if score == "vs" {
+		return axisPlainLine(home, " vs ", away, width)
+	}
+	homeScore, awayScore, ok := splitScoreAxis(score)
+	if !ok || width < 32 {
+		return axisPlainLine(home+" "+score, "", away, width)
+	}
+	return axisPlainLine(home+" "+homeScore, " – ", awayScore+" "+away, width)
+}
+
+func renderScoreAxisLine(text string, width int, fg lipgloss.Color, bold bool) string {
+	left, right, ok := splitScoreAxis(text)
+	if !ok {
+		return renderCenteredPanelLine(text, width, fg, bold)
+	}
+	return renderFullLine(axisPlainLine(left, " – ", right, width), width, colorBgPanel, fg, bold)
+}
+
+func splitScoreAxis(text string) (string, string, bool) {
+	left, right, ok := strings.Cut(text, " – ")
+	if ok {
+		return strings.TrimSpace(left), strings.TrimSpace(right), true
+	}
+	left, right, ok = strings.Cut(text, "-")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(left), strings.TrimSpace(right), true
+}
+
+func axisPlainLine(left, center, right string, width int) string {
+	centerWidth := ansi.StringWidth(center)
+	if centerWidth == 0 {
+		centerWidth = 1
+	}
+	leftWidth := max(0, (width-centerWidth)/2)
+	rightWidth := max(0, width-leftWidth-centerWidth)
+	return padLeft(truncate(left, leftWidth), leftWidth) + center + padRight(truncate(right, rightWidth), rightWidth)
+}
+
+func matchMetaLine(meta, weather string) string {
+	parts := matchMetaDisplayParts(meta, weather)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "  ·  ")
+}
+
+func renderMatchMetaPanelLine(meta, weather string, width int) string {
+	parts := matchMetaDisplayParts(meta, weather)
+	if len(parts) == 0 {
+		return ""
+	}
+	return renderFullLine(matchMetaAxisLine(parts, width), width, colorBgPanel, colorTextMuted, false)
+}
+
+func matchMetaDisplayParts(meta, weather string) []string {
+	parts := matchMetaParts(meta, weather)
+	displayParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if display := compactMatchMetaPart(part); display != "" {
+			displayParts = append(displayParts, display)
+		}
+	}
+	return displayParts
+}
+
+func matchMetaAxisLine(parts []string, width int) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return padCenter(truncate(parts[0], width), width)
+	}
+
+	separator := "  ·  "
+	if len(parts)%2 == 0 {
+		half := len(parts) / 2
+		return axisPlainLine(strings.Join(parts[:half], separator), separator, strings.Join(parts[half:], separator), width)
+	}
+
+	middle := len(parts) / 2
+	left := strings.Join(parts[:middle], separator) + separator
+	right := separator + strings.Join(parts[middle+1:], separator)
+	return axisPlainLine(left, parts[middle], right, width)
+}
+
+func compactMatchMetaPart(part string) string {
+	switch {
+	case strings.HasPrefix(part, "Attendance "):
+		return "Att. " + groupDigits(strings.TrimPrefix(part, "Attendance "))
+	case strings.HasPrefix(part, "Weather "):
+		return compactWeather(strings.TrimPrefix(part, "Weather "))
+	default:
+		return formatMatchDateWithDay(part)
+	}
+}
+
+func groupDigits(value string) string {
+	digits := strings.ReplaceAll(strings.TrimSpace(value), " ", "")
+	if digits == "" {
+		return strings.TrimSpace(value)
+	}
+	parts := make([]string, 0, (len(digits)+2)/3)
+	for len(digits) > 3 {
+		parts = append([]string{digits[len(digits)-3:]}, parts...)
+		digits = digits[:len(digits)-3]
+	}
+	parts = append([]string{digits}, parts...)
+	return strings.Join(parts, " ")
+}
+
+func compactWeather(value string) string {
+	cleaned := strings.TrimSpace(value)
+	cleaned = strings.TrimSuffix(cleaned, " C")
+	cleaned = strings.TrimSuffix(cleaned, "C")
+	if cleaned == "" || strings.Contains(cleaned, "°") {
+		return cleaned
+	}
+	return cleaned + "°"
+}
+
+func formatMatchDateWithDay(value string) string {
+	parsed, err := time.Parse("2 January 2006, 15:04", value)
+	if err != nil {
+		return value
+	}
+	return parsed.Format("Mon 2 January 2006, 15:04")
+}
+
+func halftimeScoreAlways(events []site.MatchEvent) string {
+	homeGoals := 0
+	awayGoals := 0
+	for _, event := range sortedEvents(events) {
+		minute, ok := minuteSortKey(event.MinuteText)
+		if !ok || minute > 4599 || event.Kind != "GOAL" {
+			continue
+		}
+		if event.TeamSide == "home" {
+			homeGoals++
+		} else if event.TeamSide == "away" {
+			awayGoals++
+		}
+	}
+	return fmt.Sprintf("HT %d – %d", homeGoals, awayGoals)
+}
+
+func halftimeScoreDisplay(page *site.MatchPage) string {
+	if page == nil || len(page.Events) == 0 {
+		return "HT —"
+	}
+	return halftimeScoreAlways(page.Events)
+}
+
+type goalTimelineRow struct {
+	home string
+	away string
+}
+
+func goalTimelineRows(events []site.MatchEvent) []goalTimelineRow {
+	firstHalf, secondHalf := splitGoalTimelineRows(events)
+	rows := append(firstHalf, secondHalf...)
+	if len(rows) == 0 {
+		return []goalTimelineRow{{home: "—", away: "—"}}
+	}
+	return rows
+}
+
+func splitGoalTimelineRows(events []site.MatchEvent) ([]goalTimelineRow, []goalTimelineRow) {
+	firstHalf := make([]goalTimelineRow, 0, 4)
+	secondHalf := make([]goalTimelineRow, 0, 4)
+	for _, event := range sortedEvents(events) {
+		if event.Kind != "GOAL" {
+			continue
+		}
+		label := goalTimelineLabel(event)
+		if label == "" {
+			continue
+		}
+		row := goalTimelineRow{home: "—", away: "—"}
+		switch event.TeamSide {
+		case "home":
+			row.home = label
+		case "away":
+			row.away = label
+		default:
+			continue
+		}
+
+		minute, ok := minuteSortKey(event.MinuteText)
+		if ok && minute <= 4599 {
+			firstHalf = append(firstHalf, row)
+		} else {
+			secondHalf = append(secondHalf, row)
+		}
+	}
+
+	return firstHalf, secondHalf
+}
+
+func goalTimelineLabel(event site.MatchEvent) string {
+	name := ansi.Strip(trimEventMinute(event))
+	minute := formatMatchMinute(event.MinuteText)
+	if name == "" || minute == "" {
+		return ""
+	}
+	if event.TeamSide == "away" {
+		return strings.TrimSpace(minute) + " " + name
+	}
+	return name + " " + minute
+}
+
+func renderGoalTimelineRow(home, away string, width int) string {
+	if home == "—" && away == "—" {
+		return renderCenteredPanelLine("—", width, colorTextMuted, false)
+	}
+	left := ""
+	right := ""
+	if home != "—" {
+		left = home
+	}
+	if away != "—" {
+		right = away
+	}
+	return renderFullLine(axisPlainLine(left, " ⚽ ", right, width), width, colorBgPanel, colorAccent, false)
+}
+
+func renderLineupsLabel(width int) string {
+	return renderSectionLabel("LINEUPS", width)
+}
+
+func renderSectionLabel(label string, width int) string {
+	label = strings.ToUpper(label)
+	line := []rune(strings.Repeat("─", max(0, width)))
+	if len(line) == 0 {
+		return ""
+	}
+	center := width / 2
+	labelStart := clamp(center-3, 0, max(0, width-len([]rune(label))))
+	for i, r := range label {
+		if labelStart+i >= len(line) {
+			break
+		}
+		line[labelStart+i] = r
+	}
+	return renderFullLine(string(line), width, colorBgPanel, colorTextMuted, false)
+}
+
+func renderLineupTwoColumnRow(home, away string, width int, bg lipgloss.Color, homeColor lipgloss.Color, awayColor lipgloss.Color, bold bool) string {
+	fg := homeColor
+	if homeColor != awayColor {
+		fg = colorTextSecondary
+	}
+	return renderFullLine(axisPlainLine(home, "│", away, width), width, bg, fg, bold)
+}
+
+func renderLineupHeaderRow(home, away string, width int) string {
+	return renderFullLine(axisPlainLine(home, "   ", away, width), width, colorBgHeader, colorAccent, true)
+}
+
+type lineupCardMarker struct {
+	color lipgloss.Color
+	ok    bool
+}
+
+func lineupDisplayName(entry lineupEntry, side string, maxWidth int) string {
+	return formatLineupPlayerWithCards(entry, side, maxWidth, true)
+}
+
+func lineupCardFor(player site.PlayerLine, idx map[string][]site.MatchEvent) lineupCardMarker {
+	return cardMarkerAnnotationName(player.Name, idx)
+}
+
+func cardMarkerAnnotationName(name string, idx map[string][]site.MatchEvent) lineupCardMarker {
+	return cardMarkerFromEvents(matchingPlayerEvents(name, idx))
+}
+
+func substituteCardMarkerAnnotationName(name string, idx map[string][]site.MatchEvent) lineupCardMarker {
+	return cardMarkerFromEvents(matchingSubstituteCardEvents(name, idx))
+}
+
+func substituteCardMarkerAnnotationNameInRoster(name string, idx map[string][]site.MatchEvent, players []site.PlayerLine) lineupCardMarker {
+	return cardMarkerFromEvents(matchingSubstituteCardEventsInRoster(name, idx, players))
+}
+
+func cardMarkerFromEvents(matched []site.MatchEvent) lineupCardMarker {
+	if len(matched) == 0 {
+		return lineupCardMarker{}
+	}
+
+	hasYellow := false
+	for _, event := range matched {
+		switch event.Kind {
+		case "RC":
+			return lineupCardMarker{color: colorRed, ok: true}
+		case "YC":
+			hasYellow = true
+		}
+	}
+	if hasYellow {
+		return lineupCardMarker{color: colorYellow, ok: true}
+	}
+	return lineupCardMarker{}
+}
+
+func lineupCardForEntry(entry lineupEntry, idx map[string][]site.MatchEvent) lineupCardMarker {
+	return lineupCardFor(entry.player, idx)
+}
+
+func renderLineupPlayerRow(home string, homeCard lineupCardMarker, away string, awayCard lineupCardMarker, width int) string {
+	leftWidth := max(1, width/2)
+	rightWidth := max(1, width-leftWidth-1)
+	defaultStyle := lipgloss.NewStyle().Foreground(colorTextSecondary).Background(colorBgPanel)
+	divider := defaultStyle.Render("│")
+
+	left := lineupSideCell(home, homeCard, leftWidth, "home", defaultStyle)
+	right := lineupSideCell(away, awayCard, rightWidth, "away", defaultStyle)
+	return left + divider + right
+}
+
+func lineupPlayerNameWidth(width int) int {
+	leftWidth := max(1, width/2)
+	rightWidth := max(1, width-leftWidth-1)
+	return max(1, min(leftWidth, rightWidth)-2)
+}
+
+func lineupSideCell(name string, card lineupCardMarker, width int, side string, defaultStyle lipgloss.Style) string {
+	if width <= 0 {
+		return ""
+	}
+	cardWidth := 2
+	nameWidth := max(0, width-cardWidth)
+	cardStyle := lipgloss.NewStyle().Foreground(card.color).Background(colorBgPanel).Bold(true)
+
+	switch side {
+	case "home":
+		text := renderLineupLabel(name, nameWidth, "home", defaultStyle)
+		if !card.ok {
+			return text + defaultStyle.Render("  ")
+		}
+		return text + cardStyle.Render("■") + defaultStyle.Render(" ")
+	default:
+		text := renderLineupLabel(name, nameWidth, "away", defaultStyle)
+		if !card.ok {
+			return defaultStyle.Render("  ") + text
+		}
+		return defaultStyle.Render(" ") + cardStyle.Render("■") + text
+	}
+}
+
+func renderLineupLabel(label string, width int, side string, defaultStyle lipgloss.Style) string {
+	text := truncate(label, width)
+	if side == "home" {
+		text = padLeft(text, width)
+	} else {
+		text = padRight(text, width)
+	}
+
+	noteStyle := lipgloss.NewStyle().Foreground(colorTextMuted).Background(colorBgPanel)
+	yellowCardStyle := lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true)
+	redCardStyle := lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel).Bold(true)
+	var b strings.Builder
+	inNote := false
+	for _, r := range text {
+		switch string(r) {
+		case lineupYellowCardToken:
+			b.WriteString(yellowCardStyle.Render("■"))
+			continue
+		case lineupRedCardToken:
+			b.WriteString(redCardStyle.Render("■"))
+			continue
+		}
+		if r == '(' {
+			inNote = true
+		}
+		style := defaultStyle
+		if inNote {
+			style = noteStyle
+		}
+		b.WriteString(style.Render(string(r)))
+		if r == ')' {
+			inNote = false
+		}
+	}
+	return b.String()
+}
+
 // matchDetailScore formats the score for the match header with an en-dash,
 // giving it more visual weight than the compact fixture list format.
 func matchDetailScore(score string) string {
 	trimmed := strings.TrimSpace(score)
-	if trimmed == "" {
-		return "? – ?"
+	if !hasFinalScore(trimmed) {
+		return "vs"
 	}
 	parts := strings.SplitN(trimmed, "-", 2)
-	if len(parts) == 2 {
-		return strings.TrimSpace(parts[0]) + " – " + strings.TrimSpace(parts[1])
-	}
-	return trimmed
+	return strings.TrimSpace(parts[0]) + " – " + strings.TrimSpace(parts[1])
+}
+
+func hasFinalScore(score string) bool {
+	return fixtureResultRe.MatchString(strings.TrimSpace(score))
 }
 
 func (m Model) matchViewportHeight() int {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -414,27 +414,6 @@ func TestRenderSectionLabelCentersFourthLetter(t *testing.T) {
 	}
 }
 
-func TestGoalTimelineRowsKeepSideAssignment(t *testing.T) {
-	rows := goalTimelineRows([]site.MatchEvent{
-		{MinuteText: "12", Kind: "GOAL", TeamSide: "home", Text: "Home Scorer 12"},
-		{MinuteText: "44", Kind: "GOAL", TeamSide: "away", Text: "Away Scorer 44"},
-		{MinuteText: "89", Kind: "GOAL", TeamSide: "home", Text: "Late Winner 89"},
-	})
-
-	if len(rows) != 3 {
-		t.Fatalf("expected three chronological timeline rows, got %+v", rows)
-	}
-	if rows[0].home != "H. Scorer 12'" || rows[0].away != "—" {
-		t.Fatalf("expected first goal on home side, got %+v", rows[0])
-	}
-	if rows[1].home != "—" || rows[1].away != "44' A. Scorer" {
-		t.Fatalf("expected second goal on away side, got %+v", rows[1])
-	}
-	if rows[2].home != "L. Winner 89'" || rows[2].away != "—" {
-		t.Fatalf("expected third goal on home side, got %+v", rows[2])
-	}
-}
-
 func TestHalftimeScoreDisplayAvoidsInventingSparseHT(t *testing.T) {
 	if got := halftimeScoreDisplay(&site.MatchPage{Score: "1-0"}); got != "HT —" {
 		t.Fatalf("expected sparse match to avoid invented HT score, got %q", got)
@@ -534,23 +513,6 @@ func TestFormatLineupPlayerShortensOnlySubstitutionNotesWhenNeeded(t *testing.T)
 	}
 }
 
-func TestFormatLineupPlayerShortensNotesForNarrowFallbackRows(t *testing.T) {
-	width := lineupPlayerWidth(32)
-	if width != 13 {
-		t.Fatalf("unexpected narrow lineup player width: %d", width)
-	}
-
-	got := ansi.Strip(formatLineupPlayer(lineupEntry{
-		player:     site.PlayerLine{Name: "Alexandre Verylongsurname"},
-		leftAt:     "82'",
-		replacedBy: "Maximilian Unnecessarilylongsurname",
-	}, "away", width))
-
-	if got != "A. Verylongsurname (Unnecessarilylongsurname 82')" {
-		t.Fatalf("expected narrow-row shortening before truncation, got %q", got)
-	}
-}
-
 func TestMatchDetailKeepsInlineSubstitutionAnnotationsInLineups(t *testing.T) {
 	m := sketchModel()
 	m.width = 140
@@ -579,30 +541,6 @@ func TestMatchDetailKeepsInlineSubstitutionAnnotationsInLineups(t *testing.T) {
 	}
 }
 
-func TestMatchDetailRowsAnchorTowardCenteredMinuteColumn(t *testing.T) {
-	line := renderMatchDetailRow("Wdowiak ⚽", "39'", "Pllana ■", 76)
-	minuteIdx := strings.Index(line, "39'")
-	leftIdx := strings.Index(line, "Wdowiak ⚽")
-	rightIdx := strings.Index(line, "Pllana ■")
-	if minuteIdx <= 0 || leftIdx < 0 || rightIdx < 0 {
-		t.Fatalf("expected all columns rendered, got %q", line)
-	}
-	if leftIdx == 0 {
-		t.Fatalf("expected left event to anchor toward the minute column, got %q", line)
-	}
-	if !(leftIdx < minuteIdx && minuteIdx < rightIdx) {
-		t.Fatalf("expected centered minute between left and right columns, got %q", line)
-	}
-}
-
-func TestMatchDetailMinuteColumnStaysFixedForDifferentHomeTextWidths(t *testing.T) {
-	short := renderMatchDetailRow("K. Kubica ⚽", "17'", "", 76)
-	long := renderMatchDetailRow("B. Wolski (pen) ⚽", "78'", "", 76)
-	if strings.Index(short, "17'") != strings.Index(long, "78'") {
-		t.Fatalf("expected minute column to stay fixed\nshort: %q\nlong: %q", short, long)
-	}
-}
-
 func TestFormatMatchMinuteLeftPadsSingleDigitMinute(t *testing.T) {
 	if got := formatMatchMinute("9"); got != " 9'" {
 		t.Fatalf("unexpected single-digit minute formatting: %q", got)
@@ -612,172 +550,10 @@ func TestFormatMatchMinuteLeftPadsSingleDigitMinute(t *testing.T) {
 	}
 }
 
-func TestMatchDividerSharesCenteredMinuteColumn(t *testing.T) {
-	row := renderMatchDetailRow("Wdowiak G", "39'", "S Pllana (4)", 76)
-	divider := renderMatchDividerRow("HT 1 - 0", 76)
-	// The divider label stays visually centered, and its score dash should remain close
-	// to the minute center used by event rows.
-	// Divider fill uses '─', so normalise it to '-' before byte-indexing.
-	dividerASCII := strings.ReplaceAll(divider, "─", "-")
-	rowMid := strings.Index(row, "39'") + 1                // '9' = middle char of "39'"
-	dividerMid := strings.Index(dividerASCII, "1 - 0") + 2 // score dash within the divider label
-	if diff := rowMid - dividerMid; diff < -2 || diff > 2 {
-		t.Fatalf("expected divider score dash to align with minute centre\nrow: %q\ndiv: %q", row, divider)
-	}
-}
-
-func TestMatchDividerFillsCenterPaddingWithDashes(t *testing.T) {
-	divider := renderMatchDividerRow("HT 0 - 0", 76)
-	// Padding chars are '─'; the test label stays ASCII so byte positions are stable.
-	if strings.Contains(divider, "HT 0 - 0   ") {
-		t.Fatalf("expected divider to avoid wide trailing spaces after label, got %q", divider)
-	}
-	if !strings.Contains(divider, " HT 0 - 0 ") {
-		t.Fatalf("expected divider to keep single spaces around label, got %q", divider)
-	}
-	if !strings.Contains(divider, "─") {
-		t.Fatalf("expected divider to use box-drawing fill character, got %q", divider)
-	}
-}
-
-func TestHeaderEventRowsMinuteInCenterColumn(t *testing.T) {
-	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "17", Kind: "GOAL", TeamSide: "home", Text: "Krzysztof Kubica 17"},
-		{MinuteText: "30", Kind: "GOAL", TeamSide: "away", Text: "Karol Czubak (k) 30"},
-	})
-	// Two goal rows only (no HT divider — all events in same half)
-	if len(rows) != 2 {
-		t.Fatalf("expected two header rows, got %d: %#v", len(rows), rows)
-	}
-	// Label has name + icon only; no minute embedded in label
-	if ansi.Strip(rows[0].label) != "K. Kubica ⚽" {
-		t.Fatalf("unexpected home scorer label: %q", ansi.Strip(rows[0].label))
-	}
-	if ansi.Strip(rows[1].label) != "⚽ K. Czubak (pen)" {
-		t.Fatalf("unexpected away scorer label: %q", ansi.Strip(rows[1].label))
-	}
-	// Penalty suffix must still be dimmed
-	if !strings.Contains(rows[1].label, "\x1b[2m(pen)\x1b[0m") {
-		t.Fatalf("expected scored penalty suffix to be dimmed, got %q", rows[1].label)
-	}
-	// Center column carries the minute
-	if strings.TrimSpace(rows[0].minute) != "17'" {
-		t.Fatalf("expected home center to carry minute 17', got %q", rows[0].minute)
-	}
-	if strings.TrimSpace(rows[1].minute) != "30'" {
-		t.Fatalf("expected away center to carry minute 30', got %q", rows[1].minute)
-	}
-	// Minutes align on the same center axis
-	home := renderMatchDetailRow(rows[0].label, rows[0].minute, "", 76)
-	away := renderMatchDetailRow("", rows[1].minute, rows[1].label, 76)
-	homeMid := strings.Index(home, "17'")
-	awayMid := strings.Index(away, "30'")
-	if diff := homeMid - awayMid; diff < -1 || diff > 1 {
-		t.Fatalf("expected minutes to share centered column\nhome: %q\naway: %q", home, away)
-	}
-}
-
-func TestHeaderEventRowsIncludesRedCardsAndHTDivider(t *testing.T) {
-	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "39", Kind: "GOAL", TeamSide: "home", Text: "Wdowiak 39"},
-		{MinuteText: "60", Kind: "GOAL", TeamSide: "home", Text: "Szkurin 60"},
-		{MinuteText: "85", Kind: "RC", TeamSide: "away", Text: "Pllana 85"},
-	})
-	// Expect: goal (39'), HT divider, goal (60'), red card (85')
-	if len(rows) != 4 {
-		t.Fatalf("expected 4 rows (goal, HT, goal, RC), got %d: %#v", len(rows), rows)
-	}
-	if !rows[1].isDivider {
-		t.Fatalf("expected row 1 to be HT divider, got %#v", rows[1])
-	}
-	if rows[1].label != "HT 1 – 0" {
-		t.Fatalf("expected HT divider label %q, got %q", "HT 1 – 0", rows[1].label)
-	}
-	if ansi.Strip(rows[0].label) != "Wdowiak ⚽" {
-		t.Fatalf("unexpected first goal label: %q", ansi.Strip(rows[0].label))
-	}
-	if strings.TrimSpace(rows[0].minute) != "39'" {
-		t.Fatalf("expected first goal minute 39' in center, got %q", rows[0].minute)
-	}
-	if !strings.Contains(ansi.Strip(rows[3].label), "■") {
-		t.Fatalf("expected red card row to contain ■, got %q", ansi.Strip(rows[3].label))
-	}
-	if rows[3].minute != "85'" {
-		t.Fatalf("expected red card minute 85', got %q", rows[3].minute)
-	}
-}
-
-func TestHeaderEventRowsIncludesGoallessHTDividerBeforeSecondHalfEvents(t *testing.T) {
-	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "60", Kind: "RC", TeamSide: "away", Text: "Pllana 60"},
-	})
-
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 rows (HT, RC), got %d: %#v", len(rows), rows)
-	}
-	if !rows[0].isDivider {
-		t.Fatalf("expected row 0 to be HT divider, got %#v", rows[0])
-	}
-	if rows[0].label != "HT 0 – 0" {
-		t.Fatalf("expected HT divider label %q, got %q", "HT 0 – 0", rows[0].label)
-	}
-	if rows[1].minute != "60'" {
-		t.Fatalf("expected second-half event minute 60', got %q", rows[1].minute)
-	}
-}
-
-func TestHeaderEventRowsKeepsHTDividerWhenSecondHalfHasOnlyHiddenEvents(t *testing.T) {
-	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "39", Kind: "GOAL", TeamSide: "home", Text: "Wdowiak 39"},
-		{MinuteText: "60", Kind: "SUB", TeamSide: "home", Text: "Igor Strzalek -> Damian Nowak"},
-		{MinuteText: "72", Kind: "YC", TeamSide: "away", Text: "Pllana 72"},
-	})
-
-	if len(rows) != 2 {
-		t.Fatalf("expected 2 rows (goal, HT), got %d: %#v", len(rows), rows)
-	}
-	if rows[0].isDivider {
-		t.Fatalf("expected first row to be visible event, got %#v", rows[0])
-	}
-	if !rows[1].isDivider || rows[1].label != "HT 1 – 0" {
-		t.Fatalf("expected final row to be HT divider, got %#v", rows[1])
-	}
-}
-
 func TestRenderPlayerLineAbbreviatesNameAndDropsEvents(t *testing.T) {
 	got := renderPlayerLine(site.PlayerLine{Name: "(86) Igor Strzalek", Events: []string{"YC", "RC"}})
 	if got != "I. Strzalek" {
 		t.Fatalf("unexpected player line: %q", got)
-	}
-}
-
-func TestCardAnnotationPrefersRedCardOverEarlierYellow(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{
-		{MinuteText: "20", Kind: "YC", TeamSide: "home", Text: "Pllana 20"},
-		{MinuteText: "85", Kind: "RC", TeamSide: "home", Text: "Pllana 85"},
-	}, "home")
-
-	if got := cardAnnotation(site.PlayerLine{Name: "Pllana"}, idx); got != eventPrefix("RC") {
-		t.Fatalf("expected red-card badge, got %q", got)
-	}
-}
-
-func TestCardAnnotationDoesNotApplyAbbreviatedCardToFullSameInitialNames(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "85",
-		Kind:       "YC",
-		TeamSide:   "home",
-		Text:       "J. Kowalski 85",
-	}}, "home")
-
-	if got := cardAnnotation(site.PlayerLine{Name: "Jan Kowalski"}, idx); got != "" {
-		t.Fatalf("expected full Jan Kowalski not to inherit abbreviated card, got %q", got)
-	}
-	if got := cardAnnotation(site.PlayerLine{Name: "Jerzy Kowalski"}, idx); got != "" {
-		t.Fatalf("expected full Jerzy Kowalski not to inherit abbreviated card, got %q", got)
-	}
-	if got := cardAnnotation(site.PlayerLine{Name: "J. Kowalski"}, idx); ansi.Strip(got) != "■" {
-		t.Fatalf("expected abbreviated row to match abbreviated card, got %q", got)
 	}
 }
 
@@ -1048,21 +824,6 @@ func TestFormatLineupPlayerShowsBookedReplacedPlayerInsideAwayNote(t *testing.T)
 	}
 }
 
-func TestRenderLineupRowUsesCenteredSeparatorColumn(t *testing.T) {
-	row := renderLineupRow("K. Kubica", "B. Mrozek", 76)
-	rowMid := strings.Index(row, "|")
-	dividerMid := 76 / 2
-	if diff := rowMid - dividerMid; diff < -1 || diff > 1 {
-		t.Fatalf("expected lineup separator to share center axis\nrow: %q", row)
-	}
-	if !strings.Contains(row, "K. Kubica") || !strings.Contains(row, "B. Mrozek") {
-		t.Fatalf("expected lineup row to contain both players, got %q", row)
-	}
-	if strings.Contains(row, "    |    ") {
-		t.Fatalf("expected tighter lineup spacing around center separator, got %q", row)
-	}
-}
-
 func TestRenderLineupHeaderRowUsesBlankCenteredGap(t *testing.T) {
 	row := ansi.Strip(renderLineupHeaderRow("Piast Gliwice", "Radomiak Radom", 76))
 
@@ -1266,49 +1027,6 @@ func TestFormatFixtureWhenInfoShortensDateAndDropsAttendance(t *testing.T) {
 	}
 }
 
-func TestRenderFixtureWindowUsesFullNamesOutsideMatchSidebar(t *testing.T) {
-	lines := renderFixtureWindow([]site.Fixture{{
-		Home:     "Legia Warszawa",
-		Away:     "Lech Poznan",
-		Score:    "2-1",
-		WhenInfo: "24 stycznia, 20:30 (16 580)",
-		MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1",
-	}}, 0, 5, 80, false)
-
-	if len(lines) != 1 || !strings.Contains(ansi.Strip(lines[0]), "Legia Warszawa") || !strings.Contains(ansi.Strip(lines[0]), "Lech Poznan") || !strings.Contains(ansi.Strip(lines[0]), "24/01 20:30") {
-		t.Fatalf("expected full fixture line, got %v", lines)
-	}
-}
-
-func TestRenderFixtureWindowUsesCompactNamesInMatchSidebar(t *testing.T) {
-	lines := renderFixtureWindow([]site.Fixture{{
-		Home:     "Legia Warszawa",
-		Away:     "Lech Poznan",
-		Score:    "2-1",
-		WhenInfo: "24 stycznia, 20:30 (16 580)",
-		MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1",
-	}}, 0, 5, 40, true)
-
-	// Compact fixture: abbreviated names + score, then when-info separated by two spaces (no pipe).
-	stripped := ansi.Strip(lines[0])
-	if len(lines) != 1 || !strings.Contains(stripped, "LEG 2-1 LEC") || !strings.Contains(stripped, "24/01 20:30") {
-		t.Fatalf("expected compact fixture line, got %v", lines)
-	}
-}
-
-func TestRenderFixtureWindowMarksNonDrillableFixturesWhenSpaceAllows(t *testing.T) {
-	lines := renderFixtureWindow([]site.Fixture{{
-		Home:     "Legia Warszawa",
-		Away:     "Lech Poznan",
-		Score:    "-",
-		WhenInfo: "24 stycznia, 20:30",
-	}}, 0, 5, 120, false)
-
-	if len(lines) != 1 || !strings.Contains(lines[0], "[no details]") {
-		t.Fatalf("expected non-drillable marker, got %v", lines)
-	}
-}
-
 func TestLeagueViewMarksNonDrillableFixturesWhenSpaceAllows(t *testing.T) {
 	m := sketchModel()
 	m.width = 160
@@ -1419,50 +1137,6 @@ func TestStatusBarPaintsSpacerBackground(t *testing.T) {
 	}
 	if !strings.Contains(status, statusText("never")) {
 		t.Fatalf("expected clock to carry status background\n%q", status)
-	}
-}
-
-func TestRenderFixtureWindowAlignsFullFixtureColumns(t *testing.T) {
-	fixtures := []site.Fixture{
-		{Home: "Bruk-Bet Termalica Nieciecza", Away: "Motor Lublin", Score: "1-2", WhenInfo: "13 marca, 18:00 (3542)", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1"},
-		{Home: "Jagiellonia Bialystok", Away: "Piast Gliwice", Score: "1-2", WhenInfo: "14 marca, 14:45 (16 580)", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=2"},
-	}
-	lines := renderFixtureWindow(fixtures, 0, 5, 84, false)
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(lines))
-	}
-	// Normalise: strip ANSI then replace the multi-byte cursor marker '›' with a space
-	// so both lines have the same 2-byte prefix and byte positions match visual positions.
-	norm := func(s string) string { return strings.Replace(ansi.Strip(s), "›", " ", 1) }
-	n0, n1 := norm(lines[0]), norm(lines[1])
-	if strings.Index(n0[2:], "13/03") != strings.Index(n1[2:], "14/03") {
-		t.Fatalf("expected aligned date column, got %q and %q", lines[0], lines[1])
-	}
-	if strings.Index(n0[2:], "1-2") != strings.Index(n1[2:], "1-2") {
-		t.Fatalf("expected score column alignment, got %q and %q", lines[0], lines[1])
-	}
-}
-
-func TestRenderFixtureWindowKeepsColumnsAlignedWhenDetailsUnavailable(t *testing.T) {
-	fixtures := []site.Fixture{
-		{Home: "Cracovia", Away: "Arka Gdynia", Score: "-", WhenInfo: "12 kwietnia, 12:15"},
-		{Home: "Legia Warszawa", Away: "Gornik Zabrze", Score: "1-1", WhenInfo: "11 kwietnia, 20:15", MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=3"},
-	}
-	lines := renderFixtureWindow(fixtures, 0, 5, 84, false)
-	if len(lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(lines))
-	}
-
-	norm := func(s string) string { return strings.Replace(ansi.Strip(s), "›", " ", 1) }
-	n0, n1 := norm(lines[0]), norm(lines[1])
-	if strings.Index(n0[2:], "Arka Gdynia") != strings.Index(n1[2:], "Gornik Zabrze") {
-		t.Fatalf("expected aligned away-team column, got %q and %q", lines[0], lines[1])
-	}
-	if strings.Index(n0[2:], "12/04") != strings.Index(n1[2:], "11/04") {
-		t.Fatalf("expected aligned date column, got %q and %q", lines[0], lines[1])
-	}
-	if !strings.Contains(lines[0], "[no details]") {
-		t.Fatalf("expected unavailable-details marker, got %q", lines[0])
 	}
 }
 
@@ -1585,8 +1259,8 @@ func TestSelectorPopupWidthDoesNotDependOnCurrentScrollWindow(t *testing.T) {
 	allLines := selectorCompetitionWidthLines(m.competitions)
 	widthFromAll := selectorPopupWidth(120, seasonLines, rightHeading, allLines)
 
-	visibleNearTop := renderCompetitionWindow(m.competitions, 0)
-	visibleNearBottom := renderCompetitionWindow(m.competitions, len(m.competitions)-1)
+	visibleNearTop := selectorCompetitionRows(m.competitions, 0)
+	visibleNearBottom := selectorCompetitionRows(m.competitions, len(m.competitions)-1)
 	widthTop := selectorPopupWidth(120, seasonLines, rightHeading, visibleNearTop)
 	widthBottom := selectorPopupWidth(120, seasonLines, rightHeading, visibleNearBottom)
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -22,7 +22,7 @@ func TestLeagueSketchViewShowsStandingsFixturesAndStatus(t *testing.T) {
 	view := m.View()
 	for _, want := range []string{
 		"PKO Bank Polski Ekstraklasa 2025/2026",
-		"# Team",
+		"#   Team",
 		"Legia Warszawa",
 		"Round 1",
 		"Lech Poznan",
@@ -84,8 +84,9 @@ func TestMatchSketchViewShowsLoadingState(t *testing.T) {
 
 	view := m.View()
 	for _, want := range []string{
-		"# Team",
+		"#   Team",
 		"Round 1",
+		"FIXTURES",
 		"LEG 2-1 LEC",
 		"Loading…",
 	} {
@@ -132,11 +133,11 @@ func TestMatchDetailRemovesRedundantMetadata(t *testing.T) {
 		"S. Mraz",
 		"17'",
 		"62'",
-		"FT 1 – 2",
-		"13 March 2026, 18:00",
-		"Attendance 3542",
+		"HT 1 – 0",
+		"Fri 13 March 2026, 18:00",
+		"Att. 3 542",
 		"Ref. Damian Kos",
-		"Weather 15 C",
+		"15°",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected match view to contain %q\n%s", want, view)
@@ -189,22 +190,16 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 
 	view := m.View()
 	plainView := ansi.Strip(view)
-	_, centerWidth, _ := matchLayoutWidths(m.width)
-	content := ansi.Strip(m.matchDetailContent(centerWidth))
-	scoreHeader := renderMatchDetailRow("GKS Katowice", matchDetailScore("2-1"), "Lechia Gdansk", centerWidth-4)
-	spacerRow := renderMatchDetailRow("", "", "", centerWidth-4)
-	if !strings.Contains(content, scoreHeader+"\n"+spacerRow+"\n") {
-		t.Fatalf("expected spacer row between score header and event log\n%s", content)
-	}
 
 	for _, want := range []string{
-		"Wdowiak", "39'", "⚽", // home goal row (minute in center, icon adjacent)
-		"HT 1 – 0", // HT divider with score
-		"❌", "52'", // away missed penalty row
-		"Szkurin", "60'", // second home goal row
-		"K. Czubak", "70'", // away goal row
-		"■", "85'", // away red card row
-		"FT 2 – 1", // FT divider with score
+		"GKS Katowice", "2 – 1", "Lechia Gdansk",
+		"TIMELINE",
+		"HT 1 – 0",
+		"FT 2 – 1",
+		"Wdowiak", "39'",
+		"Szkurin", "60'",
+		"K. Czubak", "70'",
+		"LINEUPS",
 	} {
 		if !strings.Contains(plainView, want) {
 			t.Fatalf("expected match view to contain %q\n%s", want, view)
@@ -212,7 +207,7 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 	}
 
 	for _, unwanted := range []string{
-		"Timeline",
+		"❌",
 		"↕",
 	} {
 		if strings.Contains(plainView, unwanted) {
@@ -220,47 +215,257 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		}
 	}
 
-	headerIndexes := []int{
-		strings.Index(plainView, "39'"),
-		strings.Index(plainView, "HT 1 – 0"),
-		strings.Index(plainView, "52'"),
-		strings.Index(plainView, "60'"),
-		strings.Index(plainView, "70'"),
-		strings.Index(plainView, "85'"),
-		strings.Index(plainView, "FT 2 – 1"),
-	}
-	for _, idx := range headerIndexes {
-		if idx < 0 {
-			t.Fatalf("expected ordered score header in view\n%s", plainView)
-		}
-	}
-	for i := 1; i < len(headerIndexes); i++ {
-		if headerIndexes[i-1] >= headerIndexes[i] {
-			t.Fatalf("expected score header order 39 -> HT -> 52 -> 60 -> 70 -> 85 -> FT\n%s", plainView)
-		}
-	}
-
 	for _, want := range []string{
-		"46'",      // sub minute visible at outer edge of player name
-		"D. Nowak", // sub-on player visible immediately after sub-off
-		"■",        // red card badge in event column
+		"46'",
+		"D. Nowak", // sub-on player remains visible without crowding the lineup row
+		"■",        // card badge in the dedicated card slot
 	} {
 		if !strings.Contains(plainView, want) {
 			t.Fatalf("expected lineup section to contain %q\n%s", want, view)
 		}
 	}
-	lineupIdx := strings.Index(plainView, "Lineups")
-	if lineupIdx >= 0 {
-		lineupSection := plainView[lineupIdx:]
-		if strings.Contains(lineupSection, "⚽") {
-			t.Fatalf("expected lineup section to omit goal annotations\n%s", lineupSection)
-		}
+	lineupIdx := strings.Index(plainView, "LINEUPS")
+	if lineupIdx < 0 {
+		t.Fatalf("expected lineup section\n%s", view)
+	}
+	lineupSection := plainView[lineupIdx:]
+	if strings.Contains(lineupSection, "⚽") {
+		t.Fatalf("expected lineup section to omit goal annotations\n%s", lineupSection)
 	}
 	if strings.Contains(plainView, "Substitutions") {
 		t.Fatalf("expected substitution pane to be omitted\n%s", view)
 	}
-	if !strings.Contains(view, "\x1b[2m(46' D. Nowak)\x1b[0m") {
-		t.Fatalf("expected lineup substitution note to be dimmed\n%s", view)
+	if !strings.Contains(lineupSection, "(46' D. Nowak) I. Strzalek") {
+		t.Fatalf("expected inline substitution annotation in lineup section\n%s", lineupSection)
+	}
+}
+
+func TestRenderLineupPlayerRowColorsCards(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	row := renderLineupPlayerRow(
+		"Booked Home", lineupCardMarker{color: colorYellow, ok: true},
+		"Sent Off Away", lineupCardMarker{color: colorRed, ok: true},
+		64,
+	)
+
+	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
+		t.Fatalf("expected yellow card marker to be colored\n%q", row)
+	}
+	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel).Bold(true).Render("■")) {
+		t.Fatalf("expected red card marker to be colored\n%q", row)
+	}
+	plain := ansi.Strip(row)
+	divider := strings.IndexRune(plain, '│')
+	if divider < 0 {
+		t.Fatalf("expected center divider, got %q", plain)
+	}
+	dividerCol := ansi.StringWidth(plain[:divider])
+	runes := []rune(plain)
+	if string(runes[dividerCol-2:dividerCol]) != "■ " || string(runes[dividerCol+1:dividerCol+3]) != " ■" {
+		t.Fatalf("expected card markers one cell away from center divider, got %q", plain)
+	}
+}
+
+func TestAwayBookedSubstituteUsesColoredInlineCard(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	idx := playerEventIndex([]site.MatchEvent{
+		{MinuteText: "81", Kind: "SUB", TeamSide: "away", Text: "Jan Starter -> Sebastian Kubiak"},
+		{MinuteText: "85", Kind: "RC", TeamSide: "away", Text: "Sebastian Kubiak 85"},
+	}, "away")
+	entry := annotateLineupPlayer(site.PlayerLine{Name: "Jan Starter"}, idx)
+	row := renderLineupPlayerRow("", lineupCardMarker{}, lineupDisplayName(entry, "away", 64), lineupCardForEntry(entry, idx), 96)
+	plain := ansi.Strip(row)
+
+	if !strings.Contains(plain, "J. Starter (■ S. Kubiak 81')") {
+		t.Fatalf("expected substitute note with inline card, got %q", plain)
+	}
+	if strings.Contains(plain, "│■ ") {
+		t.Fatalf("expected substitute card to stay out of starter card slot, got %q", plain)
+	}
+	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel).Bold(true).Render("■")) {
+		t.Fatalf("expected booked substitute card to keep red styling\n%q", row)
+	}
+}
+
+func TestMatchDetailShowsAbbreviatedAwaySubstituteCardInline(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Home",
+		AwayTeam: "Away",
+		Score:    "1-1",
+		Events: []site.MatchEvent{
+			{MinuteText: "81", Kind: "SUB", TeamSide: "away", Text: "Jan Starter -> Sebastian Kubiak"},
+			{MinuteText: "85", Kind: "YC", TeamSide: "away", Text: "S. Kubiak 85"},
+		},
+		AwayLineup: []site.PlayerLine{{Name: "Jan Starter"}},
+	}
+
+	content := m.matchDetailContent(96)
+	plain := ansi.Strip(content)
+	if !strings.Contains(plain, "J. Starter (■ S. Kubiak 81')") {
+		t.Fatalf("expected substitute note with inline card\n%s", plain)
+	}
+	if strings.Contains(plain, "│■ ") {
+		t.Fatalf("expected substitute card to stay out of starter card slot\n%s", plain)
+	}
+	if !strings.Contains(content, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
+		t.Fatalf("expected substitute card to keep yellow styling\n%s", content)
+	}
+}
+
+func TestHomeBookedReplacementDoesNotUseStarterCardSlot(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Home",
+		AwayTeam: "Away",
+		Score:    "1-1",
+		Events: []site.MatchEvent{
+			{MinuteText: "77", Kind: "SUB", TeamSide: "home", Text: "Pawel Kun -> Kacper Chodyna"},
+			{MinuteText: "85", Kind: "YC", TeamSide: "home", Text: "K. Chodyna 85"},
+		},
+		HomeLineup: []site.PlayerLine{{Name: "Pawel Kun"}},
+	}
+
+	content := m.matchDetailContent(96)
+	plain := ansi.Strip(content)
+	if !strings.Contains(plain, "(77' K. Chodyna■) P. Kun") {
+		t.Fatalf("expected replacement card attached to replacement note\n%s", plain)
+	}
+	if strings.Contains(plain, "P. Kun ■│") {
+		t.Fatalf("expected replacement card not to look like starter card\n%s", plain)
+	}
+	if !strings.Contains(content, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
+		t.Fatalf("expected replacement card to keep yellow styling\n%s", content)
+	}
+}
+
+func TestRenderLineupPlayerRowMutesSubstitutionNotes(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	row := renderLineupPlayerRow("(46' D. Nowak) I. Strzalek", lineupCardMarker{}, "J. Wilson-Esbrand (J. Grzesik 46')", lineupCardMarker{}, 96)
+	noteStyle := lipgloss.NewStyle().Foreground(colorTextMuted).Background(colorBgPanel)
+	nameStyle := lipgloss.NewStyle().Foreground(colorTextSecondary).Background(colorBgPanel)
+
+	if !strings.Contains(row, noteStyle.Render("(")) || !strings.Contains(row, noteStyle.Render("4")) {
+		t.Fatalf("expected substitution note to use muted style\n%q", row)
+	}
+	if !strings.Contains(row, nameStyle.Render("I")) || !strings.Contains(row, nameStyle.Render("J")) {
+		t.Fatalf("expected player names to keep lineup body style\n%q", row)
+	}
+}
+
+func TestRenderLineupPlayerRowReservesBlankCardSlots(t *testing.T) {
+	row := ansi.Strip(renderLineupPlayerRow("Home", lineupCardMarker{}, "Away", lineupCardMarker{}, 41))
+	runes := []rune(row)
+	divider := strings.IndexRune(row, '│')
+	if divider < 0 {
+		t.Fatalf("expected centered divider with card slots, got %q", row)
+	}
+	dividerCol := ansi.StringWidth(row[:divider])
+	if dividerCol < 2 || dividerCol+3 > len(runes) {
+		t.Fatalf("expected centered divider with card slots, got %q", row)
+	}
+	if string(runes[dividerCol-2:dividerCol]) != "  " {
+		t.Fatalf("expected blank home card slot before divider, got %q", row)
+	}
+	if string(runes[dividerCol+1:dividerCol+3]) != "  " {
+		t.Fatalf("expected blank away card slot after divider, got %q", row)
+	}
+}
+
+func TestRenderLineupsLabelCentersELetter(t *testing.T) {
+	line := ansi.Strip(renderLineupsLabel(41))
+	start := strings.Index(line, "LINEUPS")
+	if start < 0 {
+		t.Fatalf("expected LINEUPS label, got %q", line)
+	}
+	visibleStart := ansi.StringWidth(line[:start])
+	if visibleStart+3 != 41/2 {
+		t.Fatalf("expected E in LINEUPS at center, got label start %d in %q", start, line)
+	}
+}
+
+func TestRenderSectionLabelCentersFourthLetter(t *testing.T) {
+	line := ansi.Strip(renderSectionLabel("TIMELINE", 41))
+	start := strings.Index(line, "TIMELINE")
+	if start < 0 {
+		t.Fatalf("expected TIMELINE label, got %q", line)
+	}
+	visibleStart := ansi.StringWidth(line[:start])
+	if visibleStart+3 != 41/2 {
+		t.Fatalf("expected E in TIMELINE at center, got label start %d in %q", start, line)
+	}
+}
+
+func TestGoalTimelineRowsKeepSideAssignment(t *testing.T) {
+	rows := goalTimelineRows([]site.MatchEvent{
+		{MinuteText: "12", Kind: "GOAL", TeamSide: "home", Text: "Home Scorer 12"},
+		{MinuteText: "44", Kind: "GOAL", TeamSide: "away", Text: "Away Scorer 44"},
+		{MinuteText: "89", Kind: "GOAL", TeamSide: "home", Text: "Late Winner 89"},
+	})
+
+	if len(rows) != 3 {
+		t.Fatalf("expected three chronological timeline rows, got %+v", rows)
+	}
+	if rows[0].home != "H. Scorer 12'" || rows[0].away != "—" {
+		t.Fatalf("expected first goal on home side, got %+v", rows[0])
+	}
+	if rows[1].home != "—" || rows[1].away != "44' A. Scorer" {
+		t.Fatalf("expected second goal on away side, got %+v", rows[1])
+	}
+	if rows[2].home != "L. Winner 89'" || rows[2].away != "—" {
+		t.Fatalf("expected third goal on home side, got %+v", rows[2])
+	}
+}
+
+func TestHalftimeScoreDisplayAvoidsInventingSparseHT(t *testing.T) {
+	if got := halftimeScoreDisplay(&site.MatchPage{Score: "1-0"}); got != "HT —" {
+		t.Fatalf("expected sparse match to avoid invented HT score, got %q", got)
+	}
+	got := halftimeScoreDisplay(&site.MatchPage{Events: []site.MatchEvent{{MinuteText: "90", Kind: "GOAL", TeamSide: "home", Text: "Winner 90"}}})
+	if got != "HT 0 – 0" {
+		t.Fatalf("expected second-half goal to imply goalless HT, got %q", got)
+	}
+}
+
+func TestMatchDetailOrdersScorersAroundHTAndFT(t *testing.T) {
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Home",
+		AwayTeam: "Away",
+		Score:    "1-1",
+		Events: []site.MatchEvent{
+			{MinuteText: "35", Kind: "GOAL", TeamSide: "home", Text: "First Scorer 35"},
+			{MinuteText: "56", Kind: "GOAL", TeamSide: "away", Text: "Second Scorer 56"},
+		},
+	}
+
+	content := ansi.Strip(m.matchDetailContent(80))
+	first := strings.Index(content, "F. Scorer 35'")
+	ht := strings.Index(content, "HT 1 – 0")
+	second := strings.Index(content, "56' S. Scorer")
+	ft := strings.Index(content, "FT 1 – 1")
+	if first < 0 || ht < 0 || second < 0 || ft < 0 {
+		t.Fatalf("expected scorer, HT, and FT rows\n%s", content)
+	}
+	if !(first < ht && ht < second && second < ft) {
+		t.Fatalf("expected first-half goals before HT, second-half goals before FT\n%s", content)
 	}
 }
 
@@ -345,7 +550,7 @@ func TestFormatLineupPlayerShortensNotesForNarrowFallbackRows(t *testing.T) {
 	}
 }
 
-func TestMatchDetailKeepsSubstitutionsOnlyInLineups(t *testing.T) {
+func TestMatchDetailKeepsInlineSubstitutionAnnotationsInLineups(t *testing.T) {
 	m := sketchModel()
 	m.width = 140
 	m.matchView = true
@@ -556,6 +761,25 @@ func TestCardAnnotationPrefersRedCardOverEarlierYellow(t *testing.T) {
 	}
 }
 
+func TestCardAnnotationDoesNotApplyAbbreviatedCardToFullSameInitialNames(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{{
+		MinuteText: "85",
+		Kind:       "YC",
+		TeamSide:   "home",
+		Text:       "J. Kowalski 85",
+	}}, "home")
+
+	if got := cardAnnotation(site.PlayerLine{Name: "Jan Kowalski"}, idx); got != "" {
+		t.Fatalf("expected full Jan Kowalski not to inherit abbreviated card, got %q", got)
+	}
+	if got := cardAnnotation(site.PlayerLine{Name: "Jerzy Kowalski"}, idx); got != "" {
+		t.Fatalf("expected full Jerzy Kowalski not to inherit abbreviated card, got %q", got)
+	}
+	if got := cardAnnotation(site.PlayerLine{Name: "J. Kowalski"}, idx); ansi.Strip(got) != "■" {
+		t.Fatalf("expected abbreviated row to match abbreviated card, got %q", got)
+	}
+}
+
 func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{{
 		MinuteText: "60",
@@ -588,6 +812,23 @@ func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testin
 	}
 }
 
+func TestAnnotatedLineupMatchesAbbreviatedPlayerToFullSubstitution(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{{
+		MinuteText: "60",
+		Kind:       "SUB",
+		TeamSide:   "away",
+		Text:       "Jan Starter -> Sebastian Kubiak",
+	}}, "away")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "S. Kubiak"}}, idx)
+	if len(got) != 1 {
+		t.Fatalf("expected one lineup entry, got %#v", got)
+	}
+	if got[0].enteredAt != "60'" || got[0].replaced != "Jan Starter" {
+		t.Fatalf("expected abbreviated lineup player to receive substitution note, got %#v", got[0])
+	}
+}
+
 func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{{
 		MinuteText: "60",
@@ -609,9 +850,127 @@ func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 	if got[0].player.Name != "Jerzy Kowalski" {
 		t.Fatalf("expected same-initial teammate to stay in place, got %#v", got)
 	}
+	if got[0].enteredAt != "" || got[0].leftAt != "" || got[0].replacedBy != "" {
+		t.Fatalf("expected same-initial teammate to remain unannotated, got %#v", got[0])
+	}
 	if got[1].player.Name != "Jan Kowalski" || got[1].replacedBy != "Piotr Kowalski" {
 		t.Fatalf("expected substitution to match full name, got %#v", got)
 	}
+}
+
+func TestAnnotatedLineupDoesNotApplyAbbreviatedSubstitutionToFullSameInitialNames(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{{
+		MinuteText: "60",
+		Kind:       "SUB",
+		TeamSide:   "home",
+		Text:       "J. Kowalski -> Piotr Kowalski",
+	}}, "home")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
+	if len(got) != 2 {
+		t.Fatalf("expected no synthetic rows for ambiguous abbreviated substitution, got %#v", got)
+	}
+	for _, entry := range got {
+		if entry.enteredAt != "" || entry.leftAt != "" || entry.replacedBy != "" {
+			t.Fatalf("expected full same-initial names to stay unannotated for abbreviated event, got %#v", got)
+		}
+	}
+}
+
+func TestAnnotatedLineupDoesNotApplyFullSubstitutionToAmbiguousAbbreviatedRow(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{{
+		MinuteText: "60",
+		Kind:       "SUB",
+		TeamSide:   "home",
+		Text:       "Jan Kowalski -> Piotr Kowalski",
+	}}, "home")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "J. Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
+	if len(got) != 2 {
+		t.Fatalf("expected no synthetic rows for ambiguous abbreviated lineup row, got %#v", got)
+	}
+	if got[0].leftAt != "" || got[0].replacedBy != "" {
+		t.Fatalf("expected ambiguous abbreviated row to stay unannotated, got %#v", got[0])
+	}
+}
+
+func TestAnnotatedLineupDoesNotDuplicateExistingAbbreviatedSyntheticEntrant(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{
+		{MinuteText: "60", Kind: "SUB", TeamSide: "away", Text: "Jan Starter -> Sebastian Kubiak"},
+		{MinuteText: "78", Kind: "SUB", TeamSide: "away", Text: "Sebastian Kubiak -> Adam Next"},
+	}, "away")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "S. Kubiak"}}, idx)
+	if len(got) != 2 {
+		t.Fatalf("expected no duplicate synthetic entrant for existing abbreviated row, got %#v", got)
+	}
+	if got[1].player.Name != "S. Kubiak" || got[1].enteredAt != "60'" || got[1].leftAt != "78'" || got[1].replacedBy != "Adam Next" {
+		t.Fatalf("expected existing abbreviated row to carry both substitution notes, got %#v", got[1])
+	}
+}
+
+func TestAnnotatedLineupDoesNotDuplicateExistingFullEntrantFromAbbreviatedSubstitution(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{
+		{MinuteText: "60", Kind: "SUB", TeamSide: "away", Text: "Jan Starter -> S. Kubiak"},
+		{MinuteText: "78", Kind: "SUB", TeamSide: "away", Text: "Sebastian Kubiak -> Adam Next"},
+	}, "away")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "Sebastian Kubiak"}}, idx)
+	if len(got) != 2 {
+		t.Fatalf("expected no duplicate synthetic row for existing full entrant, got %#v", got)
+	}
+	if got[1].enteredAt != "60'" || got[1].replaced != "Jan Starter" || got[1].leftAt != "78'" || got[1].replacedBy != "Adam Next" {
+		t.Fatalf("expected existing full entrant to carry both substitution notes, got %#v", got[1])
+	}
+}
+
+func TestAnnotatedLineupDoesNotAttachAmbiguousAbbreviatedCardToSubstituteNote(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{
+		{MinuteText: "60", Kind: "SUB", TeamSide: "home", Text: "Starter One -> Jan Kowalski"},
+		{MinuteText: "85", Kind: "YC", TeamSide: "home", Text: "J. Kowalski 85"},
+	}, "home")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Starter One"}, {Name: "Jerzy Kowalski"}}, idx)
+	if len(got) != 2 {
+		t.Fatalf("expected no synthetic rows for substitute without later exit, got %#v", got)
+	}
+	if got[0].replacedByYC.ok {
+		t.Fatalf("expected ambiguous abbreviated card not to attach to Jan Kowalski note, got %#v", got[0])
+	}
+}
+
+func TestAnnotatedLineupAllowsDistinctFullSyntheticEntrantsWithSameCompactKey(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{
+		{MinuteText: "60", Kind: "SUB", TeamSide: "home", Text: "Starter One -> Oskar Lesniak"},
+		{MinuteText: "61", Kind: "SUB", TeamSide: "home", Text: "Starter Two -> Olaf Lesniak"},
+		{MinuteText: "78", Kind: "SUB", TeamSide: "home", Text: "Oskar Lesniak -> Next One"},
+		{MinuteText: "79", Kind: "SUB", TeamSide: "home", Text: "Olaf Lesniak -> Next Two"},
+	}, "home")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Starter One"}, {Name: "Starter Two"}}, idx)
+	if len(got) != 4 {
+		t.Fatalf("expected two distinct synthetic entrants, got %#v", got)
+	}
+	oskar := lineupEntryByName(got, "Oskar Lesniak")
+	olaf := lineupEntryByName(got, "Olaf Lesniak")
+	if oskar.player.Name == "" || olaf.player.Name == "" {
+		t.Fatalf("expected distinct same-compact synthetic entrants, got %#v", got)
+	}
+	if oskar.enteredAt != "60'" || oskar.leftAt != "78'" || oskar.replacedBy != "Next One" {
+		t.Fatalf("unexpected Oskar Lesniak entry: %#v", oskar)
+	}
+	if olaf.enteredAt != "61'" || olaf.leftAt != "79'" || olaf.replacedBy != "Next Two" {
+		t.Fatalf("unexpected Olaf Lesniak entry: %#v", olaf)
+	}
+}
+
+func lineupEntryByName(entries []lineupEntry, name string) lineupEntry {
+	for _, entry := range entries {
+		if entry.player.Name == name {
+			return entry
+		}
+	}
+	return lineupEntry{}
 }
 
 func TestAnnotatedLineupKeepsBookedEntrantInReplacementNote(t *testing.T) {
@@ -624,7 +983,7 @@ func TestAnnotatedLineupKeepsBookedEntrantInReplacementNote(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected only starter row, got %#v", got)
 	}
-	if got[0].player.Name != "Jason Lokilo" || got[0].replacedBy != "Oskar Lesniak" || got[0].leftAt != "66'" || ansi.Strip(got[0].replacedByYC) != "■" {
+	if got[0].player.Name != "Jason Lokilo" || got[0].replacedBy != "Oskar Lesniak" || got[0].leftAt != "66'" || !got[0].replacedByYC.ok || got[0].replacedByYC.color != colorYellow {
 		t.Fatalf("expected starter row to retain substitution note, got %#v", got)
 	}
 }
@@ -667,7 +1026,7 @@ func TestFormatLineupPlayerShowsBookedReplacementInsideHomeNote(t *testing.T) {
 		player:       site.PlayerLine{Name: "Oskar Jakubczyk"},
 		leftAt:       "72'",
 		replacedBy:   "Michal Rzuchowski",
-		replacedByYC: eventPrefix("YC"),
+		replacedByYC: lineupCardMarker{color: colorYellow, ok: true},
 	}, "home", 64)
 
 	if got := ansi.Strip(home); got != "(72' M. Rzuchowski■) O. Jakubczyk" {
@@ -680,10 +1039,10 @@ func TestFormatLineupPlayerShowsBookedReplacedPlayerInsideAwayNote(t *testing.T)
 		player:     site.PlayerLine{Name: "Jakub Sypek"},
 		enteredAt:  "46'",
 		replaced:   "Jan Kowalczyk",
-		replacedYC: eventPrefix("YC"),
+		replacedYC: lineupCardMarker{color: colorYellow, ok: true},
 	}, "away", 64)
 
-	if got := ansi.Strip(away); got != "J. Sypek (for J. Kowalczyk ■ 46')" {
+	if got := ansi.Strip(away); got != "J. Sypek (for ■ J. Kowalczyk 46')" {
 		t.Fatalf("unexpected away booked-replaced label: %q", got)
 	}
 }
@@ -704,12 +1063,12 @@ func TestRenderLineupRowUsesCenteredSeparatorColumn(t *testing.T) {
 }
 
 func TestRenderLineupHeaderRowUsesBlankCenteredGap(t *testing.T) {
-	row := renderLineupRowWithMarker("Piast Gliwice", "Radomiak Radom", " ", 76)
+	row := ansi.Strip(renderLineupHeaderRow("Piast Gliwice", "Radomiak Radom", 76))
 
 	if !strings.Contains(row, "Piast Gliwice") || !strings.Contains(row, "Radomiak Radom") {
 		t.Fatalf("expected lineup header row to contain both team names, got %q", row)
 	}
-	if strings.Contains(row, "|") {
+	if strings.Contains(row, "|") || strings.Contains(row, "│") {
 		t.Fatalf("expected lineup header row to omit separator, got %q", row)
 	}
 
@@ -719,6 +1078,9 @@ func TestRenderLineupHeaderRowUsesBlankCenteredGap(t *testing.T) {
 	dividerMid := 76 / 2
 	if diff := gapMid - dividerMid; diff < -1 || diff > 1 {
 		t.Fatalf("expected lineup header gap to stay centered\nrow: %q", row)
+	}
+	if rightStart-leftEnd < 3 {
+		t.Fatalf("expected team names to sit away from the center, got %q", row)
 	}
 }
 
@@ -738,7 +1100,7 @@ func TestMatchDetailContentStylesLineupTeamsWithoutSeparator(t *testing.T) {
 	content := m.matchDetailContent(80)
 	lines := strings.Split(content, "\n")
 	for i, line := range lines {
-		if !strings.Contains(ansi.Strip(line), "Lineups") || i+1 >= len(lines) {
+		if !strings.Contains(ansi.Strip(line), "LINEUPS") || i+1 >= len(lines) {
 			continue
 		}
 
@@ -747,8 +1109,8 @@ func TestMatchDetailContentStylesLineupTeamsWithoutSeparator(t *testing.T) {
 		if !strings.Contains(stripped, "Piast Gliwice") || !strings.Contains(stripped, "Radomiak Radom") {
 			t.Fatalf("expected lineup team header row after section title, got %q", stripped)
 		}
-		if strings.Contains(stripped, "|") {
-			t.Fatalf("expected lineup team header to omit separator, got %q", stripped)
+		if strings.Contains(stripped, "│") {
+			t.Fatalf("expected lineup team header to omit center divider, got %q", stripped)
 		}
 		if !strings.Contains(header, "\x1b[") {
 			t.Fatalf("expected lineup team header to include styling, got %q", header)
@@ -773,7 +1135,26 @@ func TestMatchDetailContentShowsFTDividerWithoutVisibleHeaderEvents(t *testing.T
 
 	content := ansi.Strip(m.matchDetailContent(80))
 	if !strings.Contains(content, "FT 1 – 0") {
-		t.Fatalf("expected FT divider even without visible header events\n%s", content)
+		t.Fatalf("expected final score block even without visible header events\n%s", content)
+	}
+}
+
+func TestMatchDetailContentDoesNotShowFTForUnknownScore(t *testing.T) {
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Motor Lublin",
+		AwayTeam: "Zaglebie Lubin",
+		Score:    "-",
+	}
+
+	content := ansi.Strip(m.matchDetailContent(80))
+	if !strings.Contains(content, "Motor Lublin") || !strings.Contains(content, "vs") || !strings.Contains(content, "Zaglebie Lubin") {
+		t.Fatalf("expected unknown-score match title, got\n%s", content)
+	}
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "FT ") {
+			t.Fatalf("expected unknown-score match to omit final-score row\n%s", content)
+		}
 	}
 }
 
@@ -787,6 +1168,54 @@ func TestRenderCenteredTextCentersSectionLabels(t *testing.T) {
 	if leftPad-rightPad > 1 || rightPad-leftPad > 1 {
 		t.Fatalf("expected roughly symmetric padding, got %q", centered)
 	}
+}
+
+func TestMatchMetaAxisLineCentersOddMiddleSection(t *testing.T) {
+	width := 80
+	line := matchMetaAxisLine([]string{
+		"Wed 29 April 2026, 21:00",
+		"Att. 68 421",
+		"Ref. Danny Desmond Makkelie",
+	}, width)
+	middle := "Att. 68 421"
+	start := strings.Index(line, middle)
+	if start < 0 {
+		t.Fatalf("expected metadata line to contain middle section, got %q", line)
+	}
+
+	got := ansi.StringWidth(line[:start]) + ansi.StringWidth(middle)/2
+	if want := scorelineAxisColumn(width); got != want {
+		t.Fatalf("expected middle metadata section to align with score axis %d, got %d in %q", want, got, line)
+	}
+}
+
+func TestMatchMetaAxisLineCentersEvenMiddleSeparator(t *testing.T) {
+	width := 120
+	line := matchMetaAxisLine([]string{
+		"Wed 29 April 2026, 21:00",
+		"Att. 68 421",
+		"Ref. Danny Desmond Makkelie",
+		"15°",
+	}, width)
+	middle := "Att. 68 421  ·  Ref. Danny Desmond Makkelie"
+	start := strings.Index(line, middle)
+	if start < 0 {
+		t.Fatalf("expected metadata line to contain middle separator, got %q", line)
+	}
+
+	got := ansi.StringWidth(line[:start]) + ansi.StringWidth("Att. 68 421  ")
+	if want := scorelineAxisColumn(width); got != want {
+		t.Fatalf("expected middle metadata separator to align with score axis %d, got %d in %q", want, got, line)
+	}
+}
+
+func scorelineAxisColumn(width int) int {
+	scoreline := matchTitleLine("Home", "1-1", "Away", width)
+	dash := strings.Index(scoreline, "–")
+	if dash < 0 {
+		return -1
+	}
+	return ansi.StringWidth(scoreline[:dash])
 }
 
 func TestFinalScoreLineUsesMatchScore(t *testing.T) {
@@ -860,19 +1289,66 @@ func TestRenderFixtureWindowMarksNonDrillableFixturesWhenSpaceAllows(t *testing.
 	}
 }
 
+func TestLeagueViewMarksNonDrillableFixturesWhenSpaceAllows(t *testing.T) {
+	m := sketchModel()
+	m.width = 160
+	m.league.Rounds[0].Fixtures[0].MatchURL = ""
+	m.league.Rounds[0].Fixtures[0].MatchID = ""
+	m.league.Rounds[0].Fixtures[0].Score = "-"
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "[no details]") {
+		t.Fatalf("expected league fixture grid to mark non-drillable fixture\n%s", view)
+	}
+}
+
+func TestFixtureGridNonDrillableMarkerDoesNotReplaceDate(t *testing.T) {
+	line := ansi.Strip(formatFixtureGridRow(&site.Fixture{
+		Home:     "Legia Warszawa",
+		Away:     "Lech Poznan",
+		Score:    "-",
+		WhenInfo: "1 maja, 20:30",
+	}, false, 84, "Ekstraklasa", false, colorBgPanel))
+	drillable := ansi.Strip(formatFixtureGridRow(&site.Fixture{
+		Home:     "Legia Warszawa",
+		Away:     "Lech Poznan",
+		Score:    "0-1",
+		WhenInfo: "2 maja, 20:15",
+		MatchURL: "http://www.90minut.pl/mecz.php?id_mecz=1",
+	}, false, 84, "Ekstraklasa", false, colorBgPanel))
+
+	if !strings.Contains(line, "01/05 20:30") {
+		t.Fatalf("expected date to remain visible, got %q", line)
+	}
+	if !strings.Contains(line, "[no details]") {
+		t.Fatalf("expected no-details marker when space allows, got %q", line)
+	}
+	if strings.Index(line, "[no details]") > strings.Index(line, "01/05 20:30") {
+		t.Fatalf("expected no-details marker before date, got %q", line)
+	}
+	dateColumn := ansi.StringWidth(line[:strings.Index(line, "01/05 20:30")])
+	drillableDateColumn := ansi.StringWidth(drillable[:strings.Index(drillable, "02/05 20:15")])
+	if dateColumn != drillableDateColumn {
+		t.Fatalf("expected date column to stay aligned, got %q and %q", line, drillable)
+	}
+	if ansi.StringWidth(line[:strings.Index(line, "Lech Poznan")]) != ansi.StringWidth(drillable[:strings.Index(drillable, "Lech Poznan")]) {
+		t.Fatalf("expected fixture columns to stay aligned, got %q and %q", line, drillable)
+	}
+}
+
 func TestStatusBarViewReflectsFixtureDrillability(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
 
-	status := m.statusBarView()
-	if !strings.Contains(status, "enter: details") {
+	status := ansi.Strip(m.statusBarView())
+	if !strings.Contains(status, "enter  details") {
 		t.Fatalf("expected drillable status hint, got %q", status)
 	}
 
 	m.league.Rounds[0].Fixtures[0].MatchURL = ""
 	m.league.Rounds[0].Fixtures[0].MatchID = ""
-	status = m.statusBarView()
-	if !strings.Contains(status, "enter: unavail") {
+	status = ansi.Strip(m.statusBarView())
+	if !strings.Contains(status, "enter  unavail") {
 		t.Fatalf("expected non-drillable status hint, got %q", status)
 	}
 }
@@ -881,9 +1357,29 @@ func TestStatusBarViewLeagueViewIncludesReloadHint(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
 
-	status := m.statusBarView()
-	if !strings.Contains(status, "r: reload") {
+	status := ansi.Strip(m.statusBarView())
+	if !strings.Contains(status, "r  reload") {
 		t.Fatalf("expected reload hint in league status bar, got %q", status)
+	}
+}
+
+func TestStatusBarPaintsSpacerBackground(t *testing.T) {
+	prevProfile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(prevProfile)
+
+	m := sketchModel()
+	m.width = 120
+	status := m.statusBarView()
+
+	if ansi.StringWidth(status) != m.width {
+		t.Fatalf("expected status bar width %d, got %d", m.width, ansi.StringWidth(status))
+	}
+	if !strings.Contains(status, statusSpace(2)) {
+		t.Fatalf("expected status bar separators to carry status background\n%q", status)
+	}
+	if !strings.Contains(status, statusText("never")) {
+		t.Fatalf("expected clock to carry status background\n%q", status)
 	}
 }
 
@@ -948,6 +1444,26 @@ func TestStandingsTeamWidthUsesAvailableSpaceWithoutOverexpanding(t *testing.T) 
 	}
 }
 
+func TestRenderPitchStandingsWindowHighlightsHomeAndAway(t *testing.T) {
+	rows := []site.StandingRow{
+		{Position: 1, Team: "Cracovia", Played: 30, Points: 38},
+		{Position: 2, Team: "Pogon Szczecin", Played: 30, Points: 38},
+		{Position: 3, Team: "Lech Poznan", Played: 31, Points: 55},
+	}
+	fixture := &site.Fixture{Home: "Cracovia", Away: "Pogon Szczecin"}
+
+	lines := renderPitchStandingsWindow(rows, fixture, 54, 3)
+	if len(lines) != 3 {
+		t.Fatalf("expected standings lines, got %d", len(lines))
+	}
+	if !strings.Contains(ansi.Strip(lines[0]), "▌") || !strings.Contains(ansi.Strip(lines[1]), "▌") {
+		t.Fatalf("expected both fixture teams to be selected\n%q\n%q", lines[0], lines[1])
+	}
+	if strings.Contains(ansi.Strip(lines[2]), "▌") {
+		t.Fatalf("expected non-fixture team to stay unselected\n%q", lines[2])
+	}
+}
+
 func TestLeagueViewCanShowSelectorPopup(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
@@ -957,14 +1473,14 @@ func TestLeagueViewCanShowSelectorPopup(t *testing.T) {
 
 	view := m.View()
 	for _, want := range []string{
-		"# Team",
+		"#   Team",
 		"Legia Warszawa",
 		"Lech Poznan",
 		"24/01 20:30",
-		"Season",
+		"SEASON",
 		"2024/2025",
 		"Ekstraklasa",
-		"esc: close",
+		"esc  close",
 	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q\n%s", want, view)
@@ -981,7 +1497,7 @@ func TestSelectorPopupPlacesSeasonsAndLeaguesSideBySide(t *testing.T) {
 
 	popup := m.selectorPopupView(60)
 	for _, line := range strings.Split(popup, "\n") {
-		if strings.Contains(line, "Season") && strings.Contains(line, "Leagues") {
+		if strings.Contains(line, "SEASON") && strings.Contains(line, "COMPETITIONS") {
 			return
 		}
 	}
@@ -1061,7 +1577,7 @@ func TestSelectorPopupHandlesShortTerminal(t *testing.T) {
 	m.focus = focusCompetitions
 
 	view := m.View()
-	for _, want := range []string{"Season", "Round"} {
+	for _, want := range []string{"SEASON", "Round"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected view to contain %q\n%s", want, view)
 		}
@@ -1119,7 +1635,7 @@ func TestMatchViewScrollsLongContent(t *testing.T) {
 	if !strings.Contains(view, "Player01") {
 		t.Fatalf("expected initial match view to show top content\n%s", view)
 	}
-	for _, want := range []string{"# Team", "Round", "LEG 2-1 LEC"} {
+	for _, want := range []string{"#   Team", "Round", "FIXTURES", "LEG 2-1 LEC"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected match view to keep sidebar content %q visible\n%s", want, view)
 		}
@@ -1133,7 +1649,7 @@ func TestMatchViewScrollsLongContent(t *testing.T) {
 	if !strings.Contains(view, "Player20") {
 		t.Fatalf("expected scrolled match view to show later content\n%s", view)
 	}
-	for _, want := range []string{"# Team", "Round", "LEG 2-1 LEC"} {
+	for _, want := range []string{"#   Team", "Round", "FIXTURES", "LEG 2-1 LEC"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("expected scrolled match view to keep sidebar content %q visible\n%s", want, view)
 		}
@@ -1155,9 +1671,9 @@ func TestMatchViewShowsFullStandingsWhenHeightAllows(t *testing.T) {
 	}
 
 	view := m.View()
-	for _, want := range []string{"Team 01", "Team 16"} {
+	for _, want := range []string{"Team 01", "Team 16", "FIXTURES", "LEG 2-1 LEC"} {
 		if !strings.Contains(view, want) {
-			t.Fatalf("expected match sidebar to show full standings including %q\n%s", want, view)
+			t.Fatalf("expected match sidebar to keep full standings and minilist content %q\n%s", want, view)
 		}
 	}
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1209,7 +1209,7 @@ func TestMatchMetaAxisLineCentersEvenMiddleSeparator(t *testing.T) {
 	}
 }
 
-func TestMatchMetaAxisLineCompactsDateBeforeTruncatingAttendance(t *testing.T) {
+func TestMatchMetaAxisLineDropsDateBeforeTruncatingAttendance(t *testing.T) {
 	line := matchMetaAxisLine([]string{
 		"Sat 2 May 2026, 20:15",
 		"Att. 8 470",
@@ -1217,8 +1217,8 @@ func TestMatchMetaAxisLineCompactsDateBeforeTruncatingAttendance(t *testing.T) {
 		"15°",
 	}, 70)
 
-	if !strings.Contains(line, "Sat 02/05 20:15") {
-		t.Fatalf("expected compact date at narrow width, got %q", line)
+	if strings.Contains(line, "May") || strings.Contains(line, "02/05") {
+		t.Fatalf("expected date to be dropped at narrow width, got %q", line)
 	}
 	if !strings.Contains(line, "Att. 8 470") {
 		t.Fatalf("expected full attendance to remain visible, got %q", line)
@@ -1352,6 +1352,25 @@ func TestFixtureGridNonDrillableMarkerDoesNotReplaceDate(t *testing.T) {
 	}
 	if ansi.StringWidth(line[:strings.Index(line, "Lech Poznan")]) != ansi.StringWidth(drillable[:strings.Index(drillable, "Lech Poznan")]) {
 		t.Fatalf("expected fixture columns to stay aligned, got %q and %q", line, drillable)
+	}
+}
+
+func TestFixtureGridSuppressesDetailsMarkerBeforeOverTruncatingTeams(t *testing.T) {
+	line := ansi.Strip(formatFixtureGridRow(&site.Fixture{
+		Home:     "GKS Katowice",
+		Away:     "Bruk-Bet Termalica Nieciecza",
+		Score:    "-",
+		WhenInfo: "3 maja, 12:15",
+	}, false, 57, "Ekstraklasa", false, colorBgPanel))
+
+	if strings.Contains(line, "[no details]") {
+		t.Fatalf("expected details marker to be suppressed before crushing team names, got %q", line)
+	}
+	if !strings.Contains(line, "GKS Katowice") {
+		t.Fatalf("expected home team to remain readable, got %q", line)
+	}
+	if !strings.Contains(line, "03/05 12:15") {
+		t.Fatalf("expected date to remain visible, got %q", line)
 	}
 }
 

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -197,8 +197,10 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		"HT 1 – 0",
 		"FT 2 – 1",
 		"Wdowiak", "39'",
+		"Barkowskij", "52'", "❌",
 		"Szkurin", "60'",
 		"K. Czubak", "70'",
+		"Pllana", "85'", "■",
 		"LINEUPS",
 	} {
 		if !strings.Contains(plainView, want) {
@@ -207,7 +209,6 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 	}
 
 	for _, unwanted := range []string{
-		"❌",
 		"↕",
 	} {
 		if strings.Contains(plainView, unwanted) {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1209,6 +1209,25 @@ func TestMatchMetaAxisLineCentersEvenMiddleSeparator(t *testing.T) {
 	}
 }
 
+func TestMatchMetaAxisLineCompactsDateBeforeTruncatingAttendance(t *testing.T) {
+	line := matchMetaAxisLine([]string{
+		"Sat 2 May 2026, 20:15",
+		"Att. 8 470",
+		"Ref. Karol Arys",
+		"15°",
+	}, 70)
+
+	if !strings.Contains(line, "Sat 02/05 20:15") {
+		t.Fatalf("expected compact date at narrow width, got %q", line)
+	}
+	if !strings.Contains(line, "Att. 8 470") {
+		t.Fatalf("expected full attendance to remain visible, got %q", line)
+	}
+	if !strings.Contains(line, "Ref. Karol Arys") {
+		t.Fatalf("expected full referee to remain visible, got %q", line)
+	}
+}
+
 func scorelineAxisColumn(width int) int {
 	scoreline := matchTitleLine("Home", "1-1", "Away", width)
 	dash := strings.Index(scoreline, "–")

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -7,9 +7,7 @@ import (
 	"time"
 
 	"github.com/adrunkhuman/90minuTUI/internal/site"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/muesli/termenv"
 )
 
 func TestLeagueSketchViewShowsStandingsFixturesAndStatus(t *testing.T) {
@@ -242,39 +240,24 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 }
 
 func TestRenderLineupPlayerRowColorsCards(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
 	row := renderLineupPlayerRow(
 		"Booked Home", lineupCardMarker{color: colorYellow, ok: true},
 		"Sent Off Away", lineupCardMarker{color: colorRed, ok: true},
 		64,
 	)
 
-	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
-		t.Fatalf("expected yellow card marker to be colored\n%q", row)
-	}
-	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel).Bold(true).Render("■")) {
-		t.Fatalf("expected red card marker to be colored\n%q", row)
-	}
 	plain := ansi.Strip(row)
-	divider := strings.IndexRune(plain, '│')
-	if divider < 0 {
-		t.Fatalf("expected center divider, got %q", plain)
+	for _, want := range []string{"Booked Home", "Sent Off Away", "│"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("expected lineup row to contain %q, got %q", want, plain)
+		}
 	}
-	dividerCol := ansi.StringWidth(plain[:divider])
-	runes := []rune(plain)
-	if string(runes[dividerCol-2:dividerCol]) != "■ " || string(runes[dividerCol+1:dividerCol+3]) != " ■" {
-		t.Fatalf("expected card markers one cell away from center divider, got %q", plain)
+	if strings.Count(plain, "■") != 2 {
+		t.Fatalf("expected both card markers, got %q", plain)
 	}
 }
 
-func TestAwayBookedSubstituteUsesColoredInlineCard(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
+func TestAwayBookedSubstituteUsesInlineCard(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
 		{MinuteText: "81", Kind: "SUB", TeamSide: "away", Text: "Jan Starter -> Sebastian Kubiak"},
 		{MinuteText: "85", Kind: "RC", TeamSide: "away", Text: "Sebastian Kubiak 85"},
@@ -289,16 +272,9 @@ func TestAwayBookedSubstituteUsesColoredInlineCard(t *testing.T) {
 	if strings.Contains(plain, "│■ ") {
 		t.Fatalf("expected substitute card to stay out of starter card slot, got %q", plain)
 	}
-	if !strings.Contains(row, lipgloss.NewStyle().Foreground(colorRed).Background(colorBgPanel).Bold(true).Render("■")) {
-		t.Fatalf("expected booked substitute card to keep red styling\n%q", row)
-	}
 }
 
 func TestMatchDetailShowsAbbreviatedAwaySubstituteCardInline(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
 	m := sketchModel()
 	m.match = &site.MatchPage{
 		HomeTeam: "Home",
@@ -319,16 +295,9 @@ func TestMatchDetailShowsAbbreviatedAwaySubstituteCardInline(t *testing.T) {
 	if strings.Contains(plain, "│■ ") {
 		t.Fatalf("expected substitute card to stay out of starter card slot\n%s", plain)
 	}
-	if !strings.Contains(content, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
-		t.Fatalf("expected substitute card to keep yellow styling\n%s", content)
-	}
 }
 
 func TestHomeBookedReplacementDoesNotUseStarterCardSlot(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
 	m := sketchModel()
 	m.match = &site.MatchPage{
 		HomeTeam: "Home",
@@ -348,69 +317,6 @@ func TestHomeBookedReplacementDoesNotUseStarterCardSlot(t *testing.T) {
 	}
 	if strings.Contains(plain, "P. Kun ■│") {
 		t.Fatalf("expected replacement card not to look like starter card\n%s", plain)
-	}
-	if !strings.Contains(content, lipgloss.NewStyle().Foreground(colorYellow).Background(colorBgPanel).Bold(true).Render("■")) {
-		t.Fatalf("expected replacement card to keep yellow styling\n%s", content)
-	}
-}
-
-func TestRenderLineupPlayerRowMutesSubstitutionNotes(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
-	row := renderLineupPlayerRow("(46' D. Nowak) I. Strzalek", lineupCardMarker{}, "J. Wilson-Esbrand (J. Grzesik 46')", lineupCardMarker{}, 96)
-	noteStyle := lipgloss.NewStyle().Foreground(colorTextMuted).Background(colorBgPanel)
-	nameStyle := lipgloss.NewStyle().Foreground(colorTextSecondary).Background(colorBgPanel)
-
-	if !strings.Contains(row, noteStyle.Render("(")) || !strings.Contains(row, noteStyle.Render("4")) {
-		t.Fatalf("expected substitution note to use muted style\n%q", row)
-	}
-	if !strings.Contains(row, nameStyle.Render("I")) || !strings.Contains(row, nameStyle.Render("J")) {
-		t.Fatalf("expected player names to keep lineup body style\n%q", row)
-	}
-}
-
-func TestRenderLineupPlayerRowReservesBlankCardSlots(t *testing.T) {
-	row := ansi.Strip(renderLineupPlayerRow("Home", lineupCardMarker{}, "Away", lineupCardMarker{}, 41))
-	runes := []rune(row)
-	divider := strings.IndexRune(row, '│')
-	if divider < 0 {
-		t.Fatalf("expected centered divider with card slots, got %q", row)
-	}
-	dividerCol := ansi.StringWidth(row[:divider])
-	if dividerCol < 2 || dividerCol+3 > len(runes) {
-		t.Fatalf("expected centered divider with card slots, got %q", row)
-	}
-	if string(runes[dividerCol-2:dividerCol]) != "  " {
-		t.Fatalf("expected blank home card slot before divider, got %q", row)
-	}
-	if string(runes[dividerCol+1:dividerCol+3]) != "  " {
-		t.Fatalf("expected blank away card slot after divider, got %q", row)
-	}
-}
-
-func TestRenderLineupsLabelCentersELetter(t *testing.T) {
-	line := ansi.Strip(renderLineupsLabel(41))
-	start := strings.Index(line, "LINEUPS")
-	if start < 0 {
-		t.Fatalf("expected LINEUPS label, got %q", line)
-	}
-	visibleStart := ansi.StringWidth(line[:start])
-	if visibleStart+3 != 41/2 {
-		t.Fatalf("expected E in LINEUPS at center, got label start %d in %q", start, line)
-	}
-}
-
-func TestRenderSectionLabelCentersFourthLetter(t *testing.T) {
-	line := ansi.Strip(renderSectionLabel("TIMELINE", 41))
-	start := strings.Index(line, "TIMELINE")
-	if start < 0 {
-		t.Fatalf("expected TIMELINE label, got %q", line)
-	}
-	visibleStart := ansi.StringWidth(line[:start])
-	if visibleStart+3 != 41/2 {
-		t.Fatalf("expected E in TIMELINE at center, got label start %d in %q", start, line)
 	}
 }
 
@@ -833,24 +739,9 @@ func TestRenderLineupHeaderRowUsesBlankCenteredGap(t *testing.T) {
 	if strings.Contains(row, "|") || strings.Contains(row, "│") {
 		t.Fatalf("expected lineup header row to omit separator, got %q", row)
 	}
-
-	leftEnd := strings.Index(row, "Piast Gliwice") + len("Piast Gliwice")
-	rightStart := strings.Index(row, "Radomiak Radom")
-	gapMid := leftEnd + ((rightStart - leftEnd) / 2)
-	dividerMid := 76 / 2
-	if diff := gapMid - dividerMid; diff < -1 || diff > 1 {
-		t.Fatalf("expected lineup header gap to stay centered\nrow: %q", row)
-	}
-	if rightStart-leftEnd < 3 {
-		t.Fatalf("expected team names to sit away from the center, got %q", row)
-	}
 }
 
-func TestMatchDetailContentStylesLineupTeamsWithoutSeparator(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
+func TestMatchDetailContentShowsLineupTeamsWithoutSeparator(t *testing.T) {
 	m := sketchModel()
 	m.match = &site.MatchPage{
 		HomeTeam:   "Piast Gliwice",
@@ -873,9 +764,6 @@ func TestMatchDetailContentStylesLineupTeamsWithoutSeparator(t *testing.T) {
 		}
 		if strings.Contains(stripped, "│") {
 			t.Fatalf("expected lineup team header to omit center divider, got %q", stripped)
-		}
-		if !strings.Contains(header, "\x1b[") {
-			t.Fatalf("expected lineup team header to include styling, got %q", header)
 		}
 		return
 	}
@@ -920,57 +808,6 @@ func TestMatchDetailContentDoesNotShowFTForUnknownScore(t *testing.T) {
 	}
 }
 
-func TestRenderCenteredTextCentersSectionLabels(t *testing.T) {
-	centered := renderCenteredText("Timeline", 21)
-	leftPad := strings.Index(centered, "Timeline")
-	rightPad := len(centered) - leftPad - len("Timeline")
-	if leftPad == 0 || rightPad == 0 {
-		t.Fatalf("expected centered padding, got %q", centered)
-	}
-	if leftPad-rightPad > 1 || rightPad-leftPad > 1 {
-		t.Fatalf("expected roughly symmetric padding, got %q", centered)
-	}
-}
-
-func TestMatchMetaAxisLineCentersOddMiddleSection(t *testing.T) {
-	width := 80
-	line := matchMetaAxisLine([]string{
-		"Wed 29 April 2026, 21:00",
-		"Att. 68 421",
-		"Ref. Danny Desmond Makkelie",
-	}, width)
-	middle := "Att. 68 421"
-	start := strings.Index(line, middle)
-	if start < 0 {
-		t.Fatalf("expected metadata line to contain middle section, got %q", line)
-	}
-
-	got := ansi.StringWidth(line[:start]) + ansi.StringWidth(middle)/2
-	if want := scorelineAxisColumn(width); got != want {
-		t.Fatalf("expected middle metadata section to align with score axis %d, got %d in %q", want, got, line)
-	}
-}
-
-func TestMatchMetaAxisLineCentersEvenMiddleSeparator(t *testing.T) {
-	width := 120
-	line := matchMetaAxisLine([]string{
-		"Wed 29 April 2026, 21:00",
-		"Att. 68 421",
-		"Ref. Danny Desmond Makkelie",
-		"15°",
-	}, width)
-	middle := "Att. 68 421  ·  Ref. Danny Desmond Makkelie"
-	start := strings.Index(line, middle)
-	if start < 0 {
-		t.Fatalf("expected metadata line to contain middle separator, got %q", line)
-	}
-
-	got := ansi.StringWidth(line[:start]) + ansi.StringWidth("Att. 68 421  ")
-	if want := scorelineAxisColumn(width); got != want {
-		t.Fatalf("expected middle metadata separator to align with score axis %d, got %d in %q", want, got, line)
-	}
-}
-
 func TestMatchMetaAxisLineDropsDateBeforeTruncatingAttendance(t *testing.T) {
 	line := matchMetaAxisLine([]string{
 		"Sat 2 May 2026, 20:15",
@@ -988,15 +825,6 @@ func TestMatchMetaAxisLineDropsDateBeforeTruncatingAttendance(t *testing.T) {
 	if !strings.Contains(line, "Ref. Karol Arys") {
 		t.Fatalf("expected full referee to remain visible, got %q", line)
 	}
-}
-
-func scorelineAxisColumn(width int) int {
-	scoreline := matchTitleLine("Home", "1-1", "Away", width)
-	dash := strings.Index(scoreline, "–")
-	if dash < 0 {
-		return -1
-	}
-	return ansi.StringWidth(scoreline[:dash])
 }
 
 func TestFinalScoreLineUsesMatchScore(t *testing.T) {
@@ -1120,11 +948,7 @@ func TestStatusBarViewLeagueViewIncludesReloadHint(t *testing.T) {
 	}
 }
 
-func TestStatusBarPaintsSpacerBackground(t *testing.T) {
-	prevProfile := lipgloss.ColorProfile()
-	lipgloss.SetColorProfile(termenv.TrueColor)
-	defer lipgloss.SetColorProfile(prevProfile)
-
+func TestStatusBarFitsWidthAndShowsFetchTime(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
 	status := m.statusBarView()
@@ -1132,11 +956,8 @@ func TestStatusBarPaintsSpacerBackground(t *testing.T) {
 	if ansi.StringWidth(status) != m.width {
 		t.Fatalf("expected status bar width %d, got %d", m.width, ansi.StringWidth(status))
 	}
-	if !strings.Contains(status, statusSpace(2)) {
-		t.Fatalf("expected status bar separators to carry status background\n%q", status)
-	}
-	if !strings.Contains(status, statusText("never")) {
-		t.Fatalf("expected clock to carry status background\n%q", status)
+	if !strings.Contains(ansi.Strip(status), "never") {
+		t.Fatalf("expected status bar to show empty fetch time\n%q", status)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Redesign the UI around a pitch-dark two-pane layout with refreshed standings, fixture grid, selector, match detail, status bar, and match sidebar rendering.
- Rework match detail alignment for scorelines, metadata, goal timeline, lineups, cards, substitutions, and non-final score states.
- Add regression coverage for layout alignment, non-drillable fixture markers, substitute/card attribution, compact player matching, and key rendering contracts.

## Testing

- `go test ./...`
- `git diff --check`
