### PR TITLE
Remove confirmed cleanup noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terminal UI for browsing `90minut.pl` (Polish football archive) without an API.
 ## Current Features
 
 - Season/competition popup selector from `archsezon.php`, including submenu navigation for III liga, regional leagues, and regional cups.
-- Standings plus round/fixture browsing for the selected league, with rounds normalized by round number and fixtures within each round ordered by parsed match date.
+- Standings plus round/fixture browsing for the selected league, with rounds normalized by round number, fixture-derived round date spans when parseable, and fixtures within each round ordered by parsed match date.
 - Linkless fixture support for competitions where results exist without match pages; those fixtures stay browsable in standings/round context and surface an unavailable-details state instead of opening match view.
 - Match details view with:
   - centered score line with scorer rows anchored to a shared minute column

--- a/internal/site/client.go
+++ b/internal/site/client.go
@@ -45,6 +45,8 @@ func (c *Client) Resolve(raw string) string {
 	return c.baseURL.ResolveReference(u).String()
 }
 
+// Document resolves rawURL, sends the project User-Agent, decodes legacy HTML charsets,
+// and reports request, transport, status, body-read, and parse failures with URL context.
 func (c *Client) Document(ctx context.Context, rawURL string) (*goquery.Document, error) {
 	absoluteURL := c.Resolve(rawURL)
 

--- a/internal/site/client_test.go
+++ b/internal/site/client_test.go
@@ -1,0 +1,122 @@
+package site
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
+func TestClientDocumentReportsRequestBuildFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: http.DefaultClient}
+
+	_, err = client.Document(context.Background(), "http://[::1")
+	if err == nil || !strings.Contains(err.Error(), "build request") {
+		t.Fatalf("expected request-build error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsFetchFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{
+		baseURL: base,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network down")
+		})},
+	}
+
+	_, err = client.Document(context.Background(), BaseURL)
+	if err == nil || !strings.Contains(err.Error(), "fetch") {
+		t.Fatalf("expected fetch error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsUnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client()}
+
+	_, err = client.Document(context.Background(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "unexpected status 404") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsBodyReadFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{
+		baseURL: base,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       failingReadCloser{},
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	_, err = client.Document(context.Background(), BaseURL)
+	if err == nil || !strings.Contains(err.Error(), "read") {
+		t.Fatalf("expected body-read error, got %v", err)
+	}
+}
+
+func TestClientDocumentSendsUserAgent(t *testing.T) {
+	var userAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.UserAgent()
+		_, _ = io.WriteString(w, `<html><body>ok</body></html>`)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client()}
+
+	if _, err := client.Document(context.Background(), server.URL); err != nil {
+		t.Fatalf("expected document load to succeed, got %v", err)
+	}
+	if !strings.HasPrefix(userAgent, "90minuTUI/") {
+		t.Fatalf("unexpected user agent: %q", userAgent)
+	}
+}

--- a/internal/site/parser_archive_test.go
+++ b/internal/site/parser_archive_test.go
@@ -331,3 +331,11 @@ func TestParseCompetitionMenuForFutsalTierPage(t *testing.T) {
 		t.Fatalf("unexpected second futsal tier item: %+v", menu.Items[1])
 	}
 }
+
+func womenTierMenuURL(archiveURL, key string) string {
+	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[0])
+}
+
+func futsalTierMenuURL(archiveURL, key string) string {
+	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[1])
+}

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -48,6 +48,9 @@ func NewService() *Service {
 	return &Service{client: NewClient()}
 }
 
+// LoadArchive returns parsed seasons, the selected season index, and top-level competitions.
+// Empty archive pages return nil results and -1; pages with seasons but no competitions
+// return the parsed season context with an error so callers can surface partial state.
 func (s *Service) LoadArchive(ctx context.Context, archiveURL string) ([]Season, int, []Competition, error) {
 	doc, err := s.client.Document(ctx, archiveURL)
 	if err != nil {
@@ -128,6 +131,8 @@ func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage
 	return league, nil
 }
 
+// LoadMatch returns a parsed match page. Fetch/parse failures return nil; validation failures
+// may return a partial page with stable URL/title/ID fields alongside the error.
 func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, error) {
 	doc, err := s.client.Document(ctx, matchURL)
 	if err != nil {

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -402,14 +402,6 @@ func archiveCompetitionMenuFromURL(raw string, spec archiveGroupSpec) string {
 	return strings.TrimSpace(values.Get(spec.fragmentKey))
 }
 
-func womenTierMenuURL(archiveURL, key string) string {
-	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[0])
-}
-
-func futsalTierMenuURL(archiveURL, key string) string {
-	return archiveCompetitionMenuURL(archiveURL, key, archiveGroupSpecs[1])
-}
-
 func parseIIIligaMenu(doc *goquery.Document, resolvedURL string, c *Client) *CompetitionMenu {
 	title := competitionMenuTitle(doc, "III liga")
 	items := make([]Competition, 0, 4)

--- a/internal/site/service_test.go
+++ b/internal/site/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -98,4 +99,130 @@ func TestLoadCompetitionLoadsRegionalCupsMenu(t *testing.T) {
 		return
 	}
 	t.Fatalf("expected submenu load to succeed, got %v", err)
+}
+
+func TestServiceLoadArchiveReportsEmptyArchive(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body>empty</body></html>`)
+
+	seasons, selectedIdx, competitions, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "archive parse: no seasons found") {
+		t.Fatalf("expected no-seasons error, got %v", err)
+	}
+	if seasons != nil || selectedIdx != -1 || competitions != nil {
+		t.Fatalf("expected empty archive result on parse failure, got seasons=%v selected=%d competitions=%v", seasons, selectedIdx, competitions)
+	}
+}
+
+func TestServiceLoadArchivePropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "network down")
+
+	_, _, _, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected propagated archive client error, got %v", err)
+	}
+}
+
+func TestServiceLoadArchiveReportsMissingCompetitions(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body><select name="urljump"><option selected value="/archsezon.php?id_sezon=107">2025/26</option></select></body></html>`)
+
+	seasons, selectedIdx, competitions, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "archive parse: no league links found") {
+		t.Fatalf("expected no-competitions error, got %v", err)
+	}
+	if len(seasons) != 1 || selectedIdx != 0 || competitions != nil {
+		t.Fatalf("expected partial archive result, got seasons=%v selected=%d competitions=%v", seasons, selectedIdx, competitions)
+	}
+}
+
+func TestServiceLoadCompetitionReportsUnclassifiedPage(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body>not a supported competition page</body></html>`)
+
+	menu, league, err := svc.LoadCompetition(context.Background(), "/misc.html")
+	if err == nil || !strings.Contains(err.Error(), "competition parse: no submenu or fixtures found") {
+		t.Fatalf("expected unclassified competition error, got %v", err)
+	}
+	if menu != nil || league != nil {
+		t.Fatalf("expected no competition result, got menu=%v league=%v", menu, league)
+	}
+}
+
+func TestServiceLoadCompetitionPropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "competition fetch failed")
+
+	menu, league, err := svc.LoadCompetition(context.Background(), "/liga/1/liga1.html")
+	if err == nil || !strings.Contains(err.Error(), "competition fetch failed") {
+		t.Fatalf("expected propagated competition client error, got %v", err)
+	}
+	if menu != nil || league != nil {
+		t.Fatalf("expected no competition result, got menu=%v league=%v", menu, league)
+	}
+}
+
+func TestServiceLoadLeagueReportsSubmenu(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body><table class="main"><tr><td valign="top"><p align="center"><b>Puchary krajowe 2025/26</b></p><a href="/liga/1/liga14076.html" class="main">Puchar Polski</a><a href="/liga/1/liga14636.html" class="main">Puchar Polski 2025/2026, grupa: Lubuski ZPN</a><a href="/liga/1/liga14069.html" class="main">Puchar Polski 2025/2026, grupa: Lubuski ZPN - Gorzów Wielkopolski</a></td></tr></table></body></html>`)
+
+	league, err := svc.LoadLeague(context.Background(), "/polcups.php?id_sezon=107")
+	if err == nil || !strings.Contains(err.Error(), "league parse: competition is a submenu") {
+		t.Fatalf("expected submenu error, got %v", err)
+	}
+	if league != nil {
+		t.Fatalf("expected no league result, got %+v", league)
+	}
+}
+
+func TestServiceLoadMatchReportsMissingDetails(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><head><title>Broken match</title></head><body>not a match page</body></html>`)
+
+	match, err := svc.LoadMatch(context.Background(), "/mecz.php?id_mecz=1")
+	if err == nil || !strings.Contains(err.Error(), "match parse: missing teams and score") {
+		t.Fatalf("expected missing-details error, got %v", err)
+	}
+	if match == nil || match.Title != "Broken match" || !strings.HasSuffix(match.URL, "/mecz.php?id_mecz=1") || match.MatchID != "1" {
+		t.Fatalf("expected populated partial match result on validation failure, got %+v", match)
+	}
+}
+
+func TestServiceLoadMatchPropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "match fetch failed")
+
+	match, err := svc.LoadMatch(context.Background(), "/mecz.php?id_mecz=1")
+	if err == nil || !strings.Contains(err.Error(), "match fetch failed") {
+		t.Fatalf("expected propagated match client error, got %v", err)
+	}
+	if match != nil {
+		t.Fatalf("expected no match result, got %+v", match)
+	}
+}
+
+func serviceWithHTML(t *testing.T, body string) *Service {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	return &Service{client: &Client{baseURL: baseURL, http: server.Client()}}
+}
+
+func serviceWithClientError(t *testing.T, message string) *Service {
+	t.Helper()
+
+	baseURL, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+
+	return &Service{client: &Client{
+		baseURL: baseURL,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("%s", message)
+		})},
+	}}
 }

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -40,15 +40,6 @@ func (m Model) loadCompetitionCmd(url, competitionKey string) tea.Cmd {
 	}
 }
 
-func (m Model) loadLeagueCmd(url, competitionKey string) tea.Cmd {
-	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
-		defer cancel()
-		league, err := m.service.LoadLeague(ctx, url)
-		return leagueLoadedMsg{competitionKey: competitionKey, league: league, err: err}
-	}
-}
-
 func (m Model) loadMatchCmd(url, fixtureKey string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -55,12 +55,6 @@ type competitionMenuState struct {
 	cursor int
 }
 
-type leagueLoadedMsg struct {
-	competitionKey string
-	league         *site.LeaguePage
-	err            error
-}
-
 type matchLoadedMsg struct {
 	fixtureKey string
 	match      *site.MatchPage

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -1146,6 +1146,77 @@ func displayRoundLabel(name string, fallback int) string {
 	return translatePolishDateText(cleaned)
 }
 
+func displayRoundLabelWithFixtures(name string, fallback int, fixtures []site.Fixture, leagueTitle string) string {
+	label := displayRoundLabel(name, fallback)
+	span := roundFixtureDateSpan(fixtures, leagueTitle)
+	if span == "" || !strings.HasPrefix(label, "Round ") {
+		return label
+	}
+
+	roundPart, _, ok := strings.Cut(label, " - ")
+	if !ok {
+		roundPart = label
+	}
+	return roundPart + " - " + span
+}
+
+func roundFixtureDateSpan(fixtures []site.Fixture, leagueTitle string) string {
+	var first time.Time
+	var last time.Time
+	for _, fixture := range fixtures {
+		date, ok := fixtureDisplayDate(fixture.WhenInfo, leagueTitle)
+		if !ok {
+			continue
+		}
+		if first.IsZero() || date.Before(first) {
+			first = date
+		}
+		if last.IsZero() || date.After(last) {
+			last = date
+		}
+	}
+
+	if first.IsZero() {
+		return ""
+	}
+	if sameCalendarDate(first, last) {
+		return first.Format("Jan 2")
+	}
+	if first.Year() == last.Year() && first.Month() == last.Month() {
+		return fmt.Sprintf("%s-%d", first.Format("Jan 2"), last.Day())
+	}
+	return fmt.Sprintf("%s-%s", first.Format("Jan 2"), last.Format("Jan 2"))
+}
+
+func fixtureDisplayDate(value, leagueTitle string) (time.Time, bool) {
+	cleaned := normalizeDisplayText(value)
+	matches := fixtureDateTimeRe.FindStringSubmatch(cleaned)
+	if len(matches) != 5 {
+		return time.Time{}, false
+	}
+
+	month := polishMonthNumber(matches[2])
+	if month == "" {
+		return time.Time{}, false
+	}
+
+	day := atoiOrNeg(matches[1])
+	monthNum := atoiOrNeg(month)
+	year := atoiOrNeg(matches[3])
+	if year < 0 {
+		year = inferFixtureYear(monthNum, leagueTitle)
+	}
+	if day <= 0 || monthNum <= 0 || year <= 0 {
+		return time.Time{}, false
+	}
+
+	return time.Date(year, time.Month(monthNum), day, 0, 0, 0, 0, time.Local), true
+}
+
+func sameCalendarDate(a, b time.Time) bool {
+	return a.Year() == b.Year() && a.Month() == b.Month() && a.Day() == b.Day()
+}
+
 func trimEventMinute(event site.MatchEvent) string {
 	text := eventPlayerText(event)
 	return formatPlayerLabel(text)

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -1330,6 +1330,7 @@ func inferFixtureYear(month int, leagueTitle string) int {
 			endYear += 100
 		}
 	}
+	// 90minut often omits fixture years; Jul-Dec belongs to the season start, Jan-Jun to the season end.
 	if month >= 7 {
 		return startYear
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -190,29 +190,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.closeSelector()
 		return m, nil
 
-	case leagueLoadedMsg:
-		m.loading = false
-		if msg.err != nil {
-			m.err = msg.err.Error()
-			return m, nil
-		}
-
-		competition := m.currentCompetition()
-		// Drop stale async results after the selected competition changes.
-		if competition == nil || msg.competitionKey != competitionRequestKey(*competition) {
-			return m, nil
-		}
-
-		m.err = ""
-		m.lastFetchAt = time.Now()
-		m.matchView = false
-		m.match = nil
-		m.matchScroll = 0
-		m.league = msg.league
-		m.roundCursor, m.fixtureCursor = m.initialFixtureSelection()
-		m.closeSelector()
-		return m, nil
-
 	case matchLoadedMsg:
 		m.loading = false
 		if msg.err != nil {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -54,7 +54,7 @@ func (m Model) topBarView() string {
 
 	right := ""
 	if round := m.currentRound(); round != nil {
-		right = topBarRoundMeta(round.Name, m.roundCursor+1, len(m.league.Rounds))
+		right = topBarRoundMeta(*round, m.roundCursor+1, len(m.league.Rounds), m.league.Title)
 	}
 
 	return renderFullLine(barLine(label, right, m.width), m.width, colorBgHeader, colorTextPrimary, true)
@@ -78,8 +78,8 @@ func barLine(left, right string, width int) string {
 	return " " + leftText + strings.Repeat(" ", gap) + right + " "
 }
 
-func topBarRoundMeta(roundName string, roundIdx, total int) string {
-	label := displayRoundLabel(roundName, roundIdx)
+func topBarRoundMeta(round site.Round, roundIdx, total int, leagueTitle string) string {
+	label := displayRoundLabelWithFixtures(round.Name, roundIdx, round.Fixtures, leagueTitle)
 	roundPart, datePart, ok := strings.Cut(label, " - ")
 	if !ok || strings.TrimSpace(datePart) == "" {
 		return fmt.Sprintf("%s / %d", label, total)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -93,7 +93,7 @@ func (m Model) selectorSketchView() string {
 		return m.selectorOverlayView(m.leagueFixturesPaneViewStyled(rightWidth, true))
 	}
 
-	standings := m.standingsPaneView(leftWidth)
+	standings := m.standingsPaneViewBounded(leftWidth)
 	divider := m.verticalDivider()
 	fixtures := m.leagueFixturesPaneViewStyled(rightWidth, true)
 	body := lipgloss.JoinHorizontal(lipgloss.Top, standings, divider, fixtures)
@@ -297,7 +297,7 @@ func (m Model) leagueSketchView() string {
 		return fixtures
 	}
 
-	standings := m.standingsPaneView(leftWidth)
+	standings := m.standingsPaneViewBounded(leftWidth)
 	divider := m.verticalDivider()
 	return lipgloss.JoinHorizontal(lipgloss.Top, standings, divider, fixtures)
 }
@@ -312,10 +312,6 @@ func (m Model) verticalDivider() string {
 		parts[i] = lipgloss.NewStyle().Foreground(colorBorder).Background(colorBg).Render("│")
 	}
 	return strings.Join(parts, "\n")
-}
-
-func (m Model) standingsPaneView(width int) string {
-	return m.standingsPaneViewBounded(width)
 }
 
 func (m Model) standingsPaneViewBounded(width int) string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -423,6 +423,50 @@ func TestHomeBookedReplacementDoesNotUseStarterCardSlot(t *testing.T) {
 	}
 }
 
+func TestMatchDetailDoesNotMisattributeAmbiguousAbbreviatedSubstitution(t *testing.T) {
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Home",
+		AwayTeam: "Away",
+		Score:    "0-0",
+		Events: []site.MatchEvent{
+			testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Nowak"),
+			testEvent("75", "SUB", "home", "J. Kowalski -> Adam Zielinski"),
+		},
+		HomeLineup: []site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}},
+	}
+
+	lineups := matchLineupSection(t, m.matchDetailContent(100))
+	assertAmbiguousKowalskisRendered(t, lineups)
+	for _, unwanted := range []string{"P. Nowak", "A. Zielinski", "60'", "75'"} {
+		if strings.Contains(lineups, unwanted) {
+			t.Fatalf("expected ambiguous substitution not to annotate lineup with %q\n%s", unwanted, lineups)
+		}
+	}
+}
+
+func TestMatchDetailDoesNotAttachAmbiguousReplacementCardToLineup(t *testing.T) {
+	m := sketchModel()
+	m.match = &site.MatchPage{
+		HomeTeam: "Home",
+		AwayTeam: "Away",
+		Score:    "0-0",
+		Events: []site.MatchEvent{
+			testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Nowak"),
+			testEvent("70", "YC", "home", "Piotr Nowak 70"),
+		},
+		HomeLineup: []site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}},
+	}
+
+	lineups := matchLineupSection(t, m.matchDetailContent(100))
+	assertAmbiguousKowalskisRendered(t, lineups)
+	for _, unwanted := range []string{"P. Nowak", "60'", "■"} {
+		if strings.Contains(lineups, unwanted) {
+			t.Fatalf("expected ambiguous replacement card to stay out of lineup section as %q\n%s", unwanted, lineups)
+		}
+	}
+}
+
 func TestHalftimeScoreDisplayAvoidsInventingSparseHT(t *testing.T) {
 	if got := halftimeScoreDisplay(&site.MatchPage{Score: "1-0"}); got != "HT —" {
 		t.Fatalf("expected sparse match to avoid invented HT score, got %q", got)
@@ -548,6 +592,29 @@ func TestMatchDetailKeepsInlineSubstitutionAnnotationsInLineups(t *testing.T) {
 			t.Fatalf("expected lineup to contain %q\n%s", want, view)
 		}
 	}
+}
+
+func matchLineupSection(t *testing.T, content string) string {
+	t.Helper()
+
+	plain := ansi.Strip(content)
+	lineupIdx := strings.Index(plain, "LINEUPS")
+	if lineupIdx < 0 {
+		t.Fatalf("expected lineup section\n%s", plain)
+	}
+	return plain[lineupIdx:]
+}
+
+func assertAmbiguousKowalskisRendered(t *testing.T, lineups string) {
+	t.Helper()
+
+	if strings.Contains(lineups, "Jan Kowalski") && strings.Contains(lineups, "Jerzy Kowalski") {
+		return
+	}
+	if strings.Count(lineups, "J. Kowalski") == 2 {
+		return
+	}
+	t.Fatalf("expected both ambiguous players to remain rendered\n%s", lineups)
 }
 
 func TestFormatMatchMinuteLeftPadsSingleDigitMinute(t *testing.T) {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -75,6 +75,101 @@ func TestLeagueViewUsesTwoLineTopBar(t *testing.T) {
 	}
 }
 
+func TestTopBarRoundMetaShowsFixtureDateSpan(t *testing.T) {
+	round := site.Round{
+		Name: "1. kolejka - 4 kwietnia",
+		Fixtures: []site.Fixture{
+			{Home: "E", Away: "F", WhenInfo: "8 kwietnia, 20:15"},
+			{Home: "A", Away: "B", WhenInfo: "4 kwietnia, 18:00"},
+			{Home: "C", Away: "D", WhenInfo: "6 kwietnia, 12:30"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 1, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 1 · Apr 4-8 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestTopBarRoundMetaShowsSingleFixtureDate(t *testing.T) {
+	round := site.Round{
+		Name: "2. kolejka - 10 maja",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "10 maja, 18:00"},
+			{Home: "C", Away: "D", WhenInfo: "10 maja, 20:30"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 2, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 2 · May 10 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestTopBarRoundMetaShowsCrossMonthFixtureDateSpan(t *testing.T) {
+	round := site.Round{
+		Name: "3. kolejka - 30 kwietnia",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "2 maja, 12:00"},
+			{Home: "C", Away: "D", WhenInfo: "30 kwietnia, 18:00"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 3, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 3 · Apr 30-May 2 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestTopBarRoundMetaShowsCrossYearFixtureDateSpan(t *testing.T) {
+	round := site.Round{
+		Name: "4. kolejka - 31 grudnia",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "2 stycznia 2026, 12:00"},
+			{Home: "C", Away: "D", WhenInfo: "31 grudnia 2025, 18:00"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 4, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 4 · Dec 31-Jan 2 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestTopBarRoundMetaKeepsRoundLabelWhenFixtureDatesAreUnavailable(t *testing.T) {
+	round := site.Round{
+		Name: "5. kolejka - 12 czerwca",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "walkower"},
+			{Home: "C", Away: "D"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 5, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 5 · 12 June / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestViewTopBarUsesFixtureDateSpan(t *testing.T) {
+	m := sketchModel()
+	m.width = 120
+	m.height = 18
+	m.league.Title = "PKO Bank Polski Ekstraklasa 2025/2026"
+	m.league.Rounds[0] = site.Round{
+		Name: "1. kolejka - 4 kwietnia",
+		Fixtures: []site.Fixture{
+			{Home: "Legia Warszawa", Away: "Lech Poznan", Score: "2-1", WhenInfo: "4 kwietnia, 18:00"},
+			{Home: "Rakow Czestochowa", Away: "Pogon Szczecin", Score: "1-1", WhenInfo: "8 kwietnia, 20:15"},
+		},
+	}
+
+	topLine := ansi.Strip(strings.Split(m.View(), "\n")[0])
+	if !strings.Contains(topLine, "Round 1 · Apr 4-8 / 1") {
+		t.Fatalf("expected fixture-derived round span in top bar, got %q", topLine)
+	}
+}
+
 func TestStartupViewDoesNotFlashSelectorPopup(t *testing.T) {
 	m := NewModel(nil)
 	m.width = 120


### PR DESCRIPTION
## Summary

- Remove the dead direct league-loading command/message path.
- Collapse a one-line standings view wrapper.
- Move women/futsal tier URL helpers out of production code into archive parser tests.

Closes #62

## Verification

- `go test ./...`
- `go vet ./...`
