### PR TITLE
Use typed match event constants

### DIFF
--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -57,7 +57,7 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 					Stoppage:   s,
 					HasMinute:  ok,
 					Kind:       kind,
-					TeamSide:   "home",
+					TeamSide:   TeamSideHome,
 					Text:       left,
 				})
 			}
@@ -71,7 +71,7 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 					Stoppage:   s,
 					HasMinute:  ok,
 					Kind:       kind,
-					TeamSide:   "away",
+					TeamSide:   TeamSideAway,
 					Text:       right,
 				})
 			}
@@ -88,16 +88,16 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 			return
 		}
 
-		if parsed := parsePlayerCell(tds.Eq(0), "home"); parsed != nil {
+		if parsed := parsePlayerCell(tds.Eq(0), TeamSideHome); parsed != nil {
 			page.HomeLineup = append(page.HomeLineup, *parsed.Player)
-			for _, event := range playerTimelineEvents(*parsed.Player, "home") {
+			for _, event := range playerTimelineEvents(*parsed.Player, TeamSideHome) {
 				page.Events = append(page.Events, event)
 			}
 			page.Events = append(page.Events, parsed.ExtraEvents...)
 		}
-		if parsed := parsePlayerCell(tds.Eq(2), "away"); parsed != nil {
+		if parsed := parsePlayerCell(tds.Eq(2), TeamSideAway); parsed != nil {
 			page.AwayLineup = append(page.AwayLineup, *parsed.Player)
-			for _, event := range playerTimelineEvents(*parsed.Player, "away") {
+			for _, event := range playerTimelineEvents(*parsed.Player, TeamSideAway) {
 				page.Events = append(page.Events, event)
 			}
 			page.Events = append(page.Events, parsed.ExtraEvents...)
@@ -117,14 +117,14 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 	return page
 }
 
-func scoreRowEventKind(row *goquery.Selection) (string, bool) {
+func scoreRowEventKind(row *goquery.Selection) (MatchEventKind, bool) {
 	tds := row.Find("td")
 	if tds.Length() != 3 {
 		return "", false
 	}
 	middle := normalizeWhitespace(tds.Eq(1).Text())
 	if middle == "-" || isScoreLikeText(middle) {
-		return "GOAL", true
+		return EventKindGoal, true
 	}
 
 	leftKind := scoreCellEventKind(tds.Eq(0))
@@ -142,12 +142,12 @@ func scoreRowEventKind(row *goquery.Selection) (string, bool) {
 	return "", false
 }
 
-func scoreCellEventKind(cell *goquery.Selection) string {
+func scoreCellEventKind(cell *goquery.Selection) MatchEventKind {
 	switch {
 	case cell.Find("img[src*='goal.gif']").Length() > 0:
-		return "GOAL"
+		return EventKindGoal
 	case cell.Find("img[src*='missed.gif']").Length() > 0:
-		return "MISS"
+		return EventKindMiss
 	default:
 		return ""
 	}
@@ -270,25 +270,25 @@ func isLineupRow(row *goquery.Selection) bool {
 	return tds.Eq(0).Find("a").Length() > 0 || tds.Eq(2).Find("a").Length() > 0
 }
 
-func playerTimelineEvents(player PlayerLine, side string) []MatchEvent {
+func playerTimelineEvents(player PlayerLine, side TeamSide) []MatchEvent {
 	events := make([]MatchEvent, 0, 2)
 
 	for _, marker := range player.Events {
 		event := MatchEvent{TeamSide: side, Text: player.Name}
 
 		switch {
-		case marker == "YC":
-			event.Kind = "YC"
-		case marker == "RC":
-			event.Kind = "RC"
+		case marker == string(EventKindYellowCard):
+			event.Kind = EventKindYellowCard
+		case marker == string(EventKindRedCard):
+			event.Kind = EventKindRedCard
 		case strings.Contains(marker, "->"):
-			event.Kind = "SUB"
+			event.Kind = EventKindSubstitution
 			event.MinuteText = extractMinute(marker)
 			event.Minute, event.Stoppage, event.HasMinute = parseMinute(event.MinuteText)
 			event.SubstitutionOut, event.SubstitutionIn = substitutionEventPlayers(player.Name, marker)
 			event.Text = substitutionEventText(event.SubstitutionOut, event.SubstitutionIn, marker)
 		default:
-			event.Kind = "EVENT"
+			event.Kind = EventKindGeneric
 			event.Text = marker
 		}
 
@@ -323,7 +323,7 @@ type parsedPlayerCell struct {
 	ExtraEvents []MatchEvent
 }
 
-func parsePlayerCell(cell *goquery.Selection, side string) *parsedPlayerCell {
+func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 	raw := normalizeWhitespace(cell.Text())
 	if raw == "" {
 		return nil
@@ -362,9 +362,9 @@ func parsePlayerCell(cell *goquery.Selection, side string) *parsedPlayerCell {
 				case currentPlayer == "":
 					continue
 				case strings.Contains(src, "yel.gif"):
-					markersByPlayer[currentPlayer] = append(markersByPlayer[currentPlayer], "YC")
+					markersByPlayer[currentPlayer] = append(markersByPlayer[currentPlayer], string(EventKindYellowCard))
 				case strings.Contains(src, "red.gif"), strings.Contains(src, "red2.gif"):
-					markersByPlayer[currentPlayer] = append(markersByPlayer[currentPlayer], "RC")
+					markersByPlayer[currentPlayer] = append(markersByPlayer[currentPlayer], string(EventKindRedCard))
 				}
 			}
 		}
@@ -387,7 +387,7 @@ func parsePlayerCell(cell *goquery.Selection, side string) *parsedPlayerCell {
 	for i := 1; i < len(anchors); i++ {
 		for _, marker := range markersByPlayer[anchors[i]] {
 			extraEvents = append(extraEvents, MatchEvent{
-				Kind:     marker,
+				Kind:     MatchEventKind(marker),
 				TeamSide: side,
 				Text:     anchors[i],
 			})

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -16,7 +16,6 @@ type Competition struct {
 	LeagueKey string
 }
 
-// CompetitionMenu is an intermediate archive node that expands into more competitions.
 type CompetitionMenu struct {
 	Title string
 	URL   string
@@ -53,7 +52,6 @@ type StandingRow struct {
 	Points   int
 }
 
-// LeaguePage is the normalized league view returned by the site layer.
 type LeaguePage struct {
 	Title     string
 	URL       string
@@ -74,11 +72,12 @@ type MatchPage struct {
 	HomeTeam    string
 	AwayTeam    string
 	Score       string
-	Events      []MatchEvent
-	HomeLineup  []PlayerLine
-	AwayLineup  []PlayerLine
-	NewsTitle   string
-	NewsURL     string
+	// Events combines score-row incidents and lineup-derived cards/substitutions; consumers sort when order matters.
+	Events     []MatchEvent
+	HomeLineup []PlayerLine
+	AwayLineup []PlayerLine
+	NewsTitle  string
+	NewsURL    string
 }
 
 type MatchEvent struct {
@@ -88,16 +87,40 @@ type MatchEvent struct {
 	Minute    int
 	Stoppage  int
 	HasMinute bool
-	Kind      string
-	TeamSide  string
-	Text      string
-	// SUB events preserve both participants so UI code does not reparse display text.
+	Kind      MatchEventKind
+	// TeamSide is event ownership relative to the parsed home/away teams.
+	TeamSide TeamSide
+	// Text is normalized source text; substitution callers should prefer SubstitutionOut/SubstitutionIn.
+	Text string
+	// Substitution events keep parsed participants so UI code doesn't reparse display text.
 	SubstitutionOut string
 	SubstitutionIn  string
 }
 
+// MatchEventKind is the parser's normalized event vocabulary.
+type MatchEventKind string
+
+const (
+	EventKindGoal         MatchEventKind = "GOAL"
+	EventKindMiss         MatchEventKind = "MISS"
+	EventKindYellowCard   MatchEventKind = "YC"
+	EventKindRedCard      MatchEventKind = "RC"
+	EventKindSubstitution MatchEventKind = "SUB"
+	// EventKindGeneric preserves lineup markers without dedicated UI handling.
+	EventKindGeneric MatchEventKind = "EVENT"
+)
+
+// TeamSide uses the parser's closed home/away vocabulary for match-owned events.
+type TeamSide string
+
+const (
+	TeamSideHome TeamSide = "home"
+	TeamSideAway TeamSide = "away"
+)
+
 type PlayerLine struct {
-	Name    string
+	Name string
+	// Events stores raw lineup-cell markers until parser normalization emits MatchEvent values.
 	Events  []string
 	RawText string
 }

--- a/internal/site/parser_edgecases_test.go
+++ b/internal/site/parser_edgecases_test.go
@@ -81,7 +81,7 @@ func TestParseMatchPageGoalSideAssignmentAndStoppageMinutes(t *testing.T) {
 
 	goals := make([]MatchEvent, 0, 2)
 	for _, event := range page.Events {
-		if event.Kind == "GOAL" {
+		if event.Kind == EventKindGoal {
 			goals = append(goals, event)
 		}
 	}
@@ -89,10 +89,10 @@ func TestParseMatchPageGoalSideAssignmentAndStoppageMinutes(t *testing.T) {
 	if len(goals) != 2 {
 		t.Fatalf("expected 2 goals, got %d", len(goals))
 	}
-	if goals[0].TeamSide != "home" || goals[0].MinuteText != "45+1" {
+	if goals[0].TeamSide != TeamSideHome || goals[0].MinuteText != "45+1" {
 		t.Fatalf("unexpected first goal: %#v", goals[0])
 	}
-	if goals[1].TeamSide != "away" || goals[1].MinuteText != "90+2" {
+	if goals[1].TeamSide != TeamSideAway || goals[1].MinuteText != "90+2" {
 		t.Fatalf("unexpected second goal: %#v", goals[1])
 	}
 }
@@ -122,10 +122,10 @@ func TestParseMatchPageMissedPenaltyTimelineEvent(t *testing.T) {
 	}
 
 	event := page.Events[0]
-	if event.Kind != "MISS" {
+	if event.Kind != EventKindMiss {
 		t.Fatalf("unexpected event kind: %#v", event)
 	}
-	if event.TeamSide != "home" {
+	if event.TeamSide != TeamSideHome {
 		t.Fatalf("unexpected event side: %#v", event)
 	}
 	if event.MinuteText != "52" {
@@ -184,7 +184,7 @@ func TestParseMatchPageEventsCarryStructuredMinutes(t *testing.T) {
 
 	var goalEvent *MatchEvent
 	for i := range page.Events {
-		if page.Events[i].Kind == "GOAL" {
+		if page.Events[i].Kind == EventKindGoal {
 			goalEvent = &page.Events[i]
 			break
 		}
@@ -236,7 +236,7 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 	seenEntrantCard := false
 	for _, event := range page.Events {
 		switch {
-		case event.Kind == "SUB" && event.TeamSide == "home" && event.Text == "Oskar Jakubczyk -> Michal Rzuchowski":
+		case event.Kind == EventKindSubstitution && event.TeamSide == TeamSideHome && event.Text == "Oskar Jakubczyk -> Michal Rzuchowski":
 			if event.MinuteText != "90+2" || event.Minute != 90 || event.Stoppage != 2 || !event.HasMinute {
 				t.Fatalf("expected structured stoppage-time substitution minute, got %#v", event)
 			}
@@ -244,9 +244,9 @@ func TestParseMatchPageSubstitutionCellAssignsCardsToBothPlayers(t *testing.T) {
 				t.Fatalf("expected structured substitution players, got %#v", event)
 			}
 			seenSub = true
-		case event.Kind == "YC" && event.TeamSide == "home" && event.Text == "Oskar Jakubczyk":
+		case event.Kind == EventKindYellowCard && event.TeamSide == TeamSideHome && event.Text == "Oskar Jakubczyk":
 			seenStarterCard = true
-		case event.Kind == "YC" && event.TeamSide == "home" && event.Text == "Michal Rzuchowski":
+		case event.Kind == EventKindYellowCard && event.TeamSide == TeamSideHome && event.Text == "Michal Rzuchowski":
 			seenEntrantCard = true
 		}
 	}

--- a/internal/site/parser_match_test.go
+++ b/internal/site/parser_match_test.go
@@ -4,17 +4,17 @@ import (
 	"testing"
 )
 
-var expectedCardSidesByFixture = map[string]map[string]string{
+var expectedCardSidesByFixture = map[string]map[string]TeamSide{
 	"match_2022810": {
-		"(2) Paskal Meyer":    "away",
-		"(39) Filip Kocaba":   "home",
-		"(68) Bartosz Wolski": "away",
+		"(2) Paskal Meyer":    TeamSideAway,
+		"(39) Filip Kocaba":   TeamSideHome,
+		"(68) Bartosz Wolski": TeamSideAway,
 	},
 }
 
 var expectedMissedPenaltiesByFixture = map[string][]MatchEvent{
 	"match_2022961": {
-		{MinuteText: "52", Kind: "MISS", TeamSide: "home", Text: "Gierman Barkowskij 52 (nk)"},
+		{MinuteText: "52", Kind: EventKindMiss, TeamSide: TeamSideHome, Text: "Gierman Barkowskij 52 (nk)"},
 	},
 }
 
@@ -60,8 +60,11 @@ func TestParseMatchFixturesFromCorpus(t *testing.T) {
 			seenExpectedMissed := make([]bool, len(expectedMissedPenalties))
 
 			for _, event := range page.Events {
-				if event.TeamSide != "home" && event.TeamSide != "away" {
+				if event.TeamSide != TeamSideHome && event.TeamSide != TeamSideAway {
 					t.Fatalf("invalid event side %q in %s", event.TeamSide, fixture.Name)
+				}
+				if !validMatchEventKind(event.Kind) {
+					t.Fatalf("invalid event kind %q in %s", event.Kind, fixture.Name)
 				}
 
 				for i, want := range expectedMissedPenalties {
@@ -71,7 +74,7 @@ func TestParseMatchFixturesFromCorpus(t *testing.T) {
 					seenExpectedMissed[i] = true
 				}
 
-				if event.Kind != "YC" && event.Kind != "RC" {
+				if event.Kind != EventKindYellowCard && event.Kind != EventKindRedCard {
 					continue
 				}
 				if event.Text == "" {
@@ -114,5 +117,14 @@ func TestParseMatchFixturesFromCorpus(t *testing.T) {
 	}
 	if !foundPlayerSideEvidence {
 		t.Fatalf("expected at least one YC/RC event tied to lineup players")
+	}
+}
+
+func validMatchEventKind(kind MatchEventKind) bool {
+	switch kind {
+	case EventKindGoal, EventKindMiss, EventKindYellowCard, EventKindRedCard, EventKindSubstitution, EventKindGeneric:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -97,11 +97,11 @@ func TestPlayerTimelineEventsKeepsOutgoingAndIncomingSubstitutionPlayers(t *test
 		Events: []string{"66' -> Damian Nowak"},
 	}
 
-	events := playerTimelineEvents(player, "home")
+	events := playerTimelineEvents(player, TeamSideHome)
 	if len(events) != 1 {
 		t.Fatalf("expected one event, got %d", len(events))
 	}
-	if events[0].Kind != "SUB" {
+	if events[0].Kind != EventKindSubstitution {
 		t.Fatalf("expected substitution event, got %#v", events[0])
 	}
 	if events[0].Text != "Oskar Lesniak -> Damian Nowak" {

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -169,10 +169,10 @@ func halftimeScore(events []site.MatchEvent) string {
 		}
 		minute := event.Minute*100 + event.Stoppage
 		if minute <= firstHalfMinuteCeiling {
-			if event.Kind == "GOAL" {
-				if event.TeamSide == "home" {
+			if event.Kind == site.EventKindGoal {
+				if event.TeamSide == site.TeamSideHome {
 					homeGoals++
-				} else if event.TeamSide == "away" {
+				} else if event.TeamSide == site.TeamSideAway {
 					awayGoals++
 				}
 			}
@@ -625,14 +625,14 @@ func eventPlayerText(event site.MatchEvent) string {
 	re = regexp.MustCompile(`\s+` + minute + `(\s*(?:\([^)]*\))?)$`)
 	text = strings.TrimSpace(re.ReplaceAllString(text, `$1`))
 
-	if event.Kind == "SUB" {
+	if event.Kind == site.EventKindSubstitution {
 		text = strings.TrimSpace(strings.TrimPrefix(text, "->"))
 		text = normalizeSubstitutionText(text)
 	}
-	if event.Kind == "GOAL" {
+	if event.Kind == site.EventKindGoal {
 		text = strings.ReplaceAll(text, "(k)", "(pen)")
 	}
-	if event.Kind == "MISS" {
+	if event.Kind == site.EventKindMiss {
 		text = strings.ReplaceAll(text, "(nk)", "(pen)")
 	}
 

--- a/internal/ui/render_lineups.go
+++ b/internal/ui/render_lineups.go
@@ -29,11 +29,11 @@ const (
 )
 
 // A substitute can enter and later leave; keep both notes on one rendered row.
-func formatLineupPlayer(entry lineupEntry, side string, maxWidth int) string {
+func formatLineupPlayer(entry lineupEntry, side site.TeamSide, maxWidth int) string {
 	return formatLineupPlayerWithCards(entry, side, maxWidth, false)
 }
 
-func formatLineupPlayerWithCards(entry lineupEntry, side string, maxWidth int, tokens bool) string {
+func formatLineupPlayerWithCards(entry lineupEntry, side site.TeamSide, maxWidth int, tokens bool) string {
 	name := formatPlayerLabel(entry.player.Name)
 	if entry.enteredAt == "" && entry.replaced == "" && entry.leftAt == "" && entry.replacedBy == "" {
 		return name
@@ -50,13 +50,13 @@ func formatLineupPlayerWithCards(entry lineupEntry, side string, maxWidth int, t
 	return label
 }
 
-func lineupPlayerLabel(entry lineupEntry, side, name string, shortenNotes, tokens bool) string {
+func lineupPlayerLabel(entry lineupEntry, side site.TeamSide, name string, shortenNotes, tokens bool) string {
 	notes := lineupNotes(entry, side, shortenNotes, tokens)
 	if len(notes) == 0 {
 		return name
 	}
 
-	if side == "home" {
+	if side == site.TeamSideHome {
 		parts := append(notes, name)
 		return strings.Join(parts, " ")
 	}
@@ -65,7 +65,7 @@ func lineupPlayerLabel(entry lineupEntry, side, name string, shortenNotes, token
 	return strings.Join(parts, " ")
 }
 
-func lineupNotes(entry lineupEntry, side string, shortenNotes, tokens bool) []string {
+func lineupNotes(entry lineupEntry, side site.TeamSide, shortenNotes, tokens bool) []string {
 	notes := make([]string, 0, 2)
 
 	if note := entryNote(entry, side, shortenNotes, tokens); note != "" {
@@ -78,14 +78,14 @@ func lineupNotes(entry lineupEntry, side string, shortenNotes, tokens bool) []st
 	return notes
 }
 
-func entryNote(entry lineupEntry, side string, shortenNotes, tokens bool) string {
+func entryNote(entry lineupEntry, side site.TeamSide, shortenNotes, tokens bool) string {
 	if entry.enteredAt == "" {
 		return ""
 	}
 
 	replaced := formatSubNoteName(entry.replaced, shortenNotes)
 	card := lineupCardText(entry.replacedYC, tokens)
-	if side == "home" {
+	if side == site.TeamSideHome {
 		text := "(" + entry.enteredAt
 		if replaced != "" {
 			text += " for " + replaced + card
@@ -104,7 +104,7 @@ func entryNote(entry lineupEntry, side string, shortenNotes, tokens bool) string
 	return substitutionNoteText(text+")", tokens)
 }
 
-func exitNote(entry lineupEntry, side string, shortenNotes, tokens bool) string {
+func exitNote(entry lineupEntry, side site.TeamSide, shortenNotes, tokens bool) string {
 	if entry.replacedBy == "" {
 		return ""
 	}
@@ -112,17 +112,17 @@ func exitNote(entry lineupEntry, side string, shortenNotes, tokens bool) string 
 	replacement := formatSubNoteName(entry.replacedBy, shortenNotes)
 	card := lineupCardText(entry.replacedByYC, tokens)
 	text := "("
-	if side == "home" && entry.leftAt != "" {
+	if side == site.TeamSideHome && entry.leftAt != "" {
 		text += entry.leftAt + " "
 	}
-	if side != "home" && card != "" {
+	if side != site.TeamSideHome && card != "" {
 		text += card + " "
 	}
 	text += replacement
-	if side == "home" {
+	if side == site.TeamSideHome {
 		text += card
 	}
-	if side != "home" && entry.leftAt != "" {
+	if side != site.TeamSideHome && entry.leftAt != "" {
 		text += " " + entry.leftAt
 	}
 	return substitutionNoteText(text+")", tokens)
@@ -178,7 +178,7 @@ func annotateLineupPlayer(player site.PlayerLine, idx map[string][]site.MatchEve
 func annotateLineupPlayerInRoster(player site.PlayerLine, idx map[string][]site.MatchEvent, players []site.PlayerLine) lineupEntry {
 	entry := lineupEntry{player: player}
 	for _, event := range sortedEvents(matchingPlayerEventsInRoster(player.Name, idx, players)) {
-		if event.Kind != "SUB" {
+		if event.Kind != site.EventKindSubstitution {
 			continue
 		}
 

--- a/internal/ui/render_players.go
+++ b/internal/ui/render_players.go
@@ -42,17 +42,17 @@ func sortedEvents(events []site.MatchEvent) []site.MatchEvent {
 	return ordered
 }
 
-func eventWeight(kind string) int {
+func eventWeight(kind site.MatchEventKind) int {
 	switch kind {
-	case "GOAL":
+	case site.EventKindGoal:
 		return 0
-	case "MISS":
+	case site.EventKindMiss:
 		return 1
-	case "RC":
+	case site.EventKindRedCard:
 		return 2
-	case "YC":
+	case site.EventKindYellowCard:
 		return 3
-	case "SUB":
+	case site.EventKindSubstitution:
 		return 4
 	default:
 		return 9
@@ -73,17 +73,17 @@ func faintPenaltySuffix(text string) string {
 	return strings.ReplaceAll(text, "(pen)", faintText("(pen)"))
 }
 
-func eventPrefix(kind string) string {
+func eventPrefix(kind site.MatchEventKind) string {
 	switch kind {
-	case "GOAL":
+	case site.EventKindGoal:
 		return "⚽"
-	case "MISS":
+	case site.EventKindMiss:
 		return "❌"
-	case "SUB":
+	case site.EventKindSubstitution:
 		return "↕"
-	case "YC":
+	case site.EventKindYellowCard:
 		return styleYellow.Render("■")
-	case "RC":
+	case site.EventKindRedCard:
 		return styleRed.Render("■")
 	default:
 		return "•"
@@ -213,14 +213,14 @@ func playerMatchKey(label string) string {
 	return strings.ToLower(formatted)
 }
 
-// Index events by canonical player name; substitutions are keyed by both outgoing and incoming players.
-func playerEventIndex(events []site.MatchEvent, side string) map[string][]site.MatchEvent {
+// Key substitutions by both players so lineup annotations can find entries and exits.
+func playerEventIndex(events []site.MatchEvent, side site.TeamSide) map[string][]site.MatchEvent {
 	idx := make(map[string][]site.MatchEvent)
 	for _, e := range events {
 		if e.TeamSide != side {
 			continue
 		}
-		if e.Kind == "SUB" {
+		if e.Kind == site.EventKindSubstitution {
 			out, in := substitutionPlayers(e)
 			if key := playerMatchKey(out); key != "" {
 				idx[key] = append(idx[key], e)
@@ -356,7 +356,7 @@ func matchingSubstituteCardEventsInRoster(name string, idx map[string][]site.Mat
 func filterCardEvents(events []site.MatchEvent) []site.MatchEvent {
 	filtered := make([]site.MatchEvent, 0, len(events))
 	for _, event := range events {
-		if event.Kind == "YC" || event.Kind == "RC" {
+		if event.Kind == site.EventKindYellowCard || event.Kind == site.EventKindRedCard {
 			filtered = append(filtered, event)
 		}
 	}

--- a/internal/ui/view_match.go
+++ b/internal/ui/view_match.go
@@ -308,8 +308,8 @@ func (m Model) matchDetailContent(width int) string {
 		b.WriteString(renderLineupHeaderRow(m.match.HomeTeam, m.match.AwayTeam, width))
 		b.WriteString("\n")
 
-		homeIdx := playerEventIndex(m.match.Events, "home")
-		awayIdx := playerEventIndex(m.match.Events, "away")
+		homeIdx := playerEventIndex(m.match.Events, site.TeamSideHome)
+		awayIdx := playerEventIndex(m.match.Events, site.TeamSideAway)
 		homeEntries := annotatedLineup(m.match.HomeLineup, homeIdx)
 		awayEntries := annotatedLineup(m.match.AwayLineup, awayIdx)
 		maxPlayers := max(len(homeEntries), len(awayEntries))
@@ -325,8 +325,8 @@ func (m Model) matchDetailContent(width int) string {
 			}
 
 			b.WriteString(renderLineupPlayerRow(
-				lineupDisplayName(hEntry, "home", playerWidth), lineupCardForEntry(hEntry, homeIdx),
-				lineupDisplayName(aEntry, "away", playerWidth), lineupCardForEntry(aEntry, awayIdx),
+				lineupDisplayName(hEntry, site.TeamSideHome, playerWidth), lineupCardForEntry(hEntry, homeIdx),
+				lineupDisplayName(aEntry, site.TeamSideAway, playerWidth), lineupCardForEntry(aEntry, awayIdx),
 				width,
 			))
 			b.WriteString("\n")

--- a/internal/ui/view_match_lineups.go
+++ b/internal/ui/view_match_lineups.go
@@ -42,7 +42,7 @@ func renderLineupHeaderRow(home, away string, width int) string {
 	return renderFullLine(axisPlainLine(home, "   ", away, width), width, colorBgHeader, colorAccent, true)
 }
 
-func lineupDisplayName(entry lineupEntry, side string, maxWidth int) string {
+func lineupDisplayName(entry lineupEntry, side site.TeamSide, maxWidth int) string {
 	return formatLineupPlayerWithCards(entry, side, maxWidth, true)
 }
 
@@ -70,9 +70,9 @@ func cardMarkerFromEvents(matched []site.MatchEvent) lineupCardMarker {
 	hasYellow := false
 	for _, event := range matched {
 		switch event.Kind {
-		case "RC":
+		case site.EventKindRedCard:
 			return lineupCardMarker{color: colorRed, ok: true}
-		case "YC":
+		case site.EventKindYellowCard:
 			hasYellow = true
 		}
 	}
@@ -92,8 +92,8 @@ func renderLineupPlayerRow(home string, homeCard lineupCardMarker, away string, 
 	defaultStyle := lipgloss.NewStyle().Foreground(colorTextSecondary).Background(colorBgPanel)
 	divider := defaultStyle.Render("│")
 
-	left := lineupSideCell(home, homeCard, leftWidth, "home", defaultStyle)
-	right := lineupSideCell(away, awayCard, rightWidth, "away", defaultStyle)
+	left := lineupSideCell(home, homeCard, leftWidth, site.TeamSideHome, defaultStyle)
+	right := lineupSideCell(away, awayCard, rightWidth, site.TeamSideAway, defaultStyle)
 	return left + divider + right
 }
 
@@ -103,7 +103,7 @@ func lineupPlayerNameWidth(width int) int {
 	return max(1, min(leftWidth, rightWidth)-2)
 }
 
-func lineupSideCell(name string, card lineupCardMarker, width int, side string, defaultStyle lipgloss.Style) string {
+func lineupSideCell(name string, card lineupCardMarker, width int, side site.TeamSide, defaultStyle lipgloss.Style) string {
 	if width <= 0 {
 		return ""
 	}
@@ -112,14 +112,14 @@ func lineupSideCell(name string, card lineupCardMarker, width int, side string, 
 	cardStyle := lipgloss.NewStyle().Foreground(card.color).Background(colorBgPanel).Bold(true)
 
 	switch side {
-	case "home":
-		text := renderLineupLabel(name, nameWidth, "home", defaultStyle)
+	case site.TeamSideHome:
+		text := renderLineupLabel(name, nameWidth, site.TeamSideHome, defaultStyle)
 		if !card.ok {
 			return text + defaultStyle.Render("  ")
 		}
 		return text + cardStyle.Render("■") + defaultStyle.Render(" ")
 	default:
-		text := renderLineupLabel(name, nameWidth, "away", defaultStyle)
+		text := renderLineupLabel(name, nameWidth, site.TeamSideAway, defaultStyle)
 		if !card.ok {
 			return defaultStyle.Render("  ") + text
 		}
@@ -127,9 +127,9 @@ func lineupSideCell(name string, card lineupCardMarker, width int, side string, 
 	}
 }
 
-func renderLineupLabel(label string, width int, side string, defaultStyle lipgloss.Style) string {
+func renderLineupLabel(label string, width int, side site.TeamSide, defaultStyle lipgloss.Style) string {
 	text := truncate(label, width)
-	if side == "home" {
+	if side == site.TeamSideHome {
 		text = padLeft(text, width)
 	} else {
 		text = padRight(text, width)

--- a/internal/ui/view_match_panel.go
+++ b/internal/ui/view_match_panel.go
@@ -203,12 +203,12 @@ func halftimeScoreAlways(events []site.MatchEvent) string {
 	homeGoals := 0
 	awayGoals := 0
 	for _, event := range sortedEvents(events) {
-		if !event.HasMinute || event.Minute*100+event.Stoppage > firstHalfMinuteCeiling || event.Kind != "GOAL" {
+		if !event.HasMinute || event.Minute*100+event.Stoppage > firstHalfMinuteCeiling || event.Kind != site.EventKindGoal {
 			continue
 		}
-		if event.TeamSide == "home" {
+		if event.TeamSide == site.TeamSideHome {
 			homeGoals++
-		} else if event.TeamSide == "away" {
+		} else if event.TeamSide == site.TeamSideAway {
 			awayGoals++
 		}
 	}

--- a/internal/ui/view_match_timeline.go
+++ b/internal/ui/view_match_timeline.go
@@ -29,9 +29,9 @@ func splitTimelineRows(events []site.MatchEvent) ([]timelineRow, []timelineRow) 
 		}
 		row := timelineRow{home: "—", away: "—", marker: marker, color: color}
 		switch event.TeamSide {
-		case "home":
+		case site.TeamSideHome:
 			row.home = label
-		case "away":
+		case site.TeamSideAway:
 			row.away = label
 		default:
 			continue
@@ -47,13 +47,13 @@ func splitTimelineRows(events []site.MatchEvent) ([]timelineRow, []timelineRow) 
 	return firstHalf, secondHalf
 }
 
-func timelineMarker(kind string) (string, color.Color, bool) {
+func timelineMarker(kind site.MatchEventKind) (string, color.Color, bool) {
 	switch kind {
-	case "GOAL":
+	case site.EventKindGoal:
 		return "⚽", colorAccent, true
-	case "MISS":
+	case site.EventKindMiss:
 		return "❌", colorLoss, true
-	case "RC":
+	case site.EventKindRedCard:
 		return "■", colorRed, true
 	default:
 		return "", colorTextMuted, false
@@ -66,7 +66,7 @@ func timelineEventLabel(event site.MatchEvent) string {
 	if name == "" || minute == "" {
 		return ""
 	}
-	if event.TeamSide == "away" {
+	if event.TeamSide == site.TeamSideAway {
 		return strings.TrimSpace(minute) + " " + name
 	}
 	return name + " " + minute

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -12,7 +12,7 @@ import (
 
 // testEvent creates a site.MatchEvent with minute fields pre-populated so tests
 // bypass the site parser boundary while still exercising minute-aware rendering.
-func testEvent(minuteText, kind, side, text string) site.MatchEvent {
+func testEvent(minuteText string, kind site.MatchEventKind, side site.TeamSide, text string) site.MatchEvent {
 	m, s, ok := site.ParseMinute(minuteText)
 	event := site.MatchEvent{
 		MinuteText: minuteText,
@@ -23,7 +23,7 @@ func testEvent(minuteText, kind, side, text string) site.MatchEvent {
 		TeamSide:   side,
 		Text:       text,
 	}
-	if kind == "SUB" {
+	if kind == site.EventKindSubstitution {
 		event.SubstitutionOut, event.SubstitutionIn = testSubstitutionPlayers(text)
 	}
 	return event
@@ -37,14 +37,14 @@ func testSubstitutionPlayers(text string) (string, string) {
 	return strings.TrimSpace(left), strings.TrimSpace(right)
 }
 
-func testSubstitutionEvent(minuteText, side, outgoing, incoming, text string) site.MatchEvent {
+func testSubstitutionEvent(minuteText string, side site.TeamSide, outgoing, incoming, text string) site.MatchEvent {
 	m, s, ok := site.ParseMinute(minuteText)
 	return site.MatchEvent{
 		MinuteText:      minuteText,
 		Minute:          m,
 		Stoppage:        s,
 		HasMinute:       ok,
-		Kind:            "SUB",
+		Kind:            site.EventKindSubstitution,
 		TeamSide:        side,
 		Text:            text,
 		SubstitutionOut: outgoing,
@@ -345,8 +345,8 @@ func TestMatchDetailRemovesRedundantMetadata(t *testing.T) {
 		Meta:        "13 marca 2026, 18:00 3542 Damian Kos",
 		Weather:     "15 C",
 		Events: []site.MatchEvent{
-			testEvent("17", "GOAL", "home", "Krzysztof Kubica 17"),
-			testEvent("62", "GOAL", "away", "Samuel Mraz 62"),
+			testEvent("17", site.EventKindGoal, site.TeamSideHome, "Krzysztof Kubica 17"),
+			testEvent("62", site.EventKindGoal, site.TeamSideAway, "Samuel Mraz 62"),
 		},
 		NewsTitle: "PKO BP Ekstraklasa: Bruk-Bet Termalica 1-2 Motor",
 		NewsURL:   "http://www.90minut.pl/news/example.html",
@@ -395,13 +395,13 @@ func TestMatchDetailShowsEventsInScoreHeaderAndLineups(t *testing.T) {
 		AwayTeam: "Lechia Gdansk",
 		Score:    "2-1",
 		Events: []site.MatchEvent{
-			testEvent("39", "GOAL", "home", "Wdowiak 39"),
-			testSubstitutionEvent("46", "home", "Igor Strzalek (86)", "Damian Nowak", "display text without arrow"),
-			testEvent("46", "SUB", "away", "O. Lesniak -> Pllana"),
-			testEvent("52", "MISS", "away", "Barkowskij 52 (nk)"),
-			testEvent("60", "GOAL", "home", "Szkurin 60"),
-			testEvent("70", "GOAL", "away", "Karol Czubak (k) 70"),
-			testEvent("85", "RC", "away", "Pllana 85"),
+			testEvent("39", site.EventKindGoal, site.TeamSideHome, "Wdowiak 39"),
+			testSubstitutionEvent("46", site.TeamSideHome, "Igor Strzalek (86)", "Damian Nowak", "display text without arrow"),
+			testEvent("46", site.EventKindSubstitution, site.TeamSideAway, "O. Lesniak -> Pllana"),
+			testEvent("52", site.EventKindMiss, site.TeamSideAway, "Barkowskij 52 (nk)"),
+			testEvent("60", site.EventKindGoal, site.TeamSideHome, "Szkurin 60"),
+			testEvent("70", site.EventKindGoal, site.TeamSideAway, "Karol Czubak (k) 70"),
+			testEvent("85", site.EventKindRedCard, site.TeamSideAway, "Pllana 85"),
 		},
 		HomeLineup: []site.PlayerLine{
 			{Name: "Wdowiak"},
@@ -490,11 +490,11 @@ func TestRenderLineupPlayerRowColorsCards(t *testing.T) {
 
 func TestAwayBookedSubstituteUsesInlineCard(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("81", "SUB", "away", "Jan Starter -> Sebastian Kubiak"),
-		testEvent("85", "RC", "away", "Sebastian Kubiak 85"),
-	}, "away")
+		testEvent("81", site.EventKindSubstitution, site.TeamSideAway, "Jan Starter -> Sebastian Kubiak"),
+		testEvent("85", site.EventKindRedCard, site.TeamSideAway, "Sebastian Kubiak 85"),
+	}, site.TeamSideAway)
 	entry := annotateLineupPlayer(site.PlayerLine{Name: "Jan Starter"}, idx)
-	row := renderLineupPlayerRow("", lineupCardMarker{}, lineupDisplayName(entry, "away", 64), lineupCardForEntry(entry, idx), 96)
+	row := renderLineupPlayerRow("", lineupCardMarker{}, lineupDisplayName(entry, site.TeamSideAway, 64), lineupCardForEntry(entry, idx), 96)
 	plain := ansi.Strip(row)
 
 	if !strings.Contains(plain, "J. Starter (■ S. Kubiak 81')") {
@@ -512,8 +512,8 @@ func TestMatchDetailShowsAbbreviatedAwaySubstituteCardInline(t *testing.T) {
 		AwayTeam: "Away",
 		Score:    "1-1",
 		Events: []site.MatchEvent{
-			testEvent("81", "SUB", "away", "Jan Starter -> Sebastian Kubiak"),
-			testEvent("85", "YC", "away", "S. Kubiak 85"),
+			testEvent("81", site.EventKindSubstitution, site.TeamSideAway, "Jan Starter -> Sebastian Kubiak"),
+			testEvent("85", site.EventKindYellowCard, site.TeamSideAway, "S. Kubiak 85"),
 		},
 		AwayLineup: []site.PlayerLine{{Name: "Jan Starter"}},
 	}
@@ -535,8 +535,8 @@ func TestHomeBookedReplacementDoesNotUseStarterCardSlot(t *testing.T) {
 		AwayTeam: "Away",
 		Score:    "1-1",
 		Events: []site.MatchEvent{
-			testEvent("77", "SUB", "home", "Pawel Kun -> Kacper Chodyna"),
-			testEvent("85", "YC", "home", "K. Chodyna 85"),
+			testEvent("77", site.EventKindSubstitution, site.TeamSideHome, "Pawel Kun -> Kacper Chodyna"),
+			testEvent("85", site.EventKindYellowCard, site.TeamSideHome, "K. Chodyna 85"),
 		},
 		HomeLineup: []site.PlayerLine{{Name: "Pawel Kun"}},
 	}
@@ -558,8 +558,8 @@ func TestMatchDetailDoesNotMisattributeAmbiguousAbbreviatedSubstitution(t *testi
 		AwayTeam: "Away",
 		Score:    "0-0",
 		Events: []site.MatchEvent{
-			testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Nowak"),
-			testEvent("75", "SUB", "home", "J. Kowalski -> Adam Zielinski"),
+			testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "J. Kowalski -> Piotr Nowak"),
+			testEvent("75", site.EventKindSubstitution, site.TeamSideHome, "J. Kowalski -> Adam Zielinski"),
 		},
 		HomeLineup: []site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}},
 	}
@@ -580,8 +580,8 @@ func TestMatchDetailDoesNotAttachAmbiguousReplacementCardToLineup(t *testing.T) 
 		AwayTeam: "Away",
 		Score:    "0-0",
 		Events: []site.MatchEvent{
-			testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Nowak"),
-			testEvent("70", "YC", "home", "Piotr Nowak 70"),
+			testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "J. Kowalski -> Piotr Nowak"),
+			testEvent("70", site.EventKindYellowCard, site.TeamSideHome, "Piotr Nowak 70"),
 		},
 		HomeLineup: []site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}},
 	}
@@ -599,7 +599,7 @@ func TestHalftimeScoreDisplayAvoidsInventingSparseHT(t *testing.T) {
 	if got := halftimeScoreDisplay(&site.MatchPage{Score: "1-0"}); got != "HT —" {
 		t.Fatalf("expected sparse match to avoid invented HT score, got %q", got)
 	}
-	got := halftimeScoreDisplay(&site.MatchPage{Events: []site.MatchEvent{testEvent("90", "GOAL", "home", "Winner 90")}})
+	got := halftimeScoreDisplay(&site.MatchPage{Events: []site.MatchEvent{testEvent("90", site.EventKindGoal, site.TeamSideHome, "Winner 90")}})
 	if got != "HT 0 – 0" {
 		t.Fatalf("expected second-half goal to imply goalless HT, got %q", got)
 	}
@@ -612,8 +612,8 @@ func TestMatchDetailOrdersScorersAroundHTAndFT(t *testing.T) {
 		AwayTeam: "Away",
 		Score:    "1-1",
 		Events: []site.MatchEvent{
-			testEvent("35", "GOAL", "home", "First Scorer 35"),
-			testEvent("56", "GOAL", "away", "Second Scorer 56"),
+			testEvent("35", site.EventKindGoal, site.TeamSideHome, "First Scorer 35"),
+			testEvent("56", site.EventKindGoal, site.TeamSideAway, "Second Scorer 56"),
 		},
 	}
 
@@ -635,12 +635,12 @@ func TestFormatLineupPlayerMirrorsSubstitutionNote(t *testing.T) {
 		player:     site.PlayerLine{Name: "Igor Strzalek"},
 		leftAt:     "46'",
 		replacedBy: "Damian Nowak",
-	}, "home", 64)
+	}, site.TeamSideHome, 64)
 	away := formatLineupPlayer(lineupEntry{
 		player:     site.PlayerLine{Name: "J. Wilson-Esbrand"},
 		leftAt:     "46'",
 		replacedBy: "J. Grzesik",
-	}, "away", 64)
+	}, site.TeamSideAway, 64)
 
 	if got := ansi.Strip(home); got != "(46' D. Nowak) I. Strzalek" {
 		t.Fatalf("unexpected home lineup substitution label: %q", got)
@@ -667,14 +667,14 @@ func TestFormatLineupPlayerShowsEntryAndExitNotes(t *testing.T) {
 		replaced:   "Jason Lokilo",
 		leftAt:     "82'",
 		replacedBy: "Michal Smith",
-	}, "home", 64)
+	}, site.TeamSideHome, 64)
 	away := formatLineupPlayer(lineupEntry{
 		player:     site.PlayerLine{Name: "Oskar Lesniak"},
 		enteredAt:  "66'",
 		replaced:   "Jason Lokilo",
 		leftAt:     "82'",
 		replacedBy: "Michal Smith",
-	}, "away", 64)
+	}, site.TeamSideAway, 64)
 
 	if got := ansi.Strip(home); got != "(66' for J. Lokilo) (82' M. Smith) O. Lesniak" {
 		t.Fatalf("unexpected home double substitution label: %q", got)
@@ -691,7 +691,7 @@ func TestFormatLineupPlayerShortensOnlySubstitutionNotesWhenNeeded(t *testing.T)
 		replaced:   "Christopher Hyperextendedname",
 		leftAt:     "82'",
 		replacedBy: "Maximilian Unnecessarilylongsurname",
-	}, "home", 40))
+	}, site.TeamSideHome, 40))
 
 	if got != "(66' for Hyperextendedname) (82' Unnecessarilylongsurname) A. Verylongsurname" {
 		t.Fatalf("unexpected shortened substitution label: %q", got)
@@ -707,8 +707,8 @@ func TestMatchDetailKeepsInlineSubstitutionAnnotationsInLineups(t *testing.T) {
 		AwayTeam: "Radomiak Radom",
 		Score:    "3-1",
 		Events: []site.MatchEvent{
-			testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
-			testEvent("46", "SUB", "away", "J. Wilson-Esbrand -> J. Grzesik"),
+			testEvent("66", site.EventKindSubstitution, site.TeamSideHome, "Jason Lokilo -> Oskar Lesniak"),
+			testEvent("46", site.EventKindSubstitution, site.TeamSideAway, "J. Wilson-Esbrand -> J. Grzesik"),
 		},
 		HomeLineup: []site.PlayerLine{{Name: "Jason Lokilo"}},
 		AwayLineup: []site.PlayerLine{{Name: "J. Wilson-Esbrand"}},
@@ -775,8 +775,8 @@ func TestRenderPlayerLineAbbreviatesNameAndDropsEvents(t *testing.T) {
 
 func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
-	}, "home")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "Jan Kowalski -> Piotr Kowalski"),
+	}, site.TeamSideHome)
 
 	players := []site.PlayerLine{
 		{Name: "Adam Kowalski"},
@@ -803,7 +803,7 @@ func TestAnnotatedLineupMatchesSubstitutionByCompactNameNotSurnameOnly(t *testin
 }
 
 func TestAnnotatedLineupMatchesAbbreviatedPlayerToFullSubstitution(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "away", "Jan Starter -> Sebastian Kubiak")}, "away")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", site.EventKindSubstitution, site.TeamSideAway, "Jan Starter -> Sebastian Kubiak")}, site.TeamSideAway)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "S. Kubiak"}}, idx)
 	if len(got) != 1 {
@@ -816,8 +816,8 @@ func TestAnnotatedLineupMatchesAbbreviatedPlayerToFullSubstitution(t *testing.T)
 
 func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
-	}, "home")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "Jan Kowalski -> Piotr Kowalski"),
+	}, site.TeamSideHome)
 
 	players := []site.PlayerLine{
 		{Name: "Jerzy Kowalski"},
@@ -841,7 +841,7 @@ func TestAnnotatedLineupDistinguishesSameInitialSameSurname(t *testing.T) {
 }
 
 func TestAnnotatedLineupDoesNotApplyAbbreviatedSubstitutionToFullSameInitialNames(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "home", "J. Kowalski -> Piotr Kowalski")}, "home")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "J. Kowalski -> Piotr Kowalski")}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
 	if len(got) != 2 {
@@ -855,7 +855,7 @@ func TestAnnotatedLineupDoesNotApplyAbbreviatedSubstitutionToFullSameInitialName
 }
 
 func TestAnnotatedLineupDoesNotApplyFullSubstitutionToAmbiguousAbbreviatedRow(t *testing.T) {
-	idx := playerEventIndex([]site.MatchEvent{testEvent("60", "SUB", "home", "Jan Kowalski -> Piotr Kowalski")}, "home")
+	idx := playerEventIndex([]site.MatchEvent{testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "Jan Kowalski -> Piotr Kowalski")}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "J. Kowalski"}, {Name: "Jerzy Kowalski"}}, idx)
 	if len(got) != 2 {
@@ -868,8 +868,8 @@ func TestAnnotatedLineupDoesNotApplyFullSubstitutionToAmbiguousAbbreviatedRow(t 
 
 func TestAnnotatedLineupUsesStructuredSubstitutionPlayers(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testSubstitutionEvent("60", "home", "Jan Starter", "Piotr Entrant", "display text without arrow"),
-	}, "home")
+		testSubstitutionEvent("60", site.TeamSideHome, "Jan Starter", "Piotr Entrant", "display text without arrow"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "Piotr Entrant"}}, idx)
 	if got[0].replacedBy != "Piotr Entrant" || got[1].replaced != "Jan Starter" {
@@ -879,9 +879,9 @@ func TestAnnotatedLineupUsesStructuredSubstitutionPlayers(t *testing.T) {
 
 func TestAnnotatedLineupDoesNotDuplicateExistingAbbreviatedSyntheticEntrant(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "away", "Jan Starter -> Sebastian Kubiak"),
-		testEvent("78", "SUB", "away", "Sebastian Kubiak -> Adam Next"),
-	}, "away")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideAway, "Jan Starter -> Sebastian Kubiak"),
+		testEvent("78", site.EventKindSubstitution, site.TeamSideAway, "Sebastian Kubiak -> Adam Next"),
+	}, site.TeamSideAway)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "S. Kubiak"}}, idx)
 	if len(got) != 2 {
@@ -894,9 +894,9 @@ func TestAnnotatedLineupDoesNotDuplicateExistingAbbreviatedSyntheticEntrant(t *t
 
 func TestAnnotatedLineupDoesNotDuplicateExistingFullEntrantFromAbbreviatedSubstitution(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "away", "Jan Starter -> S. Kubiak"),
-		testEvent("78", "SUB", "away", "Sebastian Kubiak -> Adam Next"),
-	}, "away")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideAway, "Jan Starter -> S. Kubiak"),
+		testEvent("78", site.EventKindSubstitution, site.TeamSideAway, "Sebastian Kubiak -> Adam Next"),
+	}, site.TeamSideAway)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jan Starter"}, {Name: "Sebastian Kubiak"}}, idx)
 	if len(got) != 2 {
@@ -909,9 +909,9 @@ func TestAnnotatedLineupDoesNotDuplicateExistingFullEntrantFromAbbreviatedSubsti
 
 func TestAnnotatedLineupDoesNotAttachAmbiguousAbbreviatedCardToSubstituteNote(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "home", "Starter One -> Jan Kowalski"),
-		testEvent("85", "YC", "home", "J. Kowalski 85"),
-	}, "home")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "Starter One -> Jan Kowalski"),
+		testEvent("85", site.EventKindYellowCard, site.TeamSideHome, "J. Kowalski 85"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Starter One"}, {Name: "Jerzy Kowalski"}}, idx)
 	if len(got) != 2 {
@@ -924,11 +924,11 @@ func TestAnnotatedLineupDoesNotAttachAmbiguousAbbreviatedCardToSubstituteNote(t 
 
 func TestAnnotatedLineupAllowsDistinctFullSyntheticEntrantsWithSameCompactKey(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("60", "SUB", "home", "Starter One -> Oskar Lesniak"),
-		testEvent("61", "SUB", "home", "Starter Two -> Olaf Lesniak"),
-		testEvent("78", "SUB", "home", "Oskar Lesniak -> Next One"),
-		testEvent("79", "SUB", "home", "Olaf Lesniak -> Next Two"),
-	}, "home")
+		testEvent("60", site.EventKindSubstitution, site.TeamSideHome, "Starter One -> Oskar Lesniak"),
+		testEvent("61", site.EventKindSubstitution, site.TeamSideHome, "Starter Two -> Olaf Lesniak"),
+		testEvent("78", site.EventKindSubstitution, site.TeamSideHome, "Oskar Lesniak -> Next One"),
+		testEvent("79", site.EventKindSubstitution, site.TeamSideHome, "Olaf Lesniak -> Next Two"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Starter One"}, {Name: "Starter Two"}}, idx)
 	if len(got) != 4 {
@@ -958,9 +958,9 @@ func lineupEntryByName(entries []lineupEntry, name string) lineupEntry {
 
 func TestAnnotatedLineupKeepsBookedEntrantInReplacementNote(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
-		testEvent("84", "YC", "home", "Oskar Lesniak 84"),
-	}, "home")
+		testEvent("66", site.EventKindSubstitution, site.TeamSideHome, "Jason Lokilo -> Oskar Lesniak"),
+		testEvent("84", site.EventKindYellowCard, site.TeamSideHome, "Oskar Lesniak 84"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
 	if len(got) != 1 {
@@ -973,8 +973,8 @@ func TestAnnotatedLineupKeepsBookedEntrantInReplacementNote(t *testing.T) {
 
 func TestAnnotatedLineupSkipsMissingEntrantWithoutBadgeEvent(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
-	}, "home")
+		testEvent("66", site.EventKindSubstitution, site.TeamSideHome, "Jason Lokilo -> Oskar Lesniak"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
 	if len(got) != 1 {
@@ -987,10 +987,10 @@ func TestAnnotatedLineupSkipsMissingEntrantWithoutBadgeEvent(t *testing.T) {
 
 func TestAnnotatedLineupSyntheticEntrantKeepsLaterSubstitutionOff(t *testing.T) {
 	idx := playerEventIndex([]site.MatchEvent{
-		testEvent("66", "SUB", "home", "Jason Lokilo -> Oskar Lesniak"),
-		testEvent("78", "SUB", "home", "Oskar Lesniak -> Michal Smith"),
-		testEvent("72", "YC", "home", "Oskar Lesniak 72"),
-	}, "home")
+		testEvent("66", site.EventKindSubstitution, site.TeamSideHome, "Jason Lokilo -> Oskar Lesniak"),
+		testEvent("78", site.EventKindSubstitution, site.TeamSideHome, "Oskar Lesniak -> Michal Smith"),
+		testEvent("72", site.EventKindYellowCard, site.TeamSideHome, "Oskar Lesniak 72"),
+	}, site.TeamSideHome)
 
 	got := annotatedLineup([]site.PlayerLine{{Name: "Jason Lokilo"}}, idx)
 	if len(got) != 2 {
@@ -1007,7 +1007,7 @@ func TestFormatLineupPlayerShowsBookedReplacementInsideHomeNote(t *testing.T) {
 		leftAt:       "72'",
 		replacedBy:   "Michal Rzuchowski",
 		replacedByYC: lineupCardMarker{color: colorYellow, ok: true},
-	}, "home", 64)
+	}, site.TeamSideHome, 64)
 
 	if got := ansi.Strip(home); got != "(72' M. Rzuchowski■) O. Jakubczyk" {
 		t.Fatalf("unexpected home booked-replacement label: %q", got)
@@ -1020,7 +1020,7 @@ func TestFormatLineupPlayerShowsBookedReplacedPlayerInsideAwayNote(t *testing.T)
 		enteredAt:  "46'",
 		replaced:   "Jan Kowalczyk",
 		replacedYC: lineupCardMarker{color: colorYellow, ok: true},
-	}, "away", 64)
+	}, site.TeamSideAway, 64)
 
 	if got := ansi.Strip(away); got != "J. Sypek (for ■ J. Kowalczyk 46')" {
 		t.Fatalf("unexpected away booked-replaced label: %q", got)
@@ -1075,8 +1075,8 @@ func TestMatchDetailContentShowsFTDividerWithoutVisibleHeaderEvents(t *testing.T
 		AwayTeam: "Zaglebie Lubin",
 		Score:    "1-0",
 		Events: []site.MatchEvent{
-			testEvent("46", "SUB", "home", "Jan Kowalski -> Piotr Kowalski"),
-			testEvent("72", "YC", "away", "Nowak 72"),
+			testEvent("46", site.EventKindSubstitution, site.TeamSideHome, "Jan Kowalski -> Piotr Kowalski"),
+			testEvent("72", site.EventKindYellowCard, site.TeamSideAway, "Nowak 72"),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add string-backed MatchEventKind and TeamSide constants for parsed match events.
- Update parser and UI event comparisons to use typed constants instead of raw event/side strings.
- Tighten parser/UI tests around the typed event vocabulary and document the remaining raw lineup marker seam.

## Tests
- go test ./...
- go vet ./...

Closes #76