### PR TITLE
Sort fixtures with season-aware dates

### DIFF
--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -23,7 +23,7 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 		return nil
 	}
 
-	page.Rounds = normalizeLeagueOrder(rounds)
+	page.Rounds = normalizeLeagueOrder(rounds, page.Title)
 	return page
 }
 

--- a/internal/site/ordering.go
+++ b/internal/site/ordering.go
@@ -9,14 +9,15 @@ import (
 
 var roundNumberRe = regexp.MustCompile(`\d+`)
 var fixtureDateRe = regexp.MustCompile(`(?i)(\d{1,2})\s+([\p{L}]+)(?:\s+(\d{4}))?(?:,\s*(\d{1,2}):(\d{2}))?`)
+var seasonYearsRe = regexp.MustCompile(`(\d{4})\s*/\s*(\d{2,4})`)
 
 // Normalize round and fixture order here so every caller sees the same league structure.
-func normalizeLeagueOrder(rounds []Round) []Round {
+func normalizeLeagueOrder(rounds []Round, leagueTitle string) []Round {
 	ordered := make([]Round, len(rounds))
 	copy(ordered, rounds)
 
 	for i := range ordered {
-		ordered[i].Fixtures = normalizeFixturesByDate(ordered[i].Fixtures)
+		ordered[i].Fixtures = normalizeFixturesByDate(ordered[i].Fixtures, leagueTitle)
 	}
 
 	type indexedRound struct {
@@ -50,7 +51,7 @@ func normalizeLeagueOrder(rounds []Round) []Round {
 	return ordered
 }
 
-func normalizeFixturesByDate(fixtures []Fixture) []Fixture {
+func normalizeFixturesByDate(fixtures []Fixture, leagueTitle string) []Fixture {
 	ordered := make([]Fixture, len(fixtures))
 	copy(ordered, fixtures)
 
@@ -66,8 +67,8 @@ func normalizeFixturesByDate(fixtures []Fixture) []Fixture {
 
 	// Sort parsable dates first; keep undated fixtures in source order at the end.
 	sort.SliceStable(indexed, func(i, j int) bool {
-		dateI, okI := fixtureDateKey(indexed[i].fixture.WhenInfo)
-		dateJ, okJ := fixtureDateKey(indexed[j].fixture.WhenInfo)
+		dateI, okI := fixtureDateKey(indexed[i].fixture.WhenInfo, leagueTitle)
+		dateJ, okJ := fixtureDateKey(indexed[j].fixture.WhenInfo, leagueTitle)
 
 		switch {
 		case okI && okJ && dateI != dateJ:
@@ -105,7 +106,7 @@ func roundNumber(name string) (int, bool) {
 	return value, true
 }
 
-func fixtureDateKey(whenInfo string) (int, bool) {
+func fixtureDateKey(whenInfo, leagueTitle string) (int, bool) {
 	matches := fixtureDateRe.FindStringSubmatch(normalizeWhitespace(whenInfo))
 	if len(matches) == 0 {
 		return 0, false
@@ -127,6 +128,9 @@ func fixtureDateKey(whenInfo string) (int, bool) {
 		if err != nil {
 			return 0, false
 		}
+	} else {
+		year = inferFixtureYear(month, leagueTitle)
+		// Title-less synthetic pages keep the old month/day ordering because no season boundary is available.
 	}
 
 	hour := 0
@@ -145,6 +149,34 @@ func fixtureDateKey(whenInfo string) (int, bool) {
 	}
 
 	return (((year*100)+month)*100+day)*10000 + hour*100 + minute, true
+}
+
+func inferFixtureYear(month int, leagueTitle string) int {
+	matches := seasonYearsRe.FindStringSubmatch(leagueTitle)
+	if len(matches) != 3 {
+		return 0
+	}
+
+	startYear, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	endYear, err := strconv.Atoi(matches[2])
+	if err != nil {
+		return 0
+	}
+	if endYear < 100 {
+		endYear += (startYear / 100) * 100
+		if endYear < startYear {
+			endYear += 100
+		}
+	}
+
+	// 90minut often omits fixture years; Jul-Dec belongs to the season start, Jan-Jun to the season end.
+	if month >= 7 {
+		return startYear
+	}
+	return endYear
 }
 
 func polishMonthIndex(value string) (int, bool) {

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -51,7 +51,7 @@ func TestParseLeagueFixturesFromCorpus(t *testing.T) {
 				if len(round.Fixtures) == 0 {
 					t.Fatalf("round %q has no fixtures in %s", round.Name, fixture.Name)
 				}
-				assertFixturesSortedByDate(t, fixture.Name, round)
+				assertFixturesSortedByDate(t, fixture.Name, page.Title, round)
 			}
 
 			totalFixtures := 0
@@ -142,7 +142,7 @@ func TestParseLeagueFixturesWithoutMatchLinksFromCorpus(t *testing.T) {
 	}
 }
 
-func assertFixturesSortedByDate(t *testing.T, fixtureName string, round Round) {
+func assertFixturesSortedByDate(t *testing.T, fixtureName, leagueTitle string, round Round) {
 	t.Helper()
 
 	lastKey := 0
@@ -151,7 +151,7 @@ func assertFixturesSortedByDate(t *testing.T, fixtureName string, round Round) {
 	seenUndated := false
 
 	for _, fixture := range round.Fixtures {
-		dateKey, ok := fixtureDateKey(fixture.WhenInfo)
+		dateKey, ok := fixtureDateKey(fixture.WhenInfo, leagueTitle)
 		if !ok {
 			seenUndated = true
 			continue

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -347,6 +347,29 @@ func TestParseLeaguePageNormalizesFixturesByDate(t *testing.T) {
 	}
 }
 
+func TestParseLeaguePageNormalizesFixturesBySeasonAwareDate(t *testing.T) {
+	html := `<html><head><title>Test liga 2025/26</title></head><body>
+<table class="main"><tr><td class="main"><b>1. kolejka</b></td></tr></table>
+<table class="main">
+<tr><td class="main">Team C</td><td class="main">-</td><td class="main">Team D</td><td class="main">15 marca, 12:00</td></tr>
+<tr><td class="main">Team A</td><td class="main">-</td><td class="main">Team B</td><td class="main">20 listopada, 18:00</td></tr>
+</table></body></html>`
+	doc, err := decodeAndParse([]byte(html), "text/html; charset=utf-8")
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga-test.html")
+	if page == nil || len(page.Rounds) != 1 || len(page.Rounds[0].Fixtures) != 2 {
+		t.Fatalf("expected one round with two fixtures, got %+v", page)
+	}
+
+	first := page.Rounds[0].Fixtures[0]
+	if first.Home != "Team A" || first.WhenInfo != "20 listopada, 18:00" {
+		t.Fatalf("expected November 2025 fixture before March 2026 fixture, got %+v", page.Rounds[0].Fixtures)
+	}
+}
+
 func TestValidateMatchPageAllowsPartialWhenTeamsPresent(t *testing.T) {
 	page := &MatchPage{
 		Title:    "Match",

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -39,6 +40,13 @@ var playerNumberPrefixRe = regexp.MustCompile(`^\(\d+\)\s*`)
 var playerNumberSuffixRe = regexp.MustCompile(`\s+\(\d+\)$`)
 var trailingParenRe = regexp.MustCompile(`^(.*?)(\s+\([^)]*\))$`)
 var substitutionMinutePrefixRe = regexp.MustCompile(`^\d+'?\s*`)
+
+const (
+	// Round headers ignore at most three distant postponed fixtures when at least four fixtures form the main date cluster.
+	roundDateMinCluster     = 4
+	roundDateMaxOutliers    = 3
+	roundDateOutlierGapDays = 7
+)
 
 // Minute keys encode stoppage as MM*100+extra; 45+99 is the first-half ceiling.
 const firstHalfMinuteCeiling = 4599
@@ -490,24 +498,21 @@ func displayRoundLabelWithFixtures(name string, fallback int, fixtures []site.Fi
 }
 
 func roundFixtureDateSpan(fixtures []site.Fixture, leagueTitle string) string {
-	var first time.Time
-	var last time.Time
+	dates := make([]time.Time, 0, len(fixtures))
 	for _, fixture := range fixtures {
 		date, ok := fixtureDisplayDate(fixture.WhenInfo, leagueTitle)
 		if !ok {
 			continue
 		}
-		if first.IsZero() || date.Before(first) {
-			first = date
-		}
-		if last.IsZero() || date.After(last) {
-			last = date
-		}
+		dates = append(dates, date)
 	}
-
-	if first.IsZero() {
+	if len(dates) == 0 {
 		return ""
 	}
+
+	dates = roundFixtureSpanDates(dates)
+	first := dates[0]
+	last := dates[len(dates)-1]
 	if sameCalendarDate(first, last) {
 		return first.Format("Jan 2")
 	}
@@ -515,6 +520,70 @@ func roundFixtureDateSpan(fixtures []site.Fixture, leagueTitle string) string {
 		return fmt.Sprintf("%s-%d", first.Format("Jan 2"), last.Day())
 	}
 	return fmt.Sprintf("%s-%s", first.Format("Jan 2"), last.Format("Jan 2"))
+}
+
+func roundFixtureSpanDates(dates []time.Time) []time.Time {
+	ordered := append([]time.Time(nil), dates...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Before(ordered[j]) })
+
+	if len(ordered) <= roundDateMinCluster {
+		return ordered
+	}
+
+	minKeep := max(roundDateMinCluster, len(ordered)-roundDateMaxOutliers)
+	var best []time.Time
+	var bestSpan time.Duration
+	for keep := len(ordered) - 1; keep >= minKeep; keep-- {
+		if window, ok := tightRoundDateWindow(ordered, keep); ok {
+			span := window[len(window)-1].Sub(window[0])
+			if best == nil || span < bestSpan || (span == bestSpan && len(window) > len(best)) {
+				best = window
+				bestSpan = span
+			}
+		}
+	}
+	if best != nil {
+		return best
+	}
+
+	return ordered
+}
+
+func tightRoundDateWindow(dates []time.Time, keep int) ([]time.Time, bool) {
+	var best []time.Time
+	var bestSpan time.Duration
+	for start := 0; start+keep <= len(dates); start++ {
+		end := start + keep
+		window := dates[start:end]
+		if !hasOnlyDistantRoundDateOutliers(dates, start, end) {
+			continue
+		}
+
+		span := window[len(window)-1].Sub(window[0])
+		if best == nil || span < bestSpan {
+			best = window
+			bestSpan = span
+		}
+	}
+	if best == nil {
+		return nil, false
+	}
+	return append([]time.Time(nil), best...), true
+}
+
+func hasOnlyDistantRoundDateOutliers(dates []time.Time, start, end int) bool {
+	gap := time.Duration(roundDateOutlierGapDays) * 24 * time.Hour
+	for _, date := range dates[:start] {
+		if dates[start].Sub(date) <= gap {
+			return false
+		}
+	}
+	for _, date := range dates[end:] {
+		if date.Sub(dates[end-1]) <= gap {
+			return false
+		}
+	}
+	return true
 }
 
 func fixtureDisplayDate(value, leagueTitle string) (time.Time, bool) {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -136,6 +136,79 @@ func TestTopBarRoundMetaShowsCrossYearFixtureDateSpan(t *testing.T) {
 	}
 }
 
+func TestTopBarRoundMetaInfersCrossYearFixtureDateSpan(t *testing.T) {
+	round := site.Round{
+		Name: "4. kolejka - 31 grudnia",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "2 stycznia, 12:00"},
+			{Home: "C", Away: "D", WhenInfo: "31 grudnia, 18:00"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 4, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 4 · Dec 31-Jan 2 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestTopBarRoundMetaIgnoresPostponedDateOutliers(t *testing.T) {
+	round := site.Round{
+		Name: "6. kolejka - 20 listopada",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "20 listopada, 18:00"},
+			{Home: "C", Away: "D", WhenInfo: "21 listopada, 12:00"},
+			{Home: "E", Away: "F", WhenInfo: "22 listopada, 15:00"},
+			{Home: "G", Away: "H", WhenInfo: "23 listopada, 20:00"},
+			{Home: "I", Away: "J", WhenInfo: "15 marca, 18:00"},
+			{Home: "K", Away: "L", WhenInfo: "22 marca, 18:00"},
+			{Home: "M", Away: "N", WhenInfo: "1 kwietnia, 18:00"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 6, 30, "PKO Bank Polski Ekstraklasa 2025/2026")
+	if got != "Round 6 · Nov 20-23 / 30" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
+func TestRoundFixtureDateSpanKeepsTooManyOrTooCloseOutliers(t *testing.T) {
+	tooManyOutliers := []site.Fixture{
+		{WhenInfo: "20 listopada, 18:00"},
+		{WhenInfo: "21 listopada, 12:00"},
+		{WhenInfo: "22 listopada, 15:00"},
+		{WhenInfo: "23 listopada, 20:00"},
+		{WhenInfo: "15 marca, 18:00"},
+		{WhenInfo: "22 marca, 18:00"},
+		{WhenInfo: "29 marca, 18:00"},
+		{WhenInfo: "5 kwietnia, 18:00"},
+	}
+	if got := roundFixtureDateSpan(tooManyOutliers, "PKO Bank Polski Ekstraklasa 2025/2026"); got != "Nov 20-Apr 5" {
+		t.Fatalf("expected more than three distant dates to stay in span, got %q", got)
+	}
+
+	tooCloseOutlier := []site.Fixture{
+		{WhenInfo: "20 listopada, 18:00"},
+		{WhenInfo: "21 listopada, 12:00"},
+		{WhenInfo: "22 listopada, 15:00"},
+		{WhenInfo: "23 listopada, 20:00"},
+		{WhenInfo: "30 listopada, 18:00"},
+	}
+	if got := roundFixtureDateSpan(tooCloseOutlier, "PKO Bank Polski Ekstraklasa 2025/2026"); got != "Nov 20-30" {
+		t.Fatalf("expected nearby date to stay in span, got %q", got)
+	}
+
+	tooSmallCluster := []site.Fixture{
+		{WhenInfo: "20 listopada, 18:00"},
+		{WhenInfo: "21 listopada, 12:00"},
+		{WhenInfo: "22 listopada, 15:00"},
+		{WhenInfo: "15 marca, 18:00"},
+		{WhenInfo: "22 marca, 18:00"},
+	}
+	if got := roundFixtureDateSpan(tooSmallCluster, "PKO Bank Polski Ekstraklasa 2025/2026"); got != "Nov 20-Mar 22" {
+		t.Fatalf("expected fewer than four clustered fixtures to keep full span, got %q", got)
+	}
+}
+
 func TestTopBarRoundMetaKeepsRoundLabelWhenFixtureDatesAreUnavailable(t *testing.T) {
 	round := site.Round{
 		Name: "5. kolejka - 12 czerwca",


### PR DESCRIPTION
## Summary

- Sort fixture dates with inferred season years so winter/spring fixtures do not appear before autumn fixtures in split seasons.
- Keep round header date spans focused on the main fixture cluster by ignoring up to three distant postponed fixtures.
- Add regression coverage for season-aware ordering, omitted-year cross-year spans, and postponed-date outlier boundaries.

## Verification

- `go test ./...`
- `go vet ./...`
