### PR TITLE
Add service loader error tests

### DIFF
--- a/internal/site/client.go
+++ b/internal/site/client.go
@@ -45,6 +45,8 @@ func (c *Client) Resolve(raw string) string {
 	return c.baseURL.ResolveReference(u).String()
 }
 
+// Document resolves rawURL, sends the project User-Agent, decodes legacy HTML charsets,
+// and reports request, transport, status, body-read, and parse failures with URL context.
 func (c *Client) Document(ctx context.Context, rawURL string) (*goquery.Document, error) {
 	absoluteURL := c.Resolve(rawURL)
 

--- a/internal/site/client_test.go
+++ b/internal/site/client_test.go
@@ -1,0 +1,122 @@
+package site
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
+func TestClientDocumentReportsRequestBuildFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: http.DefaultClient}
+
+	_, err = client.Document(context.Background(), "http://[::1")
+	if err == nil || !strings.Contains(err.Error(), "build request") {
+		t.Fatalf("expected request-build error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsFetchFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{
+		baseURL: base,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network down")
+		})},
+	}
+
+	_, err = client.Document(context.Background(), BaseURL)
+	if err == nil || !strings.Contains(err.Error(), "fetch") {
+		t.Fatalf("expected fetch error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsUnexpectedStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client()}
+
+	_, err = client.Document(context.Background(), server.URL)
+	if err == nil || !strings.Contains(err.Error(), "unexpected status 404") {
+		t.Fatalf("expected status error, got %v", err)
+	}
+}
+
+func TestClientDocumentReportsBodyReadFailure(t *testing.T) {
+	base, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+	client := &Client{
+		baseURL: base,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				Status:     "200 OK",
+				StatusCode: http.StatusOK,
+				Body:       failingReadCloser{},
+				Header:     make(http.Header),
+			}, nil
+		})},
+	}
+
+	_, err = client.Document(context.Background(), BaseURL)
+	if err == nil || !strings.Contains(err.Error(), "read") {
+		t.Fatalf("expected body-read error, got %v", err)
+	}
+}
+
+func TestClientDocumentSendsUserAgent(t *testing.T) {
+	var userAgent string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent = r.UserAgent()
+		_, _ = io.WriteString(w, `<html><body>ok</body></html>`)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client()}
+
+	if _, err := client.Document(context.Background(), server.URL); err != nil {
+		t.Fatalf("expected document load to succeed, got %v", err)
+	}
+	if !strings.HasPrefix(userAgent, "90minuTUI/") {
+		t.Fatalf("unexpected user agent: %q", userAgent)
+	}
+}

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -48,6 +48,9 @@ func NewService() *Service {
 	return &Service{client: NewClient()}
 }
 
+// LoadArchive returns parsed seasons, the selected season index, and top-level competitions.
+// Empty archive pages return nil results and -1; pages with seasons but no competitions
+// return the parsed season context with an error so callers can surface partial state.
 func (s *Service) LoadArchive(ctx context.Context, archiveURL string) ([]Season, int, []Competition, error) {
 	doc, err := s.client.Document(ctx, archiveURL)
 	if err != nil {
@@ -128,6 +131,8 @@ func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage
 	return league, nil
 }
 
+// LoadMatch returns a parsed match page. Fetch/parse failures return nil; validation failures
+// may return a partial page with stable URL/title/ID fields alongside the error.
 func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, error) {
 	doc, err := s.client.Document(ctx, matchURL)
 	if err != nil {

--- a/internal/site/service_test.go
+++ b/internal/site/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -98,4 +99,130 @@ func TestLoadCompetitionLoadsRegionalCupsMenu(t *testing.T) {
 		return
 	}
 	t.Fatalf("expected submenu load to succeed, got %v", err)
+}
+
+func TestServiceLoadArchiveReportsEmptyArchive(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body>empty</body></html>`)
+
+	seasons, selectedIdx, competitions, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "archive parse: no seasons found") {
+		t.Fatalf("expected no-seasons error, got %v", err)
+	}
+	if seasons != nil || selectedIdx != -1 || competitions != nil {
+		t.Fatalf("expected empty archive result on parse failure, got seasons=%v selected=%d competitions=%v", seasons, selectedIdx, competitions)
+	}
+}
+
+func TestServiceLoadArchivePropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "network down")
+
+	_, _, _, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "network down") {
+		t.Fatalf("expected propagated archive client error, got %v", err)
+	}
+}
+
+func TestServiceLoadArchiveReportsMissingCompetitions(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body><select name="urljump"><option selected value="/archsezon.php?id_sezon=107">2025/26</option></select></body></html>`)
+
+	seasons, selectedIdx, competitions, err := svc.LoadArchive(context.Background(), "/archsezon.php")
+	if err == nil || !strings.Contains(err.Error(), "archive parse: no league links found") {
+		t.Fatalf("expected no-competitions error, got %v", err)
+	}
+	if len(seasons) != 1 || selectedIdx != 0 || competitions != nil {
+		t.Fatalf("expected partial archive result, got seasons=%v selected=%d competitions=%v", seasons, selectedIdx, competitions)
+	}
+}
+
+func TestServiceLoadCompetitionReportsUnclassifiedPage(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body>not a supported competition page</body></html>`)
+
+	menu, league, err := svc.LoadCompetition(context.Background(), "/misc.html")
+	if err == nil || !strings.Contains(err.Error(), "competition parse: no submenu or fixtures found") {
+		t.Fatalf("expected unclassified competition error, got %v", err)
+	}
+	if menu != nil || league != nil {
+		t.Fatalf("expected no competition result, got menu=%v league=%v", menu, league)
+	}
+}
+
+func TestServiceLoadCompetitionPropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "competition fetch failed")
+
+	menu, league, err := svc.LoadCompetition(context.Background(), "/liga/1/liga1.html")
+	if err == nil || !strings.Contains(err.Error(), "competition fetch failed") {
+		t.Fatalf("expected propagated competition client error, got %v", err)
+	}
+	if menu != nil || league != nil {
+		t.Fatalf("expected no competition result, got menu=%v league=%v", menu, league)
+	}
+}
+
+func TestServiceLoadLeagueReportsSubmenu(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><body><table class="main"><tr><td valign="top"><p align="center"><b>Puchary krajowe 2025/26</b></p><a href="/liga/1/liga14076.html" class="main">Puchar Polski</a><a href="/liga/1/liga14636.html" class="main">Puchar Polski 2025/2026, grupa: Lubuski ZPN</a><a href="/liga/1/liga14069.html" class="main">Puchar Polski 2025/2026, grupa: Lubuski ZPN - Gorzów Wielkopolski</a></td></tr></table></body></html>`)
+
+	league, err := svc.LoadLeague(context.Background(), "/polcups.php?id_sezon=107")
+	if err == nil || !strings.Contains(err.Error(), "league parse: competition is a submenu") {
+		t.Fatalf("expected submenu error, got %v", err)
+	}
+	if league != nil {
+		t.Fatalf("expected no league result, got %+v", league)
+	}
+}
+
+func TestServiceLoadMatchReportsMissingDetails(t *testing.T) {
+	svc := serviceWithHTML(t, `<html><head><title>Broken match</title></head><body>not a match page</body></html>`)
+
+	match, err := svc.LoadMatch(context.Background(), "/mecz.php?id_mecz=1")
+	if err == nil || !strings.Contains(err.Error(), "match parse: missing teams and score") {
+		t.Fatalf("expected missing-details error, got %v", err)
+	}
+	if match == nil || match.Title != "Broken match" || !strings.HasSuffix(match.URL, "/mecz.php?id_mecz=1") || match.MatchID != "1" {
+		t.Fatalf("expected populated partial match result on validation failure, got %+v", match)
+	}
+}
+
+func TestServiceLoadMatchPropagatesClientError(t *testing.T) {
+	svc := serviceWithClientError(t, "match fetch failed")
+
+	match, err := svc.LoadMatch(context.Background(), "/mecz.php?id_mecz=1")
+	if err == nil || !strings.Contains(err.Error(), "match fetch failed") {
+		t.Fatalf("expected propagated match client error, got %v", err)
+	}
+	if match != nil {
+		t.Fatalf("expected no match result, got %+v", match)
+	}
+}
+
+func serviceWithHTML(t *testing.T, body string) *Service {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = fmt.Fprint(w, body)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+
+	return &Service{client: &Client{baseURL: baseURL, http: server.Client()}}
+}
+
+func serviceWithClientError(t *testing.T, message string) *Service {
+	t.Helper()
+
+	baseURL, err := url.Parse(BaseURL)
+	if err != nil {
+		t.Fatalf("parse base URL: %v", err)
+	}
+
+	return &Service{client: &Client{
+		baseURL: baseURL,
+		http: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("%s", message)
+		})},
+	}}
 }


### PR DESCRIPTION
## Summary

- Add offline client tests for request-build, fetch, non-200 status, body-read, and User-Agent behavior.
- Add service loader tests for archive, competition, league, and match error/partial-result paths.
- Document the client and loader error contracts now covered by tests.

Closes #38

## Verification

- `go test ./...`
- `go vet ./...`
