### PR TITLE
Store parsed match minutes alongside display text

### DIFF
--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -48,8 +48,13 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 		if kind, ok := scoreRowEventKind(row); ok {
 			// Incident rows keep one side empty; non-empty side maps event ownership.
 			if left != "" && right == "" {
+				minuteText := extractMinute(left)
+				m, s, ok := parseMinute(minuteText)
 				page.Events = append(page.Events, MatchEvent{
-					MinuteText: extractMinute(left),
+					MinuteText: minuteText,
+					Minute:     m,
+					Stoppage:   s,
+					HasMinute:  ok,
 					Kind:       kind,
 					TeamSide:   "home",
 					Text:       left,
@@ -57,8 +62,13 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 			}
 
 			if right != "" && left == "" {
+				minuteText := extractMinute(right)
+				m, s, ok := parseMinute(minuteText)
 				page.Events = append(page.Events, MatchEvent{
-					MinuteText: extractMinute(right),
+					MinuteText: minuteText,
+					Minute:     m,
+					Stoppage:   s,
+					HasMinute:  ok,
 					Kind:       kind,
 					TeamSide:   "away",
 					Text:       right,
@@ -271,6 +281,7 @@ func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
 		case strings.Contains(marker, "->"):
 			event.Kind = "SUB"
 			event.MinuteText = extractMinute(marker)
+			event.Minute, event.Stoppage, event.HasMinute = parseMinute(event.MinuteText)
 			event.Text = substitutionEventText(player.Name, marker)
 		default:
 			event.Kind = "EVENT"

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -83,8 +83,13 @@ type MatchPage struct {
 
 type MatchEvent struct {
 	MinuteText string
-	Kind       string
-	TeamSide   string
+	// Minute and Stoppage are the parsed components of MinuteText (e.g. "45+2" → 45, 2).
+	// HasMinute is false when MinuteText was absent or unparseable.
+	Minute    int
+	Stoppage  int
+	HasMinute bool
+	Kind      string
+	TeamSide  string
 	// SUB events carry "<outgoing> -> <incoming>" so renderers can place both players.
 	Text string
 }

--- a/internal/site/parser_common.go
+++ b/internal/site/parser_common.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -24,6 +25,33 @@ func extractMinute(text string) string {
 	}
 
 	return matches[1]
+}
+
+// ParseMinute splits a minute string like "45+2" into base minute and stoppage addition.
+// Returns (0, 0, false) when the string is empty or cannot be parsed as a valid minute.
+func ParseMinute(text string) (int, int, bool) {
+	return parseMinute(text)
+}
+
+func parseMinute(text string) (int, int, bool) {
+	if text == "" {
+		return 0, 0, false
+	}
+
+	parts := strings.SplitN(text, "+", 2)
+	base, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || base < 0 {
+		return 0, 0, false
+	}
+
+	stoppage := 0
+	if len(parts) == 2 {
+		if s, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil && s > 0 {
+			stoppage = s
+		}
+	}
+
+	return base, stoppage, true
 }
 
 func isScoreLikeText(text string) bool {

--- a/internal/site/parser_common.go
+++ b/internal/site/parser_common.go
@@ -9,7 +9,7 @@ import (
 )
 
 var spaceRe = regexp.MustCompile(`\s+`)
-var minuteAtEndRe = regexp.MustCompile(`(\d{1,3})\s*$`)
+var minuteAtEndRe = regexp.MustCompile(`(\d{1,3}(?:\+\d{1,2})?)\s*$`)
 var minuteAnywhereRe = regexp.MustCompile(`(\d{1,3}(?:\+\d{1,2})?)`)
 var scoreLikeTextRe = regexp.MustCompile(`^\d+\s*-\s*\d+$`)
 var leaguePathKeyRe = regexp.MustCompile(`(?i)(?:^|/)liga/\d+/(liga\d+)\.html$`)

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -210,7 +210,7 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 	<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
 	<td width="45%"><a href="/wystepy.php?id=1" class="main">Oskar Jakubczyk</a>&nbsp;<img src="http://img.90minut.pl/img/yel.gif" width="15" height="15" align="absmiddle" alt="ZK"><br>
 	<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
-	72 <a href="/wystepy.php?id=2" class="main">Michal Rzuchowski</a>&nbsp;<img src="http://img.90minut.pl/img/yel.gif" width="15" height="15" align="absmiddle" alt="ZK"></td>
+	90+2 <a href="/wystepy.php?id=2" class="main">Michal Rzuchowski</a>&nbsp;<img src="http://img.90minut.pl/img/yel.gif" width="15" height="15" align="absmiddle" alt="ZK"></td>
 	<td bgcolor="#FFFFFF"></td><td width="45%"></td></tr>
 	</table>
 	</body></html>`
@@ -237,6 +237,9 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 	for _, event := range page.Events {
 		switch {
 		case event.Kind == "SUB" && event.TeamSide == "home" && event.Text == "Oskar Jakubczyk -> Michal Rzuchowski":
+			if event.MinuteText != "90+2" || event.Minute != 90 || event.Stoppage != 2 || !event.HasMinute {
+				t.Fatalf("expected structured stoppage-time substitution minute, got %#v", event)
+			}
 			seenSub = true
 		case event.Kind == "YC" && event.TeamSide == "home" && event.Text == "Oskar Jakubczyk":
 			seenStarterCard = true

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -135,3 +135,67 @@ func TestParseMatchPageMissedPenaltyTimelineEvent(t *testing.T) {
 		t.Fatalf("unexpected missed penalty text: %#v", event)
 	}
 }
+
+func TestParseMinuteSplitsBaseAndStoppage(t *testing.T) {
+	cases := []struct {
+		input    string
+		minute   int
+		stoppage int
+		ok       bool
+	}{
+		{"45+2", 45, 2, true},
+		{"90+5", 90, 5, true},
+		{"67", 67, 0, true},
+		{"1", 1, 0, true},
+		{"", 0, 0, false},
+		{"abc", 0, 0, false},
+		{"45+abc", 45, 0, true}, // invalid stoppage treated as 0
+	}
+
+	for _, c := range cases {
+		m, s, ok := ParseMinute(c.input)
+		if ok != c.ok || m != c.minute || s != c.stoppage {
+			t.Errorf("ParseMinute(%q) = (%d, %d, %v), want (%d, %d, %v)",
+				c.input, m, s, ok, c.minute, c.stoppage, c.ok)
+		}
+	}
+}
+
+func TestParseMatchPageEventsCarryStructuredMinutes(t *testing.T) {
+	html := `
+	<html><head><title>Match Test</title></head><body>
+	<table class="main" width="480">
+	<tr><td colspan="3"><b>Ekstraklasa</b></td></tr>
+	<tr><td colspan="3">20 marca 2026, 18:00</td></tr>
+	<tr><td>Home FC</td><td>1 - 0</td><td>Away FC</td></tr>
+	<tr><td align="right">Kowalski 45+1&nbsp;&nbsp;&nbsp;&nbsp;</td><td>1 - 0</td><td></td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse html: %v", err)
+	}
+
+	page := parseMatchPage(doc, "http://www.90minut.pl/mecz.php?id_mecz=9999")
+	if page == nil {
+		t.Fatalf("expected parsed match page")
+	}
+
+	var goalEvent *MatchEvent
+	for i := range page.Events {
+		if page.Events[i].Kind == "GOAL" {
+			goalEvent = &page.Events[i]
+			break
+		}
+	}
+	if goalEvent == nil {
+		t.Fatalf("expected GOAL event, got %#v", page.Events)
+	}
+	if !goalEvent.HasMinute {
+		t.Fatalf("expected HasMinute=true for event with MinuteText %q", goalEvent.MinuteText)
+	}
+	if goalEvent.Minute != 45 || goalEvent.Stoppage != 1 {
+		t.Fatalf("expected Minute=45 Stoppage=1, got Minute=%d Stoppage=%d", goalEvent.Minute, goalEvent.Stoppage)
+	}
+}

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -246,8 +246,10 @@ func sortedEvents(events []site.MatchEvent) []site.MatchEvent {
 	copy(ordered, events)
 
 	sort.SliceStable(ordered, func(i, j int) bool {
-		mi, hi := minuteSortKey(ordered[i].MinuteText)
-		mj, hj := minuteSortKey(ordered[j].MinuteText)
+		hi := ordered[i].HasMinute
+		hj := ordered[j].HasMinute
+		mi := ordered[i].Minute*100 + ordered[i].Stoppage
+		mj := ordered[j].Minute*100 + ordered[j].Stoppage
 
 		if hi != hj {
 			return hi
@@ -283,33 +285,6 @@ func eventWeight(kind string) int {
 	default:
 		return 9
 	}
-}
-
-func minuteSortKey(text string) (int, bool) {
-	if text == "" {
-		return 0, false
-	}
-
-	parts := strings.SplitN(text, "+", 2)
-	base := atoiOrNeg(parts[0])
-	if base < 0 {
-		return 0, false
-	}
-
-	extra := 0
-	if len(parts) == 2 {
-		extra = max(0, atoiOrNeg(parts[1]))
-	}
-
-	return base*100 + extra, true
-}
-
-func atoiOrNeg(s string) int {
-	value := 0
-	if _, err := fmt.Sscanf(strings.TrimSpace(s), "%d", &value); err != nil {
-		return -1
-	}
-	return value
 }
 
 func substitutionPlayers(text string) (string, string) {
@@ -541,8 +516,11 @@ func headerEventRows(events []site.MatchEvent) []scorerLine {
 	firstSecondHalfKey := 0
 	hasSecondHalfEvent := false
 	for _, event := range ordered {
-		key, ok := minuteSortKey(event.MinuteText)
-		if !ok || key <= 4599 {
+		if !event.HasMinute {
+			continue
+		}
+		key := event.Minute*100 + event.Stoppage
+		if key <= 4599 {
 			continue
 		}
 		firstSecondHalfKey = key
@@ -554,10 +532,10 @@ func headerEventRows(events []site.MatchEvent) []scorerLine {
 	lines := make([]scorerLine, 0, 8)
 
 	for _, event := range ordered {
-		key, ok := minuteSortKey(event.MinuteText)
-		if !ok {
+		if !event.HasMinute {
 			continue
 		}
+		key := event.Minute*100 + event.Stoppage
 		if !insertedHT && htLabel != "" && hasSecondHalfEvent && key >= firstSecondHalfKey {
 			lines = append(lines, scorerLine{label: htLabel, isDivider: true})
 			insertedHT = true
@@ -920,11 +898,11 @@ func halftimeScore(events []site.MatchEvent) string {
 	hasSecondHalf := false
 
 	for _, event := range sortedEvents(events) {
-		minute, ok := minuteSortKey(event.MinuteText)
-		if !ok {
+		if !event.HasMinute {
 			continue
 		}
-		// minuteSortKey encodes stoppage as MM*100+extra, so 45:59 is the first-half ceiling.
+		// minute encodes stoppage as MM*100+extra, so 45:59 is the first-half ceiling.
+		minute := event.Minute*100 + event.Stoppage
 		if minute <= 4599 {
 			if event.Kind == "GOAL" {
 				if event.TeamSide == "home" {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/muesli/termenv"
 )
 
+// testEvent creates a site.MatchEvent with minute fields pre-populated so tests
+// bypass the site parser boundary while still exercising minute-aware rendering.
+func testEvent(minuteText, kind, side, text string) site.MatchEvent {
+	m, s, ok := site.ParseMinute(minuteText)
+	return site.MatchEvent{
+		MinuteText: minuteText,
+		Minute:     m,
+		Stoppage:   s,
+		HasMinute:  ok,
+		Kind:       kind,
+		TeamSide:   side,
+		Text:       text,
+	}
+}
+
 func TestLeagueSketchViewShowsStandingsFixturesAndStatus(t *testing.T) {
 	m := sketchModel()
 	m.width = 120
@@ -107,17 +122,10 @@ func TestMatchDetailRemovesRedundantMetadata(t *testing.T) {
 		Competition: "PKO Bank Polski Ekstraklasa 2025/2026 - Kolejka 25",
 		Meta:        "13 marca 2026, 18:00 3542 Damian Kos",
 		Weather:     "15 C",
-		Events: []site.MatchEvent{{
-			MinuteText: "17",
-			Kind:       "GOAL",
-			TeamSide:   "home",
-			Text:       "Krzysztof Kubica 17",
-		}, {
-			MinuteText: "62",
-			Kind:       "GOAL",
-			TeamSide:   "away",
-			Text:       "Samuel Mraz 62",
-		}},
+		Events: []site.MatchEvent{
+			testEvent("17", "GOAL", "home", "Krzysztof Kubica 17"),
+			testEvent("62", "GOAL", "away", "Samuel Mraz 62"),
+		},
 		NewsTitle: "PKO BP Ekstraklasa: Bruk-Bet Termalica 1-2 Motor",
 		NewsURL:   "http://www.90minut.pl/news/example.html",
 	}
@@ -165,13 +173,13 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		AwayTeam: "Lechia Gdansk",
 		Score:    "2-1",
 		Events: []site.MatchEvent{
-			{MinuteText: "39", Kind: "GOAL", TeamSide: "home", Text: "Wdowiak 39"},
-			{MinuteText: "46", Kind: "SUB", TeamSide: "home", Text: "Igor Strzalek (86) -> Damian Nowak"},
-			{MinuteText: "46", Kind: "SUB", TeamSide: "away", Text: "O. Lesniak -> Pllana"},
-			{MinuteText: "52", Kind: "MISS", TeamSide: "away", Text: "Barkowskij 52 (nk)"},
-			{MinuteText: "60", Kind: "GOAL", TeamSide: "home", Text: "Szkurin 60"},
-			{MinuteText: "70", Kind: "GOAL", TeamSide: "away", Text: "Karol Czubak (k) 70"},
-			{MinuteText: "85", Kind: "RC", TeamSide: "away", Text: "Pllana 85"},
+			testEvent("39", "GOAL", "home", "Wdowiak 39"),
+			testEvent("46", "SUB", "home", "Igor Strzalek (86) -> Damian Nowak"),
+			testEvent("46", "SUB", "away", "O. Lesniak -> Pllana"),
+			testEvent("52", "MISS", "away", "Barkowskij 52 (nk)"),
+			testEvent("60", "GOAL", "home", "Szkurin 60"),
+			testEvent("70", "GOAL", "away", "Karol Czubak (k) 70"),
+			testEvent("85", "RC", "away", "Pllana 85"),
 		},
 		HomeLineup: []site.PlayerLine{
 			{Name: "Wdowiak"},
@@ -354,8 +362,8 @@ func TestMatchDetailKeepsSubstitutionsOnlyInLineups(t *testing.T) {
 		AwayTeam: "Radomiak Radom",
 		Score:    "3-1",
 		Events: []site.MatchEvent{
-			{MinuteText: "66", Kind: "SUB", TeamSide: "home", Text: "Jason Lokilo -> Oskar Lesniak"},
-			{MinuteText: "46", Kind: "SUB", TeamSide: "away", Text: "J. Wilson-Esbrand -> J. Grzesik"},
+			testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
+			testEvent("46", "SUB", "away", "J. Wilson-Esbrand -> J. Grzesik"),
 		},
 		HomeLineup: []site.PlayerLine{{Name: "Jason Lokilo"}},
 		AwayLineup: []site.PlayerLine{{Name: "J. Wilson-Esbrand"}},
@@ -436,8 +444,8 @@ func TestMatchDividerFillsCenterPaddingWithDashes(t *testing.T) {
 
 func TestHeaderEventRowsMinuteInCenterColumn(t *testing.T) {
 	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "17", Kind: "GOAL", TeamSide: "home", Text: "Krzysztof Kubica 17"},
-		{MinuteText: "30", Kind: "GOAL", TeamSide: "away", Text: "Karol Czubak (k) 30"},
+		testEvent("17", "GOAL", "home", "Krzysztof Kubica 17"),
+		testEvent("30", "GOAL", "away", "Karol Czubak (k) 30"),
 	})
 	// Two goal rows only (no HT divider — all events in same half)
 	if len(rows) != 2 {
@@ -473,9 +481,9 @@ func TestHeaderEventRowsMinuteInCenterColumn(t *testing.T) {
 
 func TestHeaderEventRowsIncludesRedCardsAndHTDivider(t *testing.T) {
 	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "39", Kind: "GOAL", TeamSide: "home", Text: "Wdowiak 39"},
-		{MinuteText: "60", Kind: "GOAL", TeamSide: "home", Text: "Szkurin 60"},
-		{MinuteText: "85", Kind: "RC", TeamSide: "away", Text: "Pllana 85"},
+		testEvent("39", "GOAL", "home", "Wdowiak 39"),
+		testEvent("60", "GOAL", "home", "Szkurin 60"),
+		testEvent("85", "RC", "away", "Pllana 85"),
 	})
 	// Expect: goal (39'), HT divider, goal (60'), red card (85')
 	if len(rows) != 4 {
@@ -503,7 +511,7 @@ func TestHeaderEventRowsIncludesRedCardsAndHTDivider(t *testing.T) {
 
 func TestHeaderEventRowsIncludesGoallessHTDividerBeforeSecondHalfEvents(t *testing.T) {
 	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "60", Kind: "RC", TeamSide: "away", Text: "Pllana 60"},
+		testEvent("60", "RC", "away", "Pllana 60"),
 	})
 
 	if len(rows) != 2 {
@@ -522,9 +530,9 @@ func TestHeaderEventRowsIncludesGoallessHTDividerBeforeSecondHalfEvents(t *testi
 
 func TestHeaderEventRowsKeepsHTDividerWhenSecondHalfHasOnlyHiddenEvents(t *testing.T) {
 	rows := headerEventRows([]site.MatchEvent{
-		{MinuteText: "39", Kind: "GOAL", TeamSide: "home", Text: "Wdowiak 39"},
-		{MinuteText: "60", Kind: "SUB", TeamSide: "home", Text: "Igor Strzalek -> Damian Nowak"},
-		{MinuteText: "72", Kind: "YC", TeamSide: "away", Text: "Pllana 72"},
+		testEvent("39", "GOAL", "home", "Wdowiak 39"),
+		testEvent("60", "SUB", "home", "Igor Strzalek -> Damian Nowak"),
+		testEvent("72", "YC", "away", "Pllana 72"),
 	})
 
 	if len(rows) != 2 {
@@ -547,8 +555,8 @@ func TestRenderPlayerLineAbbreviatesNameAndDropsEvents(t *testing.T) {
 
 func TestCardAnnotationPrefersRedCardOverEarlierYellow(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		{MinuteText: "20", Kind: "YC", TeamSide: "home", Text: "Pllana 20"},
-		{MinuteText: "85", Kind: "RC", TeamSide: "home", Text: "Pllana 85"},
+		testEvent("20", "YC", "home", "Pllana 20"),
+		testEvent("85", "RC", "home", "Pllana 85"),
 	}, "home")
 
 	if got := cardAnnotation(site.PlayerLine{Name: "Pllana"}, idx); got != eventPrefix("RC") {
@@ -557,12 +565,9 @@ func TestCardAnnotationPrefersRedCardOverEarlierYellow(t *testing.T) {
 }
 
 func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "60",
-		Kind:       "SUB",
-		TeamSide:   "home",
-		Text:       "Jan Kowalski -> Piotr Kowalski",
-	}}, "home")
+	idx := playerEventIndex([]site.MatchEvent{
+		testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
+	}, "home")
 
 	players := []site.PlayerLine{
 		{Name: "Adam Kowalski"},
@@ -589,12 +594,9 @@ func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testin
 }
 
 func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "60",
-		Kind:       "SUB",
-		TeamSide:   "home",
-		Text:       "Jan Kowalski -> Piotr Kowalski",
-	}}, "home")
+	idx := playerEventIndex([]site.MatchEvent{
+		testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
+	}, "home")
 
 	players := []site.PlayerLine{
 		{Name: "Jerzy Kowalski"},
@@ -616,8 +618,8 @@ func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 
 func TestAnnotatedLineupAddsMissingEntrantWhenTheyHaveCardEvent(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		{MinuteText: "66", Kind: "SUB", TeamSide: "home", Text: "Jason Lokilo -> Oskar Lesniak"},
-		{MinuteText: "84", Kind: "YC", TeamSide: "home", Text: "Oskar Lesniak 84"},
+		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
+		testEvent("84", "YC", "home", "Oskar Lesniak 84"),
 	}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
@@ -636,12 +638,9 @@ func TestAnnotatedLineupAddsMissingEntrantWhenTheyHaveCardEvent(t *testing.T) {
 }
 
 func TestAnnotatedLineupSkipsMissingEntrantWithoutBadgeEvent(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "66",
-		Kind:       "SUB",
-		TeamSide:   "home",
-		Text:       "Jason Lokilo -> Oskar Lesniak",
-	}}, "home")
+	idx := playerEventIndex([]site.MatchEvent{
+		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
+	}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
 	if len(got) != 1 {
@@ -654,9 +653,9 @@ func TestAnnotatedLineupSkipsMissingEntrantWithoutBadgeEvent(t *testing.T) {
 
 func TestAnnotatedLineupSyntheticEntrantKeepsLaterSubstitutionOff(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		{MinuteText: "66", Kind: "SUB", TeamSide: "home", Text: "Jason Lokilo -> Oskar Lesniak"},
-		{MinuteText: "78", Kind: "SUB", TeamSide: "home", Text: "Oskar Lesniak -> Michal Smith"},
-		{MinuteText: "72", Kind: "YC", TeamSide: "home", Text: "Oskar Lesniak 72"},
+		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
+		testEvent("78", "SUB", "home", "Oskar Lesniak -> Michal Smith"),
+		testEvent("72", "YC", "home", "Oskar Lesniak 72"),
 	}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
@@ -746,8 +745,8 @@ func TestMatchDetailContentShowsFTDividerWithoutVisibleHeaderEvents(t *testing.T
 		AwayTeam: "Zaglebie Lubin",
 		Score:    "1-0",
 		Events: []site.MatchEvent{
-			{MinuteText: "46", Kind: "SUB", TeamSide: "home", Text: "Jan Kowalski -> Piotr Kowalski"},
-			{MinuteText: "72", Kind: "YC", TeamSide: "away", Text: "Nowak 72"},
+			testEvent("46", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
+			testEvent("72", "YC", "away", "Nowak 72"),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Store parsed match minute components on `site.MatchEvent` while keeping `MinuteText` for display.
- Move event sorting, halftime, and timeline placement onto structured minute fields instead of reparsing display text in UI helpers.
- Cover stoppage-time parsing, parser-populated event minutes, and minute-aware UI test fixtures.

Closes #29.

## Review

- Ran an internal review pass on the resolved branch.
- Fixed the found issue where lineup-derived stoppage-time substitutions like `90+2` could be parsed as minute `2`.

## Testing

- `go test ./...`
