### PR TITLE
Fix chained substitution parsing

### DIFF
--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -373,8 +373,8 @@ func parsePlayerCell(cell *goquery.Selection, side string) *parsedPlayerCell {
 	events := append([]string(nil), markersByPlayer[name]...)
 
 	if cell.Find("img[src*='sub.gif']").Length() > 0 && len(anchors) > 1 {
-		// In 90minut substitution cells, the last linked player is the replacement.
-		replacement := anchors[len(anchors)-1]
+		// A single lineup cell can contain a chain: starter -> entrant -> next entrant.
+		replacement := anchors[1]
 		minute := substitutionMinute(raw, replacement)
 		if minute != "" {
 			events = append(events, fmt.Sprintf("%s' -> %s", minute, replacement))
@@ -390,6 +390,23 @@ func parsePlayerCell(cell *goquery.Selection, side string) *parsedPlayerCell {
 				Kind:     marker,
 				TeamSide: side,
 				Text:     anchors[i],
+			})
+		}
+	}
+	if cell.Find("img[src*='sub.gif']").Length() > 0 {
+		for i := 2; i < len(anchors); i++ {
+			minute := substitutionMinute(raw, anchors[i])
+			m, s, ok := parseMinute(minute)
+			extraEvents = append(extraEvents, MatchEvent{
+				MinuteText:      minute,
+				Minute:          m,
+				Stoppage:        s,
+				HasMinute:       ok,
+				Kind:            "SUB",
+				TeamSide:        side,
+				Text:            substitutionEventText(anchors[i-1], anchors[i], ""),
+				SubstitutionOut: anchors[i-1],
+				SubstitutionIn:  anchors[i],
 			})
 		}
 	}

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -255,3 +255,68 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 		t.Fatalf("expected sub and both YC events, got %#v", page.Events)
 	}
 }
+
+func TestParsePlayerCellKeepsChainedSubstitutionMinutesAndCards(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(`<table><tr><td>
+	<a href="/wystepy.php?id=1">Starter One</a><img src="/img/yel.gif">
+	<img src="/img/sub.gif"> 45+1 <a href="/wystepy.php?id=2">Middle Two</a><img src="/img/yel.gif">
+	<img src="/img/sub.gif"> 90+3 <a href="/wystepy.php?id=3">Late Three</a><img src="/img/yel.gif">
+	<img src="/img/sub.gif"> 90+5 <a href="/wystepy.php?id=4">Final Four</a><img src="/img/yel.gif">
+	</td></tr></table>`))
+	if err != nil {
+		t.Fatalf("parse player cell html: %v", err)
+	}
+
+	parsed := parsePlayerCell(doc.Find("td").First(), "home")
+	if parsed == nil || parsed.Player == nil {
+		t.Fatalf("expected parsed player cell")
+	}
+	if parsed.Player.Name != "Starter One" {
+		t.Fatalf("unexpected starter: %#v", parsed.Player)
+	}
+	if len(parsed.Player.Events) != 2 || parsed.Player.Events[0] != "YC" || parsed.Player.Events[1] != "45+1' -> Middle Two" {
+		t.Fatalf("unexpected starter events: %#v", parsed.Player.Events)
+	}
+
+	expectedSubs := map[string]MatchEvent{
+		"Middle Two->Late Three": {MinuteText: "90+3", Minute: 90, Stoppage: 3},
+		"Late Three->Final Four": {MinuteText: "90+5", Minute: 90, Stoppage: 5},
+	}
+	expectedCards := map[string]bool{
+		"Middle Two": false,
+		"Late Three": false,
+		"Final Four": false,
+	}
+
+	for _, event := range parsed.ExtraEvents {
+		switch event.Kind {
+		case "SUB":
+			key := event.SubstitutionOut + "->" + event.SubstitutionIn
+			want, ok := expectedSubs[key]
+			if !ok {
+				t.Fatalf("unexpected substitution event: %#v", event)
+			}
+			if event.MinuteText != want.MinuteText || event.Minute != want.Minute || event.Stoppage != want.Stoppage || !event.HasMinute {
+				t.Fatalf("unexpected chained substitution minute: got %#v want %#v", event, want)
+			}
+			delete(expectedSubs, key)
+		case "YC", "RC":
+			if _, ok := expectedCards[event.Text]; !ok {
+				continue
+			}
+			if event.Kind != "YC" || event.TeamSide != "home" {
+				t.Fatalf("unexpected card event for chained substitution player: %#v", event)
+			}
+			expectedCards[event.Text] = true
+		}
+	}
+
+	if len(expectedSubs) > 0 {
+		t.Fatalf("missing chained substitutions: %#v from events %#v", expectedSubs, parsed.ExtraEvents)
+	}
+	for player, seen := range expectedCards {
+		if !seen {
+			t.Fatalf("missing yellow card for %q in events %#v", player, parsed.ExtraEvents)
+		}
+	}
+}

--- a/internal/site/parser_match_test.go
+++ b/internal/site/parser_match_test.go
@@ -116,3 +116,38 @@ func TestParseMatchFixturesFromCorpus(t *testing.T) {
 		t.Fatalf("expected at least one YC/RC event tied to lineup players")
 	}
 }
+
+func TestParseMatchFixtureKeepsChainedSubstitutions(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/match_2023004.html")
+	page := parseMatchPage(doc, "http://www.90minut.pl/mecz.php?id_mecz=2023004")
+	if page == nil {
+		t.Fatalf("expected match page")
+	}
+
+	firstCount := 0
+	secondCount := 0
+	for _, event := range page.Events {
+		if event.Kind != "SUB" || event.TeamSide != "away" {
+			continue
+		}
+
+		switch {
+		case event.SubstitutionOut == "(8) Ali Gholizadeh" && event.SubstitutionIn == "(11) Daniel Håkans":
+			if event.MinuteText != "19" || event.Minute != 19 || event.Stoppage != 0 || !event.HasMinute {
+				t.Fatalf("unexpected first chained substitution minute: %#v", event)
+			}
+			firstCount++
+		case event.SubstitutionOut == "(11) Daniel Håkans" && event.SubstitutionIn == "(77) Luis Palma":
+			if event.MinuteText != "65" || event.Minute != 65 || event.Stoppage != 0 || !event.HasMinute {
+				t.Fatalf("unexpected second chained substitution minute: %#v", event)
+			}
+			secondCount++
+		case event.SubstitutionOut == "(8) Ali Gholizadeh" && event.SubstitutionIn == "(77) Luis Palma":
+			t.Fatalf("parser collapsed chained substitutions into final entrant: %#v", event)
+		}
+	}
+
+	if firstCount != 1 || secondCount != 1 {
+		t.Fatalf("expected both chained substitution events, got %#v", page.Events)
+	}
+}

--- a/internal/site/testdata/fixtures/match_2023004.html
+++ b/internal/site/testdata/fixtures/match_2023004.html
@@ -1,0 +1,431 @@
+
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Motor Lublin 0-1 Lech Poznań</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_podstronyinne_bill_top -->
+<div id='90minut_podstronyinne_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=14072"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=14073"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez25-26.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14072" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14073" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14074" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14072" class="menulnk" title="Sparingi - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14073" class="menulnk" title="Sparingi - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14074" class="menulnk" title="Sparingi - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14072&runda=2" class="menulnk" title="Przygotowania - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14073&runda=2" class="menulnk" title="Przygotowania - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14074&runda=2" class="menulnk" title="Przygotowania - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=107" class="menulnk" title="Baraże 2026" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14072.html" class="menulnk" title="Ekstraklasa 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14073.html" class="menulnk" title="I liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14074.html" class="menulnk" title="II liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=107" class="menulnk" title="III Liga 2025/2026 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14154.html" class="menulnk" title="III Liga 2025/2026 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14155.html" class="menulnk" title="III Liga 2025/2026 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14156.html" class="menulnk" title="III Liga 2025/2026 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14157.html" class="menulnk" title="III Liga 2025/2026 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14384.html" class="menulnk" title="Centralna Liga Juniorów 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14385.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14386.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14076.html" class="menulnk" title="Puchar Polski 2025/2026 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14075.html" class="menulnk" title="Superpuchar 2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=107" class="menulnk" title="Rozgrywki pucharowe w Polsce 2025/2026 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2025/2026 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14077.html" class="menulnk" title="Liga Mistrzów 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14078.html" class="menulnk" title="Liga Europy 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14079.html" class="menulnk" title="Liga Konferencji 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14634.html" class="menulnk" title="Liga Młodzieżowa 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=107" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=107" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=107" class="menulnk" title="Reprezentacja Polski 2025/2026 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14042.html" class="menulnk" title="Eliminacje mistrzostw świata - USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14645.html" class="menulnk" title="Mistrzostwa świata - Kanada/Meksyk/USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14658.html" class="menulnk" title="Liga Narodów 2026/2027 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 26/27</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=107" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=107" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=107" class="menulnk" title="Archiwum wyników z sezonu 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2025 / 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_podstronyinne_sky -->
+<div id='90minut_podstronyinne_sky'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+<p class="main">&nbsp;
+<table width="480" border="0" cellspacing="0" cellpadding="0" class="main" align="center">
+<tr>
+<td colspan="3" align="center"><br>&nbsp;<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+&nbsp;<b>PKO Bank Polski Ekstraklasa 2025/2026 - Kolejka 31</b>&nbsp;<img src="http://img.90minut.pl/img/redarrowr.gif" width="15" height="15" align="absmiddle">
+</td>
+</tr>
+<tr>
+<td valign="middle" align="center" colspan="3">&nbsp;&nbsp;<img src="http://img.90minut.pl/img/data.gif" width="25" height="22" valign="bottom">&nbsp;2 maja 2026, 20:15&nbsp;&nbsp;<img src="http://img.90minut.pl/img/att.gif" width="22" height="22" valign="bottom">&nbsp;15 200&nbsp;&nbsp;<img src="http://img.90minut.pl/img/ref.jpg" width="31" height="22" valign="bottom">&nbsp;<a href="/sedzia.php?id=1203&id_sezon=107" class="main">Karol Arys (Szczecin)</a></td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr><td valign="bottom" align="center" width="480" colspan="3"><img src="http://img.90minut.pl/img/pog_termo.gif" align="absmiddle" alt="temperatura"> 15 &deg;&nbsp;&nbsp;&nbsp;&nbsp;</td></tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<tr><td align="center" valign="bottom"><img src="http://img.90minut.pl/logo/dobazy/motor_lublin.gif"></td><td></td><td align="center" valign="bottom"><img src="http://img.90minut.pl/logo/dobazy/lech.gif"></td></tr>
+<td align="center" valign="bottom" width="220"><b><font size="2">Motor Lublin</font></b></td>
+<td align="center" valign="bottom" width="40"><b><font size="4"><nobr>0 - 1</nobr></font></b></td>
+<td align="center" valign="bottom" width="220"><b><font size="2">Lech Poznań</font></b></td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<tr>
+<td></td>
+<td align="center"><b>0 - 1</b></td>
+<td align="left">&nbsp;&nbsp;&nbsp;&nbsp;Leo Bengtsson 40&nbsp;<img src="http://img.90minut.pl/img/goal.gif" width="10" height="10" align="absmiddle">
+</td>
+</tr>
+<p><tr><td>&nbsp;</td></tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=50372&id_sezon=107" class="main">(33) Gašper Tratnik</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=31871&id_sezon=107" class="main">(41) Bartosz Mrozek</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
+<td width="45%"><a href="/wystepy.php?id=22781&id_sezon=107" class="main">(28) Paweł Stolarski</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+77 <a href="/wystepy.php?id=25605&id_sezon=107" class="main">(17) Filip Wójcik</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=43152&id_sezon=107" class="main">(2) <i>Joel Pereira</i></a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=49020&id_sezon=107" class="main">(39) Marek Bartoš</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=46973&id_sezon=107" class="main">(27) Wojciech Mońka</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
+<td width="45%"><a href="/wystepy.php?id=27402&id_sezon=107" class="main">(18) Arkadiusz Najemski</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=35815&id_sezon=107" class="main">(16) Antonio Milić</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=46710&id_sezon=107" class="main">(24) Filip Luberecki</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=46716&id_sezon=107" class="main">(15) Michał Gurgul</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+79 <a href="/wystepy.php?id=27743&id_sezon=107" class="main">(20) Robert Gumny</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
+<td width="45%"><a href="/wystepy.php?id=48480&id_sezon=107" class="main">(30) Mbaye N'Diaye</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+65 <a href="/wystepy.php?id=33245&id_sezon=107" class="main">(26) Michał Król</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=42090&id_sezon=107" class="main">(8) Ali Gholizadeh</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+19 <a href="/wystepy.php?id=49173&id_sezon=107" class="main">(11) Daniel H&#229;kans</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+65 <a href="/wystepy.php?id=47677&id_sezon=107" class="main">(77) Luis Palma</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=28668&id_sezon=107" class="main">(6) Sergi Samper</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=49614&id_sezon=107" class="main">(6) Timothy Ouma</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
+<td width="45%"><a href="/wystepy.php?id=24878&id_sezon=107" class="main">(68) Bartosz Wolski</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=36665&id_sezon=107" class="main">(43) Antoni Kozubal</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=51111&id_sezon=107" class="main">(7) <i>Ivo Rodrigues</i></a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+86 <a href="/wystepy.php?id=37154&id_sezon=107" class="main">(10) Kacper Karasek</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=44860&id_sezon=107" class="main">(10) Patrik W&#229;lemark</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+65 <a href="/wystepy.php?id=23429&id_sezon=107" class="main">(24) Filip Jagiełło</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#F5F5F5">
+<td width="45%"><a href="/wystepy.php?id=49594&id_sezon=107" class="main">(19) Bradly van Hoeven</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+65 <a href="/wystepy.php?id=51580&id_sezon=107" class="main">(11) <i>Fábio Ronaldo</i></a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=47456&id_sezon=107" class="main">(14) Leo Bengtsson</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+79 <a href="/wystepy.php?id=49083&id_sezon=107" class="main">(88) Taofeek Ismaheel</a></td>
+</tr>
+<tr height="20" valign="middle" align="center" bgcolor="#DFDFDF">
+<td width="45%"><a href="/wystepy.php?id=36845&id_sezon=107" class="main">(9) Karol Czubak</a><br>
+<img src="http://img.90minut.pl/img/sub.gif" width="15" height="15" align="absmiddle">&nbsp;
+77 <a href="/wystepy.php?id=50534&id_sezon=107" class="main">(77) Renat Dadaşov</a></td>
+<td bgcolor="#FFFFFF"></td>
+<td width="45%"><a href="/wystepy.php?id=41470&id_sezon=107" class="main">(9) Mikael Ishak</a></td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr><td colspan="3">Przeczytaj news: <a href="/news/341/news3413801-PKO-BP-Ekstraklasa-Motor-0-1-Lech.html" class="main">PKO BP Ekstraklasa: Motor 0-1 Lech</a></td></tr>
+</table>
+<div align="center">
+</div>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>
+

--- a/internal/site/testdata/manifest.json
+++ b/internal/site/testdata/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "sha256:2bcd36d3e39dc9f5503651a6471fba9fe7e5ad32b07c36d9061403688b2521c9",
+  "generated_at": "sha256:cf427f8e4a0a8553cecbad69de680de5bcc35ecec270990c8e53b193171e2f3b",
   "source": "http://www.90minut.pl/archsezon.php",
   "fixtures": [
     {
@@ -117,6 +117,14 @@
       "season": "2025/26",
       "file": "fixtures/match_2022961.html",
       "note": "missed penalty timeline row"
+    },
+    {
+      "name": "match_2023004",
+      "kind": "match",
+      "url": "http://www.90minut.pl/mecz.php?id_mecz=2023004",
+      "season": "2025/26",
+      "file": "fixtures/match_2023004.html",
+      "note": "chained substitution cell"
     },
     {
       "name": "match_2023487",

--- a/internal/ui/render_lineups.go
+++ b/internal/ui/render_lineups.go
@@ -21,6 +21,13 @@ type lineupEntry struct {
 	leftAt       string
 	replacedBy   string
 	replacedByYC lineupCardMarker
+	chain        []lineupSubNote
+}
+
+type lineupSubNote struct {
+	minute string
+	player string
+	card   lineupCardMarker
 }
 
 const (
@@ -35,7 +42,7 @@ func formatLineupPlayer(entry lineupEntry, side string, maxWidth int) string {
 
 func formatLineupPlayerWithCards(entry lineupEntry, side string, maxWidth int, tokens bool) string {
 	name := formatPlayerLabel(entry.player.Name)
-	if entry.enteredAt == "" && entry.replaced == "" && entry.leftAt == "" && entry.replacedBy == "" {
+	if entry.enteredAt == "" && entry.replaced == "" && entry.leftAt == "" && entry.replacedBy == "" && len(entry.chain) == 0 {
 		return name
 	}
 
@@ -73,6 +80,11 @@ func lineupNotes(entry lineupEntry, side string, shortenNotes, tokens bool) []st
 	}
 	if note := exitNote(entry, side, shortenNotes, tokens); note != "" {
 		notes = append(notes, note)
+	}
+	for _, chained := range entry.chain {
+		if note := chainNote(chained, side, shortenNotes, tokens); note != "" {
+			notes = append(notes, note)
+		}
 	}
 
 	return notes
@@ -124,6 +136,30 @@ func exitNote(entry lineupEntry, side string, shortenNotes, tokens bool) string 
 	}
 	if side != "home" && entry.leftAt != "" {
 		text += " " + entry.leftAt
+	}
+	return substitutionNoteText(text+")", tokens)
+}
+
+func chainNote(note lineupSubNote, side string, shortenNotes, tokens bool) string {
+	if note.player == "" {
+		return ""
+	}
+
+	replacement := formatSubNoteName(note.player, shortenNotes)
+	card := lineupCardText(note.card, tokens)
+	text := "("
+	if side == "home" && note.minute != "" {
+		text += note.minute + " "
+	}
+	if side != "home" && card != "" {
+		text += card + " "
+	}
+	text += replacement
+	if side == "home" {
+		text += card
+	}
+	if side != "home" && note.minute != "" {
+		text += " " + note.minute
 	}
 	return substitutionNoteText(text+")", tokens)
 }
@@ -193,10 +229,48 @@ func annotateLineupPlayerInRoster(player site.PlayerLine, idx map[string][]site.
 			entry.leftAt = minute
 			entry.replacedBy = in
 			entry.replacedByYC = substituteCardMarkerAnnotationNameInRoster(in, idx, players)
+			entry.chain = chainedReplacementNotes(in, idx, players)
 		}
 	}
 
 	return entry
+}
+
+func chainedReplacementNotes(name string, idx map[string][]site.MatchEvent, players []site.PlayerLine) []lineupSubNote {
+	seen := map[string]bool{playerMatchKey(name): true}
+	chain := make([]lineupSubNote, 0, 2)
+	current := name
+
+	for {
+		next, ok := nextReplacementNote(current, idx, players)
+		if !ok || seen[playerMatchKey(next.player)] {
+			return chain
+		}
+		chain = append(chain, next)
+		seen[playerMatchKey(next.player)] = true
+		current = next.player
+	}
+}
+
+func nextReplacementNote(name string, idx map[string][]site.MatchEvent, players []site.PlayerLine) (lineupSubNote, bool) {
+	for _, event := range sortedEvents(matchingPlayerEventsInRoster(name, idx, players)) {
+		if event.Kind != "SUB" {
+			continue
+		}
+
+		out, in := substitutionPlayers(event)
+		if !playerNameMatchesInRoster(out, name, players) {
+			continue
+		}
+
+		return lineupSubNote{
+			minute: strings.TrimSpace(formatMatchMinute(event.MinuteText)),
+			player: in,
+			card:   substituteCardMarkerAnnotationNameInRoster(in, idx, players),
+		}, true
+	}
+
+	return lineupSubNote{}, false
 }
 
 func playerNameMatches(left, right string) bool {
@@ -250,62 +324,15 @@ func compactMatchCountForName(name string, players []site.PlayerLine) int {
 	return count
 }
 
-// Only synthesize rows for substitutes who were later subbed off; avoid inventing one-off bench entrants absent from the source lineup.
 func annotatedLineup(players []site.PlayerLine, idx map[string][]site.MatchEvent) []lineupEntry {
 	if len(players) == 0 {
 		return nil
 	}
 
-	byKey := make(map[string]site.PlayerLine, len(players))
-	for _, player := range players {
-		byKey[playerMatchKey(player.Name)] = player
-	}
-
 	entries := make([]lineupEntry, 0, len(players))
-	addedSynthetic := make(map[string]bool)
 	for _, player := range players {
-		entry := annotateLineupPlayerInRoster(player, idx, players)
-		entries = append(entries, entry)
-
-		inKey := playerMatchKey(entry.replacedBy)
-		syntheticKey := playerSyntheticKey(entry.replacedBy)
-		if inKey == "" || addedSynthetic[syntheticKey] {
-			continue
-		}
-		if _, exists := byKey[inKey]; exists || lineupContainsPlayer(players, entry.replacedBy) {
-			continue
-		}
-
-		synthetic := annotateLineupPlayerInRoster(site.PlayerLine{Name: entry.replacedBy}, idx, players)
-		if synthetic.replacedBy == "" {
-			continue
-		}
-
-		entries = append(entries, synthetic)
-		addedSynthetic[syntheticKey] = true
+		entries = append(entries, annotateLineupPlayerInRoster(player, idx, players))
 	}
 
 	return entries
-}
-
-func lineupContainsPlayer(players []site.PlayerLine, name string) bool {
-	for _, player := range players {
-		if playerNameMatches(name, player.Name) || playerNameMatches(player.Name, name) {
-			return true
-		}
-	}
-	return false
-}
-
-func playerSyntheticKey(name string) string {
-	if isAbbreviatedPlayerName(name) {
-		return playerCompactMatchKey(name)
-	}
-	if key := playerMatchKey(name); key != "" {
-		return key
-	}
-	if compact := playerCompactMatchKey(name); compact != "" {
-		return compact
-	}
-	return ""
 }

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -931,29 +931,15 @@ func TestAnnotatedLineupAllowsDistinctFullSyntheticEntrantsWithSameCompactKey(t 
 	}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Starter One"}, {Name: "Starter Two"}}, idx)
-	if len(got) != 4 {
-		t.Fatalf("expected two distinct synthetic entrants, got %#v", got)
+	if len(got) != 2 {
+		t.Fatalf("expected only starter rows, got %#v", got)
 	}
-	oskar := lineupEntryByName(got, "Oskar Lesniak")
-	olaf := lineupEntryByName(got, "Olaf Lesniak")
-	if oskar.player.Name == "" || olaf.player.Name == "" {
-		t.Fatalf("expected distinct same-compact synthetic entrants, got %#v", got)
+	if got[0].player.Name != "Starter One" || got[0].replacedBy != "Oskar Lesniak" || len(got[0].chain) != 1 || got[0].chain[0].player != "Next One" || got[0].chain[0].minute != "78'" {
+		t.Fatalf("expected first starter row to carry chained replacement, got %#v", got[0])
 	}
-	if oskar.enteredAt != "60'" || oskar.leftAt != "78'" || oskar.replacedBy != "Next One" {
-		t.Fatalf("unexpected Oskar Lesniak entry: %#v", oskar)
+	if got[1].player.Name != "Starter Two" || got[1].replacedBy != "Olaf Lesniak" || len(got[1].chain) != 1 || got[1].chain[0].player != "Next Two" || got[1].chain[0].minute != "79'" {
+		t.Fatalf("expected second starter row to carry chained replacement, got %#v", got[1])
 	}
-	if olaf.enteredAt != "61'" || olaf.leftAt != "79'" || olaf.replacedBy != "Next Two" {
-		t.Fatalf("unexpected Olaf Lesniak entry: %#v", olaf)
-	}
-}
-
-func lineupEntryByName(entries []lineupEntry, name string) lineupEntry {
-	for _, entry := range entries {
-		if entry.player.Name == name {
-			return entry
-		}
-	}
-	return lineupEntry{}
 }
 
 func TestAnnotatedLineupKeepsBookedEntrantInReplacementNote(t *testing.T) {
@@ -993,11 +979,11 @@ func TestAnnotatedLineupSyntheticEntrantKeepsLaterSubstitutionOff(t *testing.T) 
 	}, "home")
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
-	if len(got) != 2 {
-		t.Fatalf("expected starter plus synthetic entrant, got %#v", got)
+	if len(got) != 1 {
+		t.Fatalf("expected only starter row, got %#v", got)
 	}
-	if got[1].player.Name != "Oskar Lesniak" || got[1].enteredAt != "66'" || got[1].replaced != "Jason Lokilo" || got[1].leftAt != "78'" || got[1].replacedBy != "Michal Smith" {
-		t.Fatalf("expected synthetic entrant row to keep both substitution notes, got %#v", got[1])
+	if got[0].player.Name != "Jason Lokilo" || got[0].replacedBy != "Oskar Lesniak" || len(got[0].chain) != 1 || got[0].chain[0].player != "Michal Smith" || got[0].chain[0].minute != "78'" {
+		t.Fatalf("expected starter row to keep chained substitution notes, got %#v", got[0])
 	}
 }
 
@@ -1024,6 +1010,21 @@ func TestFormatLineupPlayerShowsBookedReplacedPlayerInsideAwayNote(t *testing.T)
 
 	if got := ansi.Strip(away); got != "J. Sypek (for ■ J. Kowalczyk 46')" {
 		t.Fatalf("unexpected away booked-replaced label: %q", got)
+	}
+}
+
+func TestFormatLineupPlayerShowsChainedReplacementOnStarterRow(t *testing.T) {
+	away := formatLineupPlayer(lineupEntry{
+		player:     site.PlayerLine{Name: "Ali Gholizadeh"},
+		leftAt:     "19'",
+		replacedBy: "Daniel Hakans",
+		chain: []lineupSubNote{
+			{minute: "65'", player: "Luis Palma"},
+		},
+	}, "away", 80)
+
+	if got := ansi.Strip(away); got != "A. Gholizadeh (D. Hakans 19') (L. Palma 65')" {
+		t.Fatalf("unexpected away chained replacement label: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Parse chained substitution cells as adjacent player transitions instead of starter-to-final entrant.
- Add the `match_2023004` fixture covering a real chained substitution case.
- Add parser coverage for longer chains, stoppage-time substitution minutes, and card side assignment in chained cells.

## Tests
- go test ./...
- go vet ./...