### PR TITLE
Model substitutions with structured players

### DIFF
--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -285,7 +285,8 @@ func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
 			event.Kind = "SUB"
 			event.MinuteText = extractMinute(marker)
 			event.Minute, event.Stoppage, event.HasMinute = parseMinute(event.MinuteText)
-			event.Text = substitutionEventText(player.Name, marker)
+			event.SubstitutionOut, event.SubstitutionIn = substitutionEventPlayers(player.Name, marker)
+			event.Text = substitutionEventText(event.SubstitutionOut, event.SubstitutionIn, marker)
 		default:
 			event.Kind = "EVENT"
 			event.Text = marker
@@ -297,22 +298,23 @@ func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
 	return events
 }
 
-func substitutionEventText(outgoing, marker string) string {
+func substitutionEventPlayers(outgoing, marker string) (string, string) {
 	parts := strings.SplitN(marker, "->", 2)
 	if len(parts) != 2 {
-		return normalizeWhitespace(marker)
+		return normalizeWhitespace(outgoing), ""
 	}
 
 	incoming := normalizeWhitespace(parts[1])
+	return normalizeWhitespace(outgoing), incoming
+}
+
+func substitutionEventText(outgoing, incoming, marker string) string {
 	if incoming == "" {
 		return normalizeWhitespace(marker)
 	}
-
-	outgoing = normalizeWhitespace(outgoing)
 	if outgoing == "" {
 		return incoming
 	}
-
 	return outgoing + " -> " + incoming
 }
 

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -90,8 +90,10 @@ type MatchEvent struct {
 	HasMinute bool
 	Kind      string
 	TeamSide  string
-	// SUB events carry "<outgoing> -> <incoming>" so renderers can place both players.
-	Text string
+	Text      string
+	// SUB events preserve both participants so UI code does not reparse display text.
+	SubstitutionOut string
+	SubstitutionIn  string
 }
 
 type PlayerLine struct {

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -240,6 +240,9 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 			if event.MinuteText != "90+2" || event.Minute != 90 || event.Stoppage != 2 || !event.HasMinute {
 				t.Fatalf("expected structured stoppage-time substitution minute, got %#v", event)
 			}
+			if event.SubstitutionOut != "Oskar Jakubczyk" || event.SubstitutionIn != "Michal Rzuchowski" {
+				t.Fatalf("expected structured substitution players, got %#v", event)
+			}
 			seenSub = true
 		case event.Kind == "YC" && event.TeamSide == "home" && event.Text == "Oskar Jakubczyk":
 			seenStarterCard = true

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -107,6 +107,9 @@ func TestPlayerTimelineEventsKeepsOutgoingAndIncomingSubstitutionPlayers(t *test
 	if events[0].Text != "Oskar Lesniak -> Damian Nowak" {
 		t.Fatalf("unexpected substitution text: %q", events[0].Text)
 	}
+	if events[0].SubstitutionOut != "Oskar Lesniak" || events[0].SubstitutionIn != "Damian Nowak" {
+		t.Fatalf("unexpected structured substitution players: %#v", events[0])
+	}
 	if events[0].MinuteText != "66" {
 		t.Fatalf("unexpected substitution minute: %q", events[0].MinuteText)
 	}

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -39,7 +39,6 @@ var leagueSeasonYearsRe = regexp.MustCompile(`(\d{4})\s*/\s*(\d{2,4})`)
 var playerNumberPrefixRe = regexp.MustCompile(`^\(\d+\)\s*`)
 var playerNumberSuffixRe = regexp.MustCompile(`\s+\(\d+\)$`)
 var trailingParenRe = regexp.MustCompile(`^(.*?)(\s+\([^)]*\))$`)
-var substitutionMinutePrefixRe = regexp.MustCompile(`^\d+'?\s*`)
 
 const (
 	// Round headers ignore at most three distant postponed fixtures when at least four fixtures form the main date cluster.

--- a/internal/ui/render_lineups.go
+++ b/internal/ui/render_lineups.go
@@ -182,7 +182,7 @@ func annotateLineupPlayerInRoster(player site.PlayerLine, idx map[string][]site.
 			continue
 		}
 
-		out, in := substitutionPlayers(event.Text)
+		out, in := substitutionPlayers(event)
 		minute := strings.TrimSpace(formatMatchMinute(event.MinuteText))
 		if playerNameMatchesInRoster(in, player.Name, players) {
 			entry.enteredAt = minute

--- a/internal/ui/render_players.go
+++ b/internal/ui/render_players.go
@@ -59,21 +59,6 @@ func eventWeight(kind string) int {
 	}
 }
 
-func substitutionPlayers(text string) (string, string) {
-	parts := strings.SplitN(normalizeDisplayText(text), "->", 2)
-	if len(parts) != 2 {
-		return "", ""
-	}
-
-	outgoing := normalizeDisplayText(substitutionMinutePrefixRe.ReplaceAllString(strings.TrimSpace(parts[0]), ""))
-	incoming := normalizeDisplayText(parts[1])
-	if strings.EqualFold(outgoing, "sub") {
-		outgoing = ""
-	}
-
-	return canonicalPlayerName(outgoing), canonicalPlayerName(incoming)
-}
-
 func faintText(text string) string {
 	if text == "" {
 		return ""
@@ -236,7 +221,7 @@ func playerEventIndex(events []site.MatchEvent, side string) map[string][]site.M
 			continue
 		}
 		if e.Kind == "SUB" {
-			out, in := substitutionPlayers(e.Text)
+			out, in := substitutionPlayers(e)
 			if key := playerMatchKey(out); key != "" {
 				idx[key] = append(idx[key], e)
 			}
@@ -251,6 +236,10 @@ func playerEventIndex(events []site.MatchEvent, side string) map[string][]site.M
 		}
 	}
 	return idx
+}
+
+func substitutionPlayers(event site.MatchEvent) (string, string) {
+	return canonicalPlayerName(event.SubstitutionOut), canonicalPlayerName(event.SubstitutionIn)
 }
 
 func matchingPlayerEvents(name string, idx map[string][]site.MatchEvent) []site.MatchEvent {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -14,7 +14,7 @@ import (
 // bypass the site parser boundary while still exercising minute-aware rendering.
 func testEvent(minuteText, kind, side, text string) site.MatchEvent {
 	m, s, ok := site.ParseMinute(minuteText)
-	return site.MatchEvent{
+	event := site.MatchEvent{
 		MinuteText: minuteText,
 		Minute:     m,
 		Stoppage:   s,
@@ -22,6 +22,33 @@ func testEvent(minuteText, kind, side, text string) site.MatchEvent {
 		Kind:       kind,
 		TeamSide:   side,
 		Text:       text,
+	}
+	if kind == "SUB" {
+		event.SubstitutionOut, event.SubstitutionIn = testSubstitutionPlayers(text)
+	}
+	return event
+}
+
+func testSubstitutionPlayers(text string) (string, string) {
+	left, right, ok := strings.Cut(text, "->")
+	if !ok {
+		return "", ""
+	}
+	return strings.TrimSpace(left), strings.TrimSpace(right)
+}
+
+func testSubstitutionEvent(minuteText, side, outgoing, incoming, text string) site.MatchEvent {
+	m, s, ok := site.ParseMinute(minuteText)
+	return site.MatchEvent{
+		MinuteText:      minuteText,
+		Minute:          m,
+		Stoppage:        s,
+		HasMinute:       ok,
+		Kind:            "SUB",
+		TeamSide:        side,
+		Text:            text,
+		SubstitutionOut: outgoing,
+		SubstitutionIn:  incoming,
 	}
 }
 
@@ -341,7 +368,7 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		Score:    "2-1",
 		Events: []site.MatchEvent{
 			testEvent("39", "GOAL", "home", "Wdowiak 39"),
-			testEvent("46", "SUB", "home", "Igor Strzalek (86) -> Damian Nowak"),
+			testSubstitutionEvent("46", "home", "Igor Strzalek (86)", "Damian Nowak", "display text without arrow"),
 			testEvent("46", "SUB", "away", "O. Lesniak -> Pllana"),
 			testEvent("52", "MISS", "away", "Barkowskij 52 (nk)"),
 			testEvent("60", "GOAL", "home", "Szkurin 60"),
@@ -736,12 +763,7 @@ func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testin
 }
 
 func TestAnnotatedLineupMatchesAbbreviatedPlayerToFullSubstitution(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "60",
-		Kind:       "SUB",
-		TeamSide:   "away",
-		Text:       "Jan Starter -> Sebastian Kubiak",
-	}}, "away")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "away", "Jan Starter -> Sebastian Kubiak")}, "away")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "S. Kubiak"}}, idx)
 	if len(got) != 1 {
@@ -779,12 +801,7 @@ func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 }
 
 func TestAnnotatedLineupDoesNotApplyAbbreviatedSubstitutionToFullSameInitialNames(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "60",
-		Kind:       "SUB",
-		TeamSide:   "home",
-		Text:       "J. Kowalski -> Piotr Kowalski",
-	}}, "home")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Kowalski")}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
 	if len(got) != 2 {
@@ -798,12 +815,7 @@ func TestAnnotatedLineupDoesNotApplyAbbreviatedSubstitutionToFullSameInitialName
 }
 
 func TestAnnotatedLineupDoesNotApplyFullSubstitutionToAmbiguousAbbreviatedRow(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{{
-		MinuteText: "60",
-		Kind:       "SUB",
-		TeamSide:   "home",
-		Text:       "Jan Kowalski -> Piotr Kowalski",
-	}}, "home")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski")}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "J. Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
 	if len(got) != 2 {
@@ -811,6 +823,17 @@ func TestAnnotatedLineupDoesNotApplyFullSubstitutionToAmbiguousAbbreviatedRow(t 
 	}
 	if got[0].leftAt != "" || got[0].replacedBy != "" {
 		t.Fatalf("expected ambiguous abbreviated row to stay unannotated, got %#v", got[0])
+	}
+}
+
+func TestAnnotatedLineupUsesStructuredSubstitutionPlayers(t *testing.T) {
+	idx := playerEventIndex([]site.MatchEvent{
+		testSubstitutionEvent("60", "home", "Jan Starter", "Piotr Entrant", "display text without arrow"),
+	}, "home")
+
+	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "Piotr Entrant"}}, idx)
+	if got[0].replacedBy != "Piotr Entrant" || got[1].replaced != "Jan Starter" {
+		t.Fatalf("expected lineup annotations to use structured substitution players, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add structured outgoing/incoming substitution players to match events.
- Populate substitution participants in the site parser while preserving display text.
- Use structured substitution fields in lineup rendering instead of reparsing formatted text.

## Tests
- go test ./...
- go vet ./...

Closes #26