### PR TITLE
Simplify match sidebar height allocation

### DIFF
--- a/internal/ui/view_match.go
+++ b/internal/ui/view_match.go
@@ -7,6 +7,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+const (
+	matchSidebarCompactHeight      = 12
+	matchSidebarMinPaneHeight      = 4
+	matchSidebarMinStandingsHeight = 8
+	matchSidebarMaxStandingsHeight = 11
+)
+
 func (m Model) matchSketchView() string {
 	leftWidth, centerWidth, _ := matchLayoutWidths(m.width)
 	if leftWidth == 0 {
@@ -54,19 +61,27 @@ func (m Model) matchSidebarHeights() (int, int) {
 	if fullStandings > 0 && total >= fullStandings+minFixtures {
 		return fullStandings, total - fullStandings
 	}
-
-	if total < 12 {
-		return max(4, total/2), max(0, total-max(4, total/2))
+	if total < matchSidebarCompactHeight {
+		standings := preferredMatchSidebarStandingsHeight(total)
+		return standings, max(0, total-standings)
 	}
 
-	standings := clamp(total/2, 8, 11)
+	standings := preferredMatchSidebarStandingsHeight(total)
 	fixtures := total - standings
-	if fixtures < minFixtures {
-		fixtures = minFixtures
-		standings = max(4, total-fixtures)
+	if fixtures >= minFixtures {
+		return standings, fixtures
 	}
 
+	fixtures = minFixtures
+	standings = max(matchSidebarMinPaneHeight, total-fixtures)
 	return standings, fixtures
+}
+
+func preferredMatchSidebarStandingsHeight(total int) int {
+	if total < matchSidebarCompactHeight {
+		return max(matchSidebarMinPaneHeight, total/2)
+	}
+	return clamp(total/2, matchSidebarMinStandingsHeight, matchSidebarMaxStandingsHeight)
 }
 
 func (m Model) matchFixtureRailView(width int) string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1373,6 +1373,46 @@ func TestMatchViewShowsFullStandingsWhenHeightAllows(t *testing.T) {
 	}
 }
 
+func TestMatchSidebarHeightsPreservesLayoutPolicy(t *testing.T) {
+	t.Run("full standings fit", func(t *testing.T) {
+		m := matchSidebarHeightModel(10, 2)
+
+		standings, fixtures := m.matchSidebarHeights()
+		if standings != m.standingsContentHeight() || standings+fixtures != m.bodyHeightLimit() {
+			t.Fatalf("expected full standings plus remaining fixture space, got standings=%d fixtures=%d", standings, fixtures)
+		}
+	})
+
+	for _, bodyHeight := range []int{6, matchSidebarCompactHeight - 1} {
+		t.Run(fmt.Sprintf("compact terminal %d", bodyHeight), func(t *testing.T) {
+			standings, fixtures := matchSidebarHeightModel(bodyHeight, 20).matchSidebarHeights()
+			if standings < matchSidebarMinPaneHeight || fixtures <= 0 || standings+fixtures != bodyHeight {
+				t.Fatalf("expected compact layout to keep both panes visible within height %d, got standings=%d fixtures=%d", bodyHeight, standings, fixtures)
+			}
+		})
+	}
+
+	for _, bodyHeight := range []int{matchSidebarCompactHeight, 18, 30} {
+		t.Run(fmt.Sprintf("normal terminal %d", bodyHeight), func(t *testing.T) {
+			standings, fixtures := matchSidebarHeightModel(bodyHeight, 40).matchSidebarHeights()
+			if standings < matchSidebarMinStandingsHeight || standings > matchSidebarMaxStandingsHeight || fixtures < matchSidebarMinPaneHeight || standings+fixtures != bodyHeight {
+				t.Fatalf("expected normal layout to stay bounded within height %d, got standings=%d fixtures=%d", bodyHeight, standings, fixtures)
+			}
+		})
+	}
+}
+
+func matchSidebarHeightModel(bodyHeight, standingsRows int) Model {
+	m := sketchModel()
+	m.suppressTopBar = true
+	m.height = bodyHeight + 1
+	m.league.Standings = make([]site.StandingRow, 0, standingsRows)
+	for i := 1; i <= standingsRows; i++ {
+		m.league.Standings = append(m.league.Standings, site.StandingRow{Position: i, Team: fmt.Sprintf("Team %02d", i)})
+	}
+	return m
+}
+
 func TestMatchViewScrollLimitIsClamped(t *testing.T) {
 	m := sketchModel()
 	m.width = 100


### PR DESCRIPTION
## Summary

- Replace `matchSidebarHeights` magic numbers with named layout constants.
- Extract preferred standings-height calculation while preserving the existing sidebar allocation policy.
- Add policy-oriented coverage for full-standings, compact, and normal-height sidebar layouts.

Closes #54

## Verification

- `go test ./...`
- `go vet ./...`
