### PR TITLE
Preserve staged competition rounds

### DIFF
--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -30,12 +30,45 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 func parseRounds(doc *goquery.Document) []Round {
 	rounds := make([]Round, 0, 16)
 	currentName := ""
+	currentPhase := RoundPhaseRegular
+	currentSection := ""
+	sectionOneShot := false
 	hasNamedRounds := false
 
+	processHeading := func(name string) {
+		if looksLikeSectionHeading(name) {
+			// Some pages use a standalone group heading for one fixture table; others keep it for repeated matchdays.
+			currentName = ""
+			currentSection = name
+			currentPhase = RoundPhaseGroup
+			sectionOneShot = true
+			return
+		}
+
+		currentName = name
+		matchdayHeading := looksLikeMatchdayHeading(name)
+		if currentSection != "" && !matchdayHeading && !sectionOneShot {
+			currentSection = ""
+		}
+		currentPhase = classifyRoundPhase(name, currentSection)
+		if currentSection != "" && matchdayHeading {
+			sectionOneShot = false
+		}
+		if currentSection != "" && !matchdayHeading {
+			sectionOneShot = true
+		}
+	}
+
 	leagueTables(doc).Each(func(_ int, table *goquery.Selection) {
-		if name, ok := roundNameFromTable(table); ok {
-			currentName = name
+		if names := roundNamesFromTable(table); len(names) > 0 {
+			for _, name := range names {
+				processHeading(name)
+			}
 			hasNamedRounds = true
+			return
+		}
+
+		if table.Find("table").Length() > 0 {
 			return
 		}
 
@@ -45,14 +78,23 @@ func parseRounds(doc *goquery.Document) []Round {
 		}
 
 		roundName := strings.TrimSpace(currentName)
+		round := Round{Phase: currentPhase, Section: currentSection, Name: roundName, Fixtures: fixtures}
 
-		if len(rounds) > 0 && rounds[len(rounds)-1].Name == roundName {
+		if len(rounds) > 0 && sameRoundContext(rounds[len(rounds)-1], round) {
 			// 90minut sometimes splits one round across adjacent tables under the same heading.
 			rounds[len(rounds)-1].Fixtures = append(rounds[len(rounds)-1].Fixtures, fixtures...)
+			if sectionOneShot {
+				currentSection = ""
+				sectionOneShot = false
+			}
 			return
 		}
 
-		rounds = append(rounds, Round{Name: roundName, Fixtures: fixtures})
+		rounds = append(rounds, round)
+		if sectionOneShot {
+			currentSection = ""
+			sectionOneShot = false
+		}
 	})
 
 	if hasNamedRounds {
@@ -60,7 +102,7 @@ func parseRounds(doc *goquery.Document) []Round {
 		// not separate rounds.
 		namedOnly := make([]Round, 0, len(rounds))
 		for _, round := range rounds {
-			if strings.TrimSpace(round.Name) == "" {
+			if strings.TrimSpace(round.Name) == "" && strings.TrimSpace(round.Section) == "" {
 				continue
 			}
 			namedOnly = append(namedOnly, round)
@@ -74,11 +116,46 @@ func parseRounds(doc *goquery.Document) []Round {
 		if strings.TrimSpace(rounds[i].Name) != "" {
 			continue
 		}
+		if strings.TrimSpace(rounds[i].Section) != "" {
+			continue
+		}
 		// Headerless fixture pages still need a stable round label for downstream rendering.
 		rounds[i].Name = "Wyniki"
 	}
 
 	return rounds
+}
+
+func sameRoundContext(a, b Round) bool {
+	return a.Name == b.Name && a.Section == b.Section && a.Phase == b.Phase
+}
+
+func roundNamesFromTable(table *goquery.Selection) []string {
+	if table.Find("a[href*='mecz.php']").Length() > 0 || len(parseFixturesTable(table)) > 0 {
+		return nil
+	}
+
+	var names []string
+	table.Find("u").Each(func(_ int, s *goquery.Selection) {
+		heading := normalizeWhitespace(s.Text())
+		if looksLikeRoundHeading(heading) || looksLikeStageHeading(heading) || looksLikeSectionHeading(heading) {
+			names = append(names, heading)
+		}
+	})
+	if len(names) > 0 {
+		return names
+	}
+
+	if !looksLikeStandaloneHeadingTable(table) {
+		return nil
+	}
+
+	text := normalizeWhitespace(table.ChildrenFiltered("tbody, tr").Text())
+	if looksLikeRoundHeading(text) || looksLikeStageHeading(text) || looksLikeSectionHeading(text) {
+		return []string{text}
+	}
+
+	return nil
 }
 
 func leagueTables(doc *goquery.Document) *goquery.Selection {
@@ -91,25 +168,11 @@ func leagueTables(doc *goquery.Document) *goquery.Selection {
 }
 
 func roundNameFromTable(table *goquery.Selection) (string, bool) {
-	if table.Find("a[href*='mecz.php']").Length() > 0 {
+	names := roundNamesFromTable(table)
+	if len(names) == 0 {
 		return "", false
 	}
-
-	heading := normalizeWhitespace(table.Find("u").First().Text())
-	if looksLikeRoundHeading(heading) || looksLikeStageHeading(heading) {
-		return heading, true
-	}
-
-	if !looksLikeStandaloneHeadingTable(table) {
-		return "", false
-	}
-
-	text := normalizeWhitespace(table.ChildrenFiltered("tbody, tr").Text())
-	if looksLikeRoundHeading(text) || looksLikeStageHeading(text) {
-		return text, true
-	}
-
-	return "", false
+	return names[len(names)-1], true
 }
 
 func looksLikeStandaloneHeadingTable(table *goquery.Selection) bool {
@@ -145,7 +208,11 @@ func looksLikeRoundHeading(text string) bool {
 	}
 
 	lower := strings.ToLower(text)
-	return strings.Contains(lower, "kolejka") || strings.Contains(lower, "runda")
+	return looksLikeMatchdayHeading(lower) || strings.Contains(lower, "runda")
+}
+
+func looksLikeMatchdayHeading(text string) bool {
+	return strings.Contains(strings.ToLower(text), "kolejka")
 }
 
 func looksLikeStageHeading(text string) bool {
@@ -155,6 +222,32 @@ func looksLikeStageHeading(text string) bool {
 
 	lower := strings.ToLower(text)
 	return strings.Contains(lower, "fina") || strings.Contains(lower, "bara") || strings.Contains(lower, "play-off") || strings.Contains(lower, "playoff")
+}
+
+func looksLikeSectionHeading(text string) bool {
+	fields := strings.Fields(normalizeWhitespace(text))
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "grupa") {
+		return false
+	}
+
+	lower := strings.ToLower(text)
+	return !strings.Contains(lower, "kolejka") && !strings.Contains(lower, "runda")
+}
+
+func classifyRoundPhase(name, section string) RoundPhase {
+	lower := strings.ToLower(normalizeWhitespace(name))
+	switch {
+	case strings.Contains(lower, "elimin"):
+		return RoundPhaseQualification
+	case strings.Contains(lower, "przedwst") || strings.Contains(lower, "wst"):
+		return RoundPhasePreliminary
+	case strings.Contains(lower, "fina") || strings.Contains(lower, "bara") || strings.Contains(lower, "play-off") || strings.Contains(lower, "playoff"):
+		return RoundPhaseKnockout
+	case section != "" && strings.Contains(lower, "kolejka"):
+		return RoundPhaseGroup
+	default:
+		return RoundPhaseRegular
+	}
 }
 
 func parseFixturesTable(table *goquery.Selection) []Fixture {

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -34,9 +34,25 @@ type Fixture struct {
 	MatchID string
 }
 
-// Round fixtures are normalized to ascending parsed date/time when available;
+// RoundPhase preserves source competition semantics for mixed tournament pages.
+// Regular rounds are the zero value and are the only rounds eligible for plain league numeric ordering.
+type RoundPhase string
+
+const (
+	RoundPhaseRegular       RoundPhase = ""
+	RoundPhasePreliminary   RoundPhase = "preliminary"
+	RoundPhaseQualification RoundPhase = "qualification"
+	RoundPhaseGroup         RoundPhase = "group"
+	RoundPhaseKnockout      RoundPhase = "knockout"
+)
+
+// Round keeps one source fixture group. Section stores an enclosing source heading
+// such as "Grupa A" so repeated names like "Kolejka 1" stay distinct.
+// Fixtures are normalized to ascending parsed date/time when available;
 // undated entries keep their relative source order after dated fixtures.
 type Round struct {
+	Phase    RoundPhase
+	Section  string
 	Name     string
 	Fixtures []Fixture
 }
@@ -58,7 +74,7 @@ type LeaguePage struct {
 	LeagueKey string
 	// Standings stays empty when the page has no detectable table.
 	Standings []StandingRow
-	// Rounds are ordered by detected round number when available.
+	// Rounds use numeric order only for plain league matchdays; staged competitions keep source order.
 	Rounds []Round
 }
 

--- a/internal/site/ordering.go
+++ b/internal/site/ordering.go
@@ -11,13 +11,17 @@ var roundNumberRe = regexp.MustCompile(`\d+`)
 var fixtureDateRe = regexp.MustCompile(`(?i)(\d{1,2})\s+([\p{L}]+)(?:\s+(\d{4}))?(?:,\s*(\d{1,2}):(\d{2}))?`)
 var seasonYearsRe = regexp.MustCompile(`(\d{4})\s*/\s*(\d{2,4})`)
 
-// Normalize round and fixture order here so every caller sees the same league structure.
+// Normalize fixture order for every round. Round reordering is limited to plain leagues;
+// staged tournaments rely on source order to preserve qualification/group/knockout flow.
 func normalizeLeagueOrder(rounds []Round, leagueTitle string) []Round {
 	ordered := make([]Round, len(rounds))
 	copy(ordered, rounds)
 
 	for i := range ordered {
 		ordered[i].Fixtures = normalizeFixturesByDate(ordered[i].Fixtures, leagueTitle)
+	}
+	if !plainLeagueRounds(ordered) {
+		return ordered
 	}
 
 	type indexedRound struct {
@@ -49,6 +53,26 @@ func normalizeLeagueOrder(rounds []Round, leagueTitle string) []Round {
 	}
 
 	return ordered
+}
+
+func plainLeagueRounds(rounds []Round) bool {
+	if len(rounds) == 0 {
+		return false
+	}
+
+	for _, round := range rounds {
+		if round.Phase != RoundPhaseRegular || strings.TrimSpace(round.Section) != "" {
+			return false
+		}
+		if !looksLikeMatchdayHeading(round.Name) {
+			return false
+		}
+		if _, ok := roundNumber(round.Name); !ok {
+			return false
+		}
+	}
+
+	return true
 }
 
 func normalizeFixturesByDate(fixtures []Fixture, leagueTitle string) []Fixture {

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -173,6 +173,224 @@ func TestParseLeaguePageSeparatesKnockoutStageFromLeagueRound(t *testing.T) {
 	}
 }
 
+func TestParseLeaguePagePreservesChampionsLeagueStageOrder(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_14077.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga14077.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	want := []struct {
+		name  string
+		phase RoundPhase
+	}{
+		{"I runda eliminacyjna - 8-9 lipca, 15-16 lipca", RoundPhaseQualification},
+		{"II runda eliminacyjna - 22-23 lipca, 29-30 lipca", RoundPhaseQualification},
+		{"III runda eliminacyjna - 5-6 sierpnia, 12-13 sierpnia", RoundPhaseQualification},
+		{"IV runda eliminacyjna - 19-20 sierpnia, 26-27 sierpnia", RoundPhaseQualification},
+		{"Kolejka 1 - 16-18 września", RoundPhaseGroup},
+	}
+	if len(page.Rounds) < len(want) {
+		t.Fatalf("expected at least %d rounds, got %d", len(want), len(page.Rounds))
+	}
+	for i, expected := range want {
+		if page.Rounds[i].Name != expected.name || page.Rounds[i].Phase != expected.phase {
+			t.Fatalf("round %d got %q/%q want %q/%q", i, page.Rounds[i].Name, page.Rounds[i].Phase, expected.name, expected.phase)
+		}
+	}
+	if page.Rounds[4].Section != "Grupa LM" {
+		t.Fatalf("expected league-phase section, got %q", page.Rounds[4].Section)
+	}
+}
+
+func TestParseLeaguePageKeepsRepeatedGroupMatchdaysSeparate(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_12909.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga12909.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	groupRounds := make([]Round, 0, 12)
+	for _, round := range page.Rounds {
+		if round.Section == "Grupa A" || round.Section == "Grupa B" {
+			groupRounds = append(groupRounds, round)
+		}
+	}
+	if len(groupRounds) < 12 {
+		t.Fatalf("expected at least 12 group rounds, got %d", len(groupRounds))
+	}
+
+	want := []struct{ section, name string }{
+		{"Grupa A", "Kolejka 1 - 19-20 września"},
+		{"Grupa A", "Kolejka 2 - 3-4 października"},
+		{"Grupa A", "Kolejka 3 - 24-25 października"},
+		{"Grupa A", "Kolejka 4 - 7-8 listopada"},
+		{"Grupa A", "Kolejka 5 - 28-29 listopada"},
+		{"Grupa A", "Kolejka 6 - 12-13 grudnia"},
+		{"Grupa B", "Kolejka 1 - 19-20 września"},
+	}
+	for i, expected := range want {
+		if groupRounds[i].Section != expected.section || groupRounds[i].Name != expected.name {
+			t.Fatalf("group round %d got %q/%q want %q/%q", i, groupRounds[i].Section, groupRounds[i].Name, expected.section, expected.name)
+		}
+		if groupRounds[i].Phase != RoundPhaseGroup {
+			t.Fatalf("expected group phase for %q/%q, got %q", groupRounds[i].Section, groupRounds[i].Name, groupRounds[i].Phase)
+		}
+	}
+	for _, round := range page.Rounds {
+		if !strings.Contains(round.Name, "finału") {
+			continue
+		}
+		if round.Section != "" {
+			t.Fatalf("knockout round inherited group section: %+v", round)
+		}
+		return
+	}
+	t.Fatalf("expected knockout round after group phase")
+}
+
+func TestParseLeaguePageHandlesTournamentGroupsWithoutHeadingDates(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_13459.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga13459.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	var firstGroupRound *Round
+	for i := range page.Rounds {
+		if page.Rounds[i].Section == "Grupa A" && page.Rounds[i].Name == "Kolejka 1" {
+			firstGroupRound = &page.Rounds[i]
+			break
+		}
+	}
+	if firstGroupRound == nil {
+		t.Fatalf("expected Grupa A / Kolejka 1 round")
+	}
+	if firstGroupRound.Phase != RoundPhaseGroup {
+		t.Fatalf("expected group phase, got %q", firstGroupRound.Phase)
+	}
+	if len(firstGroupRound.Fixtures) == 0 || !strings.Contains(firstGroupRound.Fixtures[0].WhenInfo, "14 czerwca") {
+		t.Fatalf("expected fixture row date in WhenInfo, got %+v", firstGroupRound.Fixtures)
+	}
+}
+
+func TestParseLeaguePageKeepsSectionOnlyFixtureGroup(t *testing.T) {
+	html := `
+	<html><head><title>Section Only</title></head><body>
+	<table><tr><td><u>Grupa finałowa</u></td></tr></table>
+	<table>
+	<tr><td>Team A</td><td><a href="/mecz.php?id_mecz=1">1-0</a></td><td>Team B</td><td>1 maja, 18:00</td></tr>
+	</table>
+	<table><tr><td><u>1/2 finału</u></td></tr></table>
+	<table>
+	<tr><td>Team C</td><td><a href="/mecz.php?id_mecz=2">2-0</a></td><td>Team D</td><td>8 maja, 18:00</td></tr>
+	</table>
+	</body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	if err != nil {
+		t.Fatalf("parse synthetic HTML: %v", err)
+	}
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/section-only.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+	if len(page.Rounds) != 2 {
+		t.Fatalf("expected 2 rounds, got %d", len(page.Rounds))
+	}
+	if page.Rounds[0].Section != "Grupa finałowa" || page.Rounds[0].Name != "" || page.Rounds[0].Phase != RoundPhaseGroup {
+		t.Fatalf("unexpected section-only round: %+v", page.Rounds[0])
+	}
+	if page.Rounds[1].Section != "" || page.Rounds[1].Name != "1/2 finału" || page.Rounds[1].Phase != RoundPhaseKnockout {
+		t.Fatalf("knockout round inherited section context: %+v", page.Rounds[1])
+	}
+}
+
+func TestParseLeaguePagePreservesSectionedQualifierSourceOrder(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_14042.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga14042.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	indexes := map[string]int{}
+	for i, round := range page.Rounds {
+		key := round.Section + "/" + round.Name
+		if _, exists := indexes[key]; !exists {
+			indexes[key] = i
+		}
+	}
+	groupAEnd, ok := indexes["Grupa A/Kolejka 10 - 16-18 listopada"]
+	if !ok {
+		t.Fatalf("expected Grupa A final matchday")
+	}
+	groupBStart, ok := indexes["Grupa B/Kolejka 5 - 4-6 września"]
+	if !ok {
+		t.Fatalf("expected Grupa B first matchday")
+	}
+	if groupAEnd >= groupBStart {
+		t.Fatalf("expected source order to finish Grupa A before Grupa B")
+	}
+}
+
+func TestParseLeaguePageDoesNotTreatUnderlinedFixtureTeamsAsSections(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_10529.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga10529.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	foundRound := false
+	foundNextRound := false
+	for _, round := range page.Rounds {
+		if round.Name != "1/16 finału - 26-27 stycznia" {
+			if round.Name == "1/8 finału - 13-14 lutego" {
+				foundNextRound = true
+				if round.Section != "" {
+					t.Fatalf("fixture team section leaked into next round: %+v", round)
+				}
+			}
+			continue
+		}
+		foundRound = true
+		if round.Section != "" {
+			t.Fatalf("underlined team name should not become a section: %q", round.Section)
+		}
+	}
+	if !foundRound {
+		t.Fatalf("expected 1/16 final round")
+	}
+	if !foundNextRound {
+		t.Fatalf("expected 1/8 final round")
+	}
+}
+
+func TestParseLeaguePageKeepsPlainLeagueNumericOrder(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_8694.html")
+
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/0/liga8694.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+	if len(page.Rounds) < 37 {
+		t.Fatalf("expected at least 37 rounds, got %d", len(page.Rounds))
+	}
+	if page.Rounds[0].Name != "Kolejka 1 - 16-17 lipca" || page.Rounds[36].Name != "Kolejka 37 - 2-4 czerwca" {
+		t.Fatalf("unexpected plain league order: first=%q last=%q", page.Rounds[0].Name, page.Rounds[36].Name)
+	}
+	for _, round := range page.Rounds[:37] {
+		if round.Phase != RoundPhaseRegular || round.Section != "" {
+			t.Fatalf("expected plain league round, got %+v", round)
+		}
+	}
+}
+
 func TestParseFixturesTableSkipsRowsWithMultipleMatchLinks(t *testing.T) {
 	html := `
 	<table>

--- a/internal/site/testdata/fixtures/league_10529.html
+++ b/internal/site/testdata/fixtures/league_10529.html
@@ -1,0 +1,1149 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Puchar Polski w futsalu 2018/2019</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async=true>
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://cmp.inmobi.com'
+    .concat('/choice/', 't_XST3kwtPra_', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=13482"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=13483"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez24-25.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13482" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13483" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13484" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13482" class="menulnk" title="Sparingi - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13483" class="menulnk" title="Sparingi - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13484" class="menulnk" title="Sparingi - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13482&runda=1" class="menulnk" title="Przygotowania - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13483&runda=1" class="menulnk" title="Przygotowania - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13484&runda=1" class="menulnk" title="Przygotowania - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=103" class="menulnk" title="Baraże 2024" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13482.html" class="menulnk" title="Ekstraklasa 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13483.html" class="menulnk" title="I liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13484.html" class="menulnk" title="II liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=105" class="menulnk" title="III Liga 2024/2025 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13556.html" class="menulnk" title="III Liga 2024/2025 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13557.html" class="menulnk" title="III Liga 2024/2025 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13558.html" class="menulnk" title="III Liga 2024/2025 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13559.html" class="menulnk" title="III Liga 2024/2025 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13870.html" class="menulnk" title="Centralna Liga Juniorów 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13871.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13872.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13486.html" class="menulnk" title="Puchar Polski 2024/2025 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13485.html" class="menulnk" title="Superpuchar 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=105" class="menulnk" title="Rozgrywki pucharowe w Polsce 2024/2025 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2024/2025 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13487.html" class="menulnk" title="Liga Mistrzów 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13488.html" class="menulnk" title="Liga Europy 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13489.html" class="menulnk" title="Liga Konferencji 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13552.html" class="menulnk" title="Liga Młodzieżowa 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_reprezentacji_uefa.php?rok=2017" class="menulnk" title="Ranking reprezentacyjny UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprez. UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=105" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=105" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=105" class="menulnk" title="Reprezentacja Polski 2024/2025 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga11718.html" class="menulnk" title="Eliminacje mistrzostw świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12322.html" class="menulnk" title="Mistrzostwa świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13467.html" class="menulnk" title="Liga Narodów 2024/2025 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 24/25</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=105" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=105" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/pp2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga10529.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=10529" class="main">Strzelcy</a> | <a href="/stats.php?id=10529" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Puchar Polski w futsalu 2018/2019</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_UEFA_neutral -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/32 finału - 5-6 stycznia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 16 grudnia 2018, 14:45 - Hala MOSiR w Bochni)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Grupa CRB Mrówka Mosina  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>7-4</b></td>
+<td nowrap valign="top" width="180"><b>  Mieszko Gniezno  </b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 12:00</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Kubiak 1, 13, 23, 44, Dariusz Pieczyński 32, Tomasz Gajewski 42, Szymon Wichtowski 45 - Łukasz Pieczyński 2 (s), Dariusz Rychłowski 11, Marcin Geser 14, Mariusz Sawicki 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  ALHPN TSR Rafa/BZ-Bud Lubowidz  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  LSSS Lębork  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 16:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wybrzeże Rewalskie Rewal  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-10</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  LZS Bojano  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  TAF Toruń  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Leszno  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>nieznany</i> 22, 34, 40 - Jakub Molicki 8, Jan Martin 13, Kacper Konopacki 26, 27, Michał Bartnicki 31, Adrian Niedźwiedzki 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  FC Kartuzy  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Oborniki  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Papina 20, 31, Michał Papina 24 - Jacek Sander 8, Tomasz Wicberger 28, Oktawian Solecki 31, Bartosz Banasik 34</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Kiełpinie</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Zdrowie Garwolin  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>8-1</b></td>
+<td nowrap valign="top" width="180"><b>  AZS UW Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Narew Choroszcz  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>5-0</b></td>
+<td nowrap valign="top" width="180"><b>  Vamos Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 17:00</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>(wo) </b></td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Białymstoku / goście wycofali się z rozgrywek</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Łęczycanie Łęczyca  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-5</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Constract Lubawa  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  KoGo Team Mrągowo  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-3</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Malwee Łódź  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Skonieczka 6, Mateusz Barszczewski 11 - Krystian Pomykała 9, Kamil Wasiak 35, Tomasz Sztaba 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  UMKS Zgierz  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-5</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Helios Białystok  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">29 grudnia, 16:00</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Błaszczyk 23, 25, 28, Wojciech Banaszczyk 33 - Jakub Konon 8, 20, Marcin Borowik 21, Jakub Budźko 40, Jakub Małyszko 41</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Łęczycy</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Tęcza Krosno Odrzańskie  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>10-2</b></td>
+<td nowrap valign="top" width="180"><b>  Remedium Hybryd Pyskowice  </b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 14:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Irex Gaz Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-5</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Górnik Polkowice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adrian Stachański ?, Bartłomiej Tarnówka ?, Piotr Lokwenc ?, Dominik Swatek ? - Andrzej Koryciński ?, ?, Kamil Nowakowski ?, ?, Dawid Witek ?</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Futsal Team Ząbkowice Śląskie  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>0-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  GSF Gliwice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 17:15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bongo Krapkowice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Berland OSiR Komprachcice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">4 stycznia, 20:30</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kamil Klimczak 14, Paweł Nowak 18, Łukasz Bawoł 25 - Michał Bienias 3, Paweł Boczarski 9, 10, 37, 39, 40</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Team Brzeg  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>6-4</b></td>
+<td nowrap valign="top" width="180"><b>  Odra Opole  </b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Dykus 5, 21, 28, Mateusz Mika 13, 21, Maciej Salak 25 - Thomas Skowronek 7, Stefan Karnatowski 8, 32, Szymon Pastuszek 22</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Metal Tarnów  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-7</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Nowiny  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zaczernie Futsal Team  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>5-8</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  GKS Tychy  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 15:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michał Chmiel ?, ?, Jakub Sroka ?, ?, Patryk Rusin ? - Bartłomiej Sitko ?, ?, ?, Filip Biernat ?, ?, Kacper Dudzik ?, ?, Marek Kołodziejczyk ?</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Rzeszowie; w hali IV Liceum Ogólnokształcącego</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Polska Myśl Szkoleniowa Nałęczów  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>0-10</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Gwiazda Ruda Śląska  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Mrowiec ?, 7, 37, Michał Hyży ?, ?, 13, Paweł Barański 16, Sylwester Gładkowski 23, Jakub Naleśnik 36, Piotr Hiszpański 36</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Wojciechowie</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Domex Pińczów  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-1</b></td>
+<td nowrap valign="top" width="180"><b>  Heiro Rzeszów  </b></td>
+<td valign="top" nowrap align="left" width="190">5 stycznia, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Karol Dudzik ?, Mateusz Madej ?, Łukasz Biały ?, Artur Garula ? - Sebastian Brocki ?</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  KS AZS UMCS Lublin  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-8</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Maxfarbex Busko Zdrój  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">6 stycznia, 18:00</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td colspan="4">Maciej Urtnowski 29, 39, Łukasz Mietlicki 38 - Michał Krzemiński 3, Dawid Porębski 23, Jakub Wałach 37, Marcin Taler 43, Tomasz Grzesiak 44, Adam Imiela 46, 48, Adam Przeniosło 47</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/16 finału - 26-27 stycznia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 13 stycznia 2019, 16:30 - w hali sportowej Szkoły Podstawowej nr 8 w Białymstoku)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Do gry dołączają drużyny z Ekstraklasy.</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Narew Choroszcz  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>7-8</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Słoneczny Stok Białystok  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Grupa CRB Mrówka Mosina  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>5-3</b></td>
+<td nowrap valign="top" width="180"><b>  Red Devils Chojnice  </b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 12:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Sobański ? (s), Łukasz Laskowski ?, ?, Szymon Wichtowski ?, Piotr Kubiak ? - Przemysław Laskowski ?, Sebastian Kartuszyński ?, Łukasz Sobański ?</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zdrowie Garwolin  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-11</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Leszno  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 15:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Filip Gac 1, Michał Zalewski 8 - Jan Martin 10, 12, Marcin Marcinkowski 16, 38, Kacper Konopacki 17, Piotr Pietruszko 19, 30, 37, Adrian Niedźwiedzki 22, 40, Paweł Pyra 33 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  LSSS Lębork  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>6-3</b></td>
+<td nowrap valign="top" width="180"><b>  Helios Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">26 stycznia, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  LZS Bojano  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Pogoń 04 Szczecin  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">26 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Piór 8, Maciej Osłowski 11, Kacper Ickiewicz 18, 21 - Mateusz Jakubiak 2, 17, Bartosz Przygórzewski 6, Daniel Maćkiewicz 19, 38, Karol Czyszek 34</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Futsal Oborniki  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  FC Toruń  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">24 stycznia, 20:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jakub Krzyżanowski 14, Mikołaj Wicberger 15, Bartosz Banasik 39 - Tomasz Kriezel 8, 39, Mateusz Cyman 11, Tomasz Wicberger 20 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Constract Lubawa  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-2</b></td>
+<td nowrap valign="top" width="180"><b>  AZS UG Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">25 stycznia, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Malwee Łódź  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-5</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Red Dragons Pniewy  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 12:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Tęcza Krosno Odrzańskie  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Piast Gliwice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">26 stycznia, 15:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Domex Pińczów  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-8</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Orzeł Futsal Jelcz-Laskowice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  GSF Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-2</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Clearex Chorzów  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">25 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Gwiazda Ruda Śląska  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Maxfarbex Busko Zdrój  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">26 stycznia, 13:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Berland OSiR Komprachcice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>7-10</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Gatta Zduńska Wola  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">25 stycznia, 19:30</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Polkowice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-3</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Rekord Bielsko-Biała  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">25 stycznia, 17:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Witek 7 - Kamil Surmiak 9, Tomasz Gąsior 12, Jan Dudek 19</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Futsal Nowiny  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  AZS UŚ Katowice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">26 stycznia, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  GKS Tychy  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Futsal Team Brzeg  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">27 stycznia, 18:00</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/8 finału - 13-14 lutego</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 2 lutego 2019, 17:50 - Stegu Arena, Opole)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Mecze zostaną także rozegrane 19-20 lutego.</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Futsal Team Brzeg  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-3</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Piast Gliwice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">20 lutego, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  LSSS Lębork  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Gatta Zduńska Wola  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">19 lutego, 20:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Constract Lubawa  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>8-3</b></td>
+<td nowrap valign="top" width="180"><b>  Red Dragons Pniewy  </b></td>
+<td valign="top" nowrap align="left" width="190">13 lutego, 19:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Futsal Leszno  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Rekord Bielsko-Biała  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">19 lutego, 18:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Maxfarbex Busko Zdrój  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-3</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Słoneczny Stok Białystok  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">13 lutego, 18:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Grupa CRB Mrówka Mosina  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>1-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  AZS UŚ Katowice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">13 lutego, 20:15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Orzeł Futsal Jelcz-Laskowice  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>5-0</b></td>
+<td nowrap valign="top" width="180"><b>  Pogoń 04 Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">13 lutego, 20:00</td>
+</tr>
+<tr>
+<td align="center" colspan="3"><b>(wo) </b></td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>goście zrezygnowali z wyjazdu na mecz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  FC Toruń  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-5</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Clearex Chorzów  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">20 lutego, 18:00</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/4 finału - 13 marca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 28 lutego 2019 - siedziba PZPN)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Rekord Bielsko-Biała  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>6-2</b></td>
+<td nowrap valign="top" width="180"><b>  Orzeł Futsal Jelcz-Laskowice  </b></td>
+<td valign="top" nowrap align="left" width="190">13 marca, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jan Janovský 2, Artur Popławski 2, 6, 13, Ołeksandr Bondar 11, Paweł Budniak 13 - Adriano Foglia 14, Kacper Kędra 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  AZS UŚ Katowice  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>7-5</b></td>
+<td nowrap valign="top" width="180"><b>  Słoneczny Stok Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">13 marca, 19:30</td>
+</tr>
+<tr align="left">
+<td colspan="4">Tomasz Szczurek 9, Kamil Musiał 14, Piotr Łopuch 16, Jacek Hewlik 28, Michał Dubiel 32, Sławomir Pękala 38, 40 - Damian Grabowski 7, Witalij Lisnyczenko 24, Norbert Jendruczek 28, Sławomir Pękala 34 (s), Adrian Citko 38</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Clearex Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>5-6</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Piast Gliwice  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">13 marca, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Constract Lubawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>0-4</b></td>
+<td nowrap valign="top" width="180"><b><u>
+  Gatta Zduńska Wola  </u>
+</b></td>
+<td valign="top" nowrap align="left" width="190">13 marca, 19:00</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału - 27 marca, 3 kwietnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 18 marca 2019 - siedziba PZPN)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  AZS UŚ Katowice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>0-2</b></td>
+<td nowrap valign="top" width="180"><b>  Rekord Bielsko-Biała  </b></td>
+<td valign="top" nowrap align="left" width="190">27 marca, 20:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Budniak 13, Artur Popławski 28</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Gatta Zduńska Wola  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>3-6</b></td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">27 marca, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Olczak 4, Mariusz Milewski 20, Norbert Dregier 36 - Douglas 11, Marcin Grzywa 20, Sebastian Szadurski 28, Sergio Parra Bonilla 37, 40, Rafał Franz 37</td>
+</tr>
+<tr>
+<td colspan="3"><hr size="1" width="410"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Rekord Bielsko-Biała  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>7-2</b></td>
+<td nowrap valign="top" width="180"><b>  AZS UŚ Katowice  </b></td>
+<td valign="top" nowrap align="left" width="190">3 kwietnia, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Artur Popławski 17, 36, 37, Michał Marek 33, Ołeksandr Bondar 35, 37, Michał Kubik 40 - Jacek Hewlik 2, 6</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Piast Gliwice  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-3</b></td>
+<td nowrap valign="top" width="180"><b>  Gatta Zduńska Wola  </b></td>
+<td valign="top" nowrap align="left" width="190">24 kwietnia, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dominik Śmiałkowski 19, Rafał Franz 33, Sergio Parra Bonilla 37, Maciej Rozmus 38 - Mariusz Milewski 15, Sebastian Szadurski 17 (s), Marcin Stanisławski 32</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał - 27 kwietnia, 1 maja</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie gospodarza pierwszego meczu - 18 marca 2019 - siedziba PZPN)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><b>2-7</b></td>
+<td nowrap valign="top" width="180"><b>  Rekord Bielsko-Biała  </b></td>
+<td valign="top" nowrap align="left" width="190">27 kwietnia, 18:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Franz 16, Marek Bugański 23 - Artur Popławski 1, 14, 29, Kamil Surmiak 5, Tomasz Gąsior 7, Alex Viana 17, Jan Dudek 37</td>
+</tr>
+<tr>
+<td colspan="3"><hr size="1" width="410"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b><u>
+  Rekord Bielsko-Biała  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="50"><b>4-4</b></td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">1 maja, 19:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Budniak 9, Michał Kubik 17, 39, Bartłomiej Nawrat 30 (k) - Mateusz Omylak 15, Sergio Parra Bonilla 18, Dominik Śmiałkowski 33, Douglas 40</td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+</table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Michał Turulski
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_12909.html
+++ b/internal/site/testdata/fixtures/league_12909.html
@@ -1,0 +1,5372 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Liga Mistrzów 2023/2024</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async=true>
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://cmp.inmobi.com'
+    .concat('/choice/', 't_XST3kwtPra_', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=13482"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=13483"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez24-25.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13482" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13483" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13484" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13482" class="menulnk" title="Sparingi - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13483" class="menulnk" title="Sparingi - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13484" class="menulnk" title="Sparingi - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13482&runda=1" class="menulnk" title="Przygotowania - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13483&runda=1" class="menulnk" title="Przygotowania - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13484&runda=1" class="menulnk" title="Przygotowania - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=103" class="menulnk" title="Baraże 2024" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13482.html" class="menulnk" title="Ekstraklasa 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13483.html" class="menulnk" title="I liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13484.html" class="menulnk" title="II liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=105" class="menulnk" title="III Liga 2024/2025 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13556.html" class="menulnk" title="III Liga 2024/2025 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13557.html" class="menulnk" title="III Liga 2024/2025 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13558.html" class="menulnk" title="III Liga 2024/2025 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13559.html" class="menulnk" title="III Liga 2024/2025 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13870.html" class="menulnk" title="Centralna Liga Juniorów 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13871.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13872.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13486.html" class="menulnk" title="Puchar Polski 2024/2025 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13485.html" class="menulnk" title="Superpuchar 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=105" class="menulnk" title="Rozgrywki pucharowe w Polsce 2024/2025 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2024/2025 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13487.html" class="menulnk" title="Liga Mistrzów 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13488.html" class="menulnk" title="Liga Europy 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13489.html" class="menulnk" title="Liga Konferencji 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13552.html" class="menulnk" title="Liga Młodzieżowa 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_reprezentacji_uefa.php?rok=2017" class="menulnk" title="Ranking reprezentacyjny UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprez. UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=105" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=105" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=105" class="menulnk" title="Reprezentacja Polski 2024/2025 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga11718.html" class="menulnk" title="Eliminacje mistrzostw świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12322.html" class="menulnk" title="Mistrzostwa świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13467.html" class="menulnk" title="Liga Narodów 2024/2025 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 24/25</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=105" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=105" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/eurcups2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga12909.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=12909" class="main">Strzelcy</a> | <a href="/stats.php?id=12909" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Liga Mistrzów 2023/2024</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_UEFA21 -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Runda przedwstępna - 27 czerwca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 13 czerwca 2023, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atl&#232;tic Club d'Escaldes  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Budućnost (Podgorica)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 czerwca, 15:00 (103)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Balsa Sekulić 14 (k), 60, Miomir Đuričković 21</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kópavogur</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SP Tre Penne  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-7</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Brei&#240;ablik (Kópavogur)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 czerwca, 21:00 (621)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antonio Barretta 31 - Höskuldur Gunnlaugsson 6, 89, Ágúst Hlynsson 25, 90, Kl&#230;mint Olsen 45, Stefán Sigur&#240;arson 67, Viktor Karl Einarsson 74</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kópavogur</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Runda wstępna - 30 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Budućnost (Podgorica)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Brei&#240;ablik (Kópavogur)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 czerwca, 21:00 (845)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Viktor Karl Einarsson 5, Stefán Sigur&#240;arson 22, Gísli Eyjólfsson 29, Höskuldur Gunnlaugsson 33, Jason Da&#240;i Svan&#254;órsson 74</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kópavogur</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>I runda eliminacyjna - 11-12 lipca, 18-19 lipca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 20 czerwca 2023, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BK Häcken  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  The New Saints FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 lipca, 19:00 (4516)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ibrahim Sadiq 7, Mikkel Rygaard 13, Even Hovland 37 - Declan McManus 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ballkani Suharekë  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:45 (7656)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Meriton Korenica 45, Qëndrim Zyba 55</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Shamrock Rovers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:45 (7216)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Damir Muminović 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Wilno  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  FK Struga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 18:00 (4647)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KÍ Klaksvík  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:45 (1010)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Valmiera FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:00 (4355)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mustafa Nukić 42, Rui Pedro 74 - Me&#239;ssa Diop 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  HJK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Larne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 lipca, 18:00 (<nobr>10 121</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bojan Radulović 3 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Lincoln Red Imps FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 17:30 (683)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kike Gómez 25 - Redon Xhixha 58, Yassine Benzia 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Raków Częstochowa </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1852161" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Flora Tallin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:00 (5242)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Władysław Koczerhin 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  FC Swift Hesperange  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 lipca, 20:30 (<nobr>14 470</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vladimír Weiss 25 - Dominik Stolz 22 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Farul Constan&#539;a  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Sheriff Tiraspol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 lipca, 19:30 (4028)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Kiki 56</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ovidiu</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  &#294;amrun Spartans FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Hajfa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:00 (1627)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Frantzdy Pierrot 41, 64, Dean David 45, Anan Khalaili 85</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali / w 54. minucie mecz został przerwany na 40 minut z powodu awantur na trybunach</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Urartu Erewan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 17:00 (3900)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Matej Senić 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Partizani Tirana  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  BATE Borysów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 lipca, 20:45 (5000)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tedi Cara 66 - Dmitrij Antilewskij 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Astana (2)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Dinamo Tbilisi  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 lipca, 16:00 (<nobr>27 328</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abat Ajmbietow 11 - Gabriel Sigua 57</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  The New Saints FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  BK Häcken  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 20:00 (1003)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ibrahim Sadiq 19, Momodou Sonko 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Łudogorec Razgrad  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Ballkani Suharekë  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 20:00 (5353)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bernard Tekpetey 4, 45, Matías Tissera 49, Caio Vidal 78</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Brei&#240;ablik (Kópavogur)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Shamrock Rovers FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 21:15 (1320)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jason Da&#240;i Svan&#254;órsson 16, Höskuldur Gunnlaugsson 58 - Graham Burke 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Struga  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Žalgiris Wilno  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 17:00 (1400)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Besart Ibraimi 76 (k) - Jurij Kiendysz 78, Sava Radić 84 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ochryda</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  KÍ Klaksvík  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 18:00 (<nobr>18 187</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Árni Frederiksberg 8 (k), 32, Luc Kassi 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Valmiera FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  NK Olimpija (Lublana)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 17:00 (1250)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Camilo Mena 82 - Rui Pedro 33, Ahmet Muhamedbegović 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Larne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  HJK  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 20:30 (1993)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lee Bonis 65 (k), Joe Thomson 87 - Tuomas Ollila 26, Shaun Want 97 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Belfast</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Qaraba&#287; A&#287;dam  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Lincoln Red Imps FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 18:00 (<nobr>19 453</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abdellah Zoubir 7, B&#601;hlul Mustafazad&#601; 45, Redon Xhixha 49, Marko Janković 62</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Flora Tallin  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1852162" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+ <font color="blue"> Raków Częstochowa </font> </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 19:00 (3204)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Łukasz Zwoliński 47, 59, Giánnis Papanikoláou 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Swift Hesperange  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  ŠK Slovan Bratysława  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 20:00 (3054)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vladimír Weiss 55 (k), 62 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Luksemburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sheriff Tiraspol  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Farul Constan&#539;a  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 19:00 (5792)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Amine Talal 45, Jérôme Ngom Mbekeli 99, Peter Ademo 105</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Maccabi Hajfa  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  &#294;amrun Spartans FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 19:00 (<nobr>29 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erik Shuranov 69, Frantzdy Pierrot 84 - Joseph Mbong 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  HŠK Zrinjski (Mostar)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Urartu Erewan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 20:00 (5000)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 4-3</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nemanja Bilbija 27, Tomislav Kiš 94 (k) - Narek Grigorjan 74, 90 (k), Artiom Maksimienko 105</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  BATE Borysów  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Partizani Tirana  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lipca, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Władisław Malkiewicz 71, Dmitrij Podstriełow 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Mezőkövesd / bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dinamo Tbilisi  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Astana (2)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 lipca, 18:00 (<nobr>10 736</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ousmane Camara 22 - Abzał Biejsiebiekow 50, Dembo Darboe 51</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>II runda eliminacyjna - 25-26 lipca, 1-2 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 21 czerwca 2023, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Wilno  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 18:00 (4864)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mathias Oyewusi 48, Donatas Kazlauskas 90 - Abdülkerim Bardakc&#305; 75, Halil Dervişo&#287;lu 78</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  HJK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Molde FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 18:00 (8154)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Topi Keskinen 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 21:15 (1485)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jordan Larsson 1, Rasmus Falk 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Áris Lemessoú  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-2</b></td>
+<td nowrap valign="top" width="165"><b>  BATE Borysów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 lipca, 19:00 (3338)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Yannick Gomis 17 (k), 60, Leo Bengtsson 32, Sidi Bane 39 (s), Jaden Montnor 83, Mariusz Stępiński 90 (k) - Artiom Koncewoj 48, Rusłan Chadarkiewicz 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  GNK Dinamo (Zagrzeb)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  FK Astana (2)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 20:00 (7123)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruno Petković 36, Luka Ivanušec 41, 43, 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dnipro-1 Dniepropietrowsk  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 20:00 (5248)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ołeksandr Kaplijenko 90 - Andraž Šporar 10, Filip Đuričić 74, Fótis Ioannídis 84 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Koszyce</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Servette FC Genewa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  KRC Genk  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 20:30 (<nobr>18 026</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Steve Rouiller 78 - Tolu Arokodare 21</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Raków Częstochowa </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1905157" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 lipca, 20:15 (5451)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Elvin C&#601;f&#601;rquliyev 55 (s), Fabian Piasecki 71, Sonny Kittel 90 - Redon Xhixha 73, 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sheriff Tiraspol  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Hajfa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 lipca, 19:00 (7933)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Amine Talal 28</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KÍ Klaksvík  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  BK Häcken  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 lipca, 20:45 (1224)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lipca, 21:00 (4900)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sharani Zuberu 53</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 lipca, 20:45 (5532)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dominik Jankow 44 - Timi Max Elšnik 14</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Galatasaray SK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Wilno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 20:30 (<nobr>41 505</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dries Mertens 31</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Molde FK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  HJK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 19:00 (5203)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kristian Eriksen 74, Ola Brynhildsen 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-3</b></td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 20:00 (<nobr>20 886</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Diogo Gonçalves 33, Elias Achouri 35, Jordan Larsson 37, Orri Óskarsson 45, 47, 56 - Jason Da&#240;i Svan&#254;órsson 9, Kristinn Steindórsson 51, Höskuldur Gunnlaugsson 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BATE Borysów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-5</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Áris Lemessoú  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 sierpnia, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Walerij Gromyko 25 (k), Aleksandr Martynow 48, Dienis Łaptiew 90 (k) - Shavy Babicka 8, Yannick Gomis 26, Cajú 35, Leo Bengtsson 56, Mariusz Stępiński 74</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Mezőkövesd / bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Astana (2)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  GNK Dinamo (Zagrzeb)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 16:00 (<nobr>26 978</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mahir Emreli 24, Antonio Marin 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Panathina&#239;kós AO  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Dnipro-1 Dniepropietrowsk  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 sierpnia, 19:30 (<nobr>14 098</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andraž Šporar 15, 70 - Artem Dowbyk 24, Eduard Sarapij 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KRC Genk  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Servette FC Genewa  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 19:00 (<nobr>16 280</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 1-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mike Trésor Ndayishimiye 28 (k), Tolu Arokodare 51 - Timothé Cognat 36, Chris Bédia 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1905158" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+ <font color="blue"> Raków Częstochowa </font> </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 18:00 (<nobr>31 257</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Redon Xhixha 60 - Fran Tudor 52</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku / żółtą kartką został także ukarany rezerwowy zawodnik gospodarzy - Maksim Medvedev</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Maccabi Hajfa  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Sheriff Tiraspol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 19:00 (<nobr>29 000</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tjaronn Chery 33, Mahmoud Jaber 85, Dean David 105, Erik Shuranov 107 - Amine Talal 20 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BK Häcken  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  KÍ Klaksvík  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 sierpnia, 19:00 (4396)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 3-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tobias Sana 24, Amor Layouni 48, Ibrahim Sadiq 105 - Árni Frederiksberg 17, 53, Peter Abrahamsson 109 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  ŠK Slovan Bratysława  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 sierpnia, 20:30 (<nobr>20 498</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Čavrić 5, Sharani Zuberu 66 - Hrvoje Barišić 75, Antonio Ivančić 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  NK Olimpija (Lublana)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 sierpnia, 20:00 (9265)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Timi Max Elšnik 18, 90 - Kirił Despodow 15</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>III runda eliminacyjna - 8-9 sierpnia, 15-16 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 24 lipca 2023, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  GNK Dinamo (Zagrzeb)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 20:00 (<nobr>13 311</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marko Bulat 39 - Steven Zuber 59, Kóstas Galanópoulos 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  AC Sparta Praga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 20:00 (<nobr>27 170</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  FK TSC (Bačka Topola)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 21:00 (<nobr>22 186</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruma 17, Pizzi 19, Álvaro Djaló 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Servette FC Genewa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 sierpnia, 20:45 (<nobr>48 956</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">James Tavernier 6 (k), Cyriel Dessers 15 - Chris Bedia 44 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 sierpnia, 20:00 (<nobr>11 270</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bernard 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  SK Sturm Graz  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 20:30 (<nobr>31 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Isaac Babadi 4, Luuk de Jong 22, 32, Ibrahim Sangaré 73 - Jon Gorenc Stanković 40</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Raków Częstochowa </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1927388" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Áris Lemessoú  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 20:00 (5500)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Władysław Koczerhin 7, Fabian Piasecki 63 (k) - Mihlali Mayambela 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 21:00 (<nobr>13 712</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kerem Aktürko&#287;lu 9, Dries Mertens 48, Halil Dervişo&#287;lu 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Hajfa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 sierpnia, 20:30 (<nobr>21 375</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abdoulaye Seck 12 (s) - Frantzdy Pierrot 5, Dia Saba 15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KÍ Klaksvík  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Molde FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 sierpnia, 20:45 (4584)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Árni Frederiksberg 64, 86 - Magnus Eikrem 49</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Thorshavn</i></td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  AEK (Ateny)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  GNK Dinamo (Zagrzeb)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 sierpnia, 20:45 (<nobr>30 100</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sergio Araujo 90, Domagoj Vida 90 - Josip Šutalo 45, Robert Ljubičić 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>w pierwotnym terminie (8 sierpnia, 20:45) odwołany z powodu zamieszek</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AC Sparta Praga  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 19:00 (<nobr>18 109</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 2-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Veljko Birmančević 80, Qazim Laçi 105, Victor Olatunji 107 - Jordan Larsson 1, Viktor Claesson 105, 112</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK TSC (Bačka Topola)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  SC Braga  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 20:00 (4200)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marko Rakonjac 40 - Pizzi 9, Bruma 13, Álvaro Djaló 16, Ali Al-Musrati 20</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Servette FC Genewa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Rangers FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 20:30 (<nobr>26 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dereck Kutesa 22 - James Tavernier 50</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Panathina&#239;kós AO  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 21:00 (<nobr>63 050</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 3-5</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Pierre-Emerick Aubameyang 2, 45 - Fótis Ioannídis 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Sturm Graz  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  PSV Eindhoven  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 20:30 (<nobr>12 571</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">William B&#248;ving 26 - Joey Veerman 32, Luuk de Jong 39, Ricardo Pepi 85 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Áris Lemessoú  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1927389" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+ <font color="blue"> Raków Częstochowa </font> </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 19:00 (3959)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fran Tudor 49</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Galatasaray SK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 20:00 (<nobr>38 383</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mauro Icardi 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Maccabi Hajfa  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 19:00 (<nobr>29 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Frantzdy Pierrot 29, Dia Saba 45, Dean David 90 - Marko Tolić 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Molde FK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  KÍ Klaksvík  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 sierpnia, 19:00 (<nobr>10 346</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kristian Eriksen 17, Martin Linnes 112</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>IV runda eliminacyjna - 22-23 sierpnia, 29-30 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 7 sierpnia 2023, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Hajfa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 sierpnia, 21:00 (<nobr>29 864</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 sierpnia, 21:00 (<nobr>13 376</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vincent Janssen 16</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Raków Częstochowa </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1929314" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 sierpnia, 21:00 (<nobr>11 600</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bogdan Racovi&#539;an 9 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sosnowiec</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Molde FK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 sierpnia, 21:00 (<nobr>10 553</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Martin Ellingsen 8, Kristoffer Haugen 56 - Sérgio Oliveira 25, Mauro Icardi 29, Fredrik Midtsj&#248; 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 sierpnia, 21:00 (<nobr>23 401</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abel Ruiz 51, Álvaro Djaló 73 - Daniel Mancini 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 sierpnia, 21:00 (<nobr>47 537</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abdallah Sima 45, Rabbi Matondo 76 - Ibrahim Sangaré 61, Luuk de Jong 80</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  BSC Young Boys Berno  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Hajfa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 21:00 (<nobr>31 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cédric Itten 23, Abdoulaye Seck 28 (s), Filip Ugrinic 46</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Royal Antwerp FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 21:00 (<nobr>29 300</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sergio Araujo 90 - Gyrano Kerk 73, Michel-Ange Balikwisha 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1929315" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Raków Częstochowa </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 21:00 (<nobr>34 737</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Denis Vavro 35 - Łukasz Zwoliński 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Galatasaray SK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Molde FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 21:00 (<nobr>47 845</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mauro Icardi 7 (k), Angeli&#241;o 90 - Eirik Hestad 66</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  SC Braga  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 21:00 (<nobr>61 390</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruma 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  PSV Eindhoven  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 21:00 (<nobr>34 560</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ismael Saibari 35, 53, Luuk de Jong 66, Joey Veerman 78, Connor Goldson 81 (s) - James Tavernier 64</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>I faza grupowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932227" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 18:45 (<nobr>46 911</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sacha Boey 86, Tet&#234; 88 - Mohamed Elyounoussi 35, Diogo Gonçalves 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932228" class="main"><b>4-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leroy Sané 28, Serge Gnabry 32, Harry Kane 53 (k), Mathys Tel 90 - Rasmus H&#248;jlund 49, Casemiro 88, 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932243" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>73 204</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rasmus H&#248;jlund 17, 67 - Wilfried Zaha 23, Kerem Aktürko&#287;lu 71, Mauro Icardi 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932244" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>35 690</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lukas Lerager 56 - Jamal Musiala 67, Mathys Tel 83</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932259" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 18:45 (<nobr>51 776</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mauro Icardi 30 (k) - Kingsley Coman 8, Harry Kane 73, Jamal Musiala 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932260" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>73 249</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Maguire 72</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932275" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 80, 86 - Cédric Bakambu 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932276" class="main"><b>4-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>36 099</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mohamed Elyounoussi 45, Diogo Gonçalves 45 (k), Lukas Lerager 83, Roony Bardghji 87 - Rasmus H&#248;jlund 3, 28, Bruno Fernandes 69 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932291" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 18:45 (<nobr>51 733</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hakim Ziyech 29, 62, Kerem Aktürko&#287;lu 71 - Alejandro Garnacho 11, Bruno Fernandes 18, Scott McTominay 55</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932292" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932307" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>73 073</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kingsley Coman 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932308" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>34 726</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lukas Lerager 58</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2027&id_sezon=103" class="main">FC Bayern München</a></td>
+<td>6</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>0</td>
+<td>12-6</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>6-4</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>6-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=1996&id_sezon=103" class="main">FC K&#248;benhavn</a></td>
+<td>6</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>2</td>
+<td>8-8</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>6-5</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>2-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=552&id_sezon=103" class="main">Galatasaray SK</a></td>
+<td>6</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>3</td>
+<td>10-13</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>6-8</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=1973&id_sezon=103" class="main">Manchester United FC</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>12-15</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-4</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>9-11</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932229" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>33 544</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lucas Ocampos 9 - Angelo Fulgini 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932230" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>58 860</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 8, Leandro Trossard 20, Gabriel Jesus 38, Martin &#216;degaard 70</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932245" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>38 167</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adrien Thomasson 25, Elye Wahi 69 - Gabriel Jesus 14</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932246" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>34 206</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luuk de Jong 86 (k), Jordan Teze 90 - Nemanja Gudelj 68, Youssef En-Nesyri 87</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932261" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>39 595</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nemanja Gudelj 58 - Gabriel Martinelli 45, Gabriel Jesus 53</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932262" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>38 133</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Elye Wahi 65 - Johan Bakayoko 54</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932277" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>60 024</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leandro Trossard 29, Bukayo Saka 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932278" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>34 200</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luuk de Jong 12</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932293" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 18:45 (<nobr>29 403</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sergio Ramos 24, Youssef En-Nesyri 47 - Ismael Saibari 68, Nemanja Gudelj 81 (s), Ricardo Pepi 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932294" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>59 987</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kai Havertz 13, Gabriel Jesus 21, Bukayo Saka 23, Gabriel Martinelli 27, Martin &#216;degaard 45, Jorginho 86 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RC Lens  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932309" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sevilla FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 18:45 (<nobr>37 456</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Przemysław Frankowski 63 (k), Angelo Fulgini 90 - Sergio Ramos 79 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932310" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 18:45 (<nobr>35 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Yorbe Vertessen 50 - Eddie Nketiah 42</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2019&id_sezon=103" class="main">Arsenal FC</a></td>
+<td>6</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>16-4</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>12-0</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=664&id_sezon=103" class="main">PSV Eindhoven</a></td>
+<td>6</td>
+<td><b>9</b></td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>8-10</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>4-3</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2299&id_sezon=103" class="main">RC Lens</a></td>
+<td>6</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>2</td>
+<td>6-11</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>5-3</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>1-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=5736&id_sezon=103" class="main">Sevilla FC</a></td>
+<td>6</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>4</td>
+<td>7-12</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>4-6</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa C</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932231" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 18:45 (<nobr>65 207</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jude Bellingham 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932232" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>18 422</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruma 84 - Giovanni Di Lorenzo 45, Sikou Niakaté 88 (s)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932247" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 18:45 (<nobr>73 445</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sheraldo Becker 30, 37 - Sikou Niakaté 41, Bruma 51, André Castro 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932248" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>51 649</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leo &#216;stig&#229;rd 19, Piotr Zieliński 54 (k) - Vinícius Júnior 27, Jude Bellingham 34, Alex Meret 78 (s)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932263" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>29 820</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Álvaro Djaló 63 - Rodrygo 16, Jude Bellingham 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932264" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>72 062</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Giacomo Raspadori 65</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932279" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 18:45 (<nobr>47 108</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Matteo Politano 39 - Datro David Fofana 52</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932280" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>68 509</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Brahim Díaz 27, Vinícius Júnior 58, Rodrygo 61</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932295" class="main"><b>4-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>73 562</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rodrygo 11, Jude Bellingham 22, Nico Paz 84, Joselu 90 - Giovanni Simeone 9, André Zambo 47</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932296" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>15 855</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Álvaro Djaló 51 - Robin Gosens 42</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932311" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SC Braga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>37 841</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Serdar Saatç&#305; 9 (s), Victor Osimhen 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  1.FC Union Berlin  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932312" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>73 420</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kevin Volland 45, Alex Král 85 - Joselu 61, 72, Dani Ceballos 89</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa C</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2015&id_sezon=103" class="main">Real Madrid CF</a></td>
+<td>6</td>
+<td><b>18</b></td>
+<td>6</td>
+<td>0</td>
+<td>0</td>
+<td>16-7</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>8-2</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>8-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4940&id_sezon=103" class="main">SSC Napoli</a></td>
+<td>6</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>2</td>
+<td>10-9</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>5-4</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>5-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=695&id_sezon=103" class="main">SC Braga</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>6-12</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-5</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=724&id_sezon=103" class="main">1.FC Union Berlin</a></td>
+<td>6</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>4</td>
+<td>6-10</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-7</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>2-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa D</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932233" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>60 917</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Roko Šimić 15 (k), Oscar Gloukh 51</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932234" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 września, 21:00 (<nobr>36 591</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Brais Méndez 4 - Lautaro Martínez 87</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932249" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 18:45 (<nobr>28 227</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Oyarzabal 7, Brais Méndez 27</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932250" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">3 października, 21:00 (<nobr>66 573</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marcus Thuram 62</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932265" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 18:45 (<nobr>71 825</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexis Sánchez 19, Hakan Çalhano&#287;lu 64 (k) - Oscar Gloukh 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932266" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 października, 21:00 (<nobr>56 002</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Brais Méndez 63</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932281" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 18:45 (<nobr>36 815</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Merino 6, Mikel Oyarzabal 11, Ander Barrenetxea 21 - Rafa Silva 49</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932282" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 listopada, 21:00 (<nobr>30 071</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lautaro Martínez 85 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932297" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>52 944</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jo&#227;o Mário 5, 13, 34 - Marko Arnautović 51, Davide Frattesi 58, Alexis Sánchez 72 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932298" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 listopada, 21:00 (<nobr>34 419</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932313" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>69 010</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932314" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 grudnia, 21:00 (<nobr>27 134</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luka Sučić 57 - Ángel Di María 32, Rafa Silva 45, Arthur Cabral 90</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa D</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2513&id_sezon=103" class="main">Real Sociedad de Fútbol</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>3</td>
+<td>3</td>
+<td>0</td>
+<td>7-2</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>4-2</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>3-0</td>
+<td>2</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2044&id_sezon=103" class="main">FC Internazionale Milano</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>3</td>
+<td>3</td>
+<td>0</td>
+<td>8-5</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>3-1</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>5-4</td>
+<td>2</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2279&id_sezon=103" class="main">SL e Benfica</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>7-11</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-6</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=12689&id_sezon=103" class="main">FC Salzburg</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>4-8</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>1-6</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>3-2</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-3</td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa E</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932235" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>44 008</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Calvin Stengs 45, Alireza Jahanbakhsh 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932236" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>46 168</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ivan Provedel 90 - Pablo Barrios 29</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932251" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 18:45 (<nobr>61 742</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Álvaro Morata 12, 47, Antoine Griezmann 45 - Mario Hermoso 7 (s), Dávid Hancko 34</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932252" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>56 063</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ky&#333;go Furuhashi 12 - Matías Vecino 29, Pedro Rodríguez 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932267" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 18:45 (<nobr>44 031</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Santiago Giménez 31, 74, Ramiz Zerrouki 45 - Pedro Rodríguez 83 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932268" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>55 844</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ky&#333;go Furuhashi 4, Luis Palma 28 - Antoine Griezmann 25, Álvaro Morata 53</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932283" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>60 863</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antoine Griezmann 6, 60, Álvaro Morata 45, 76, Samuel Lino 66, Saúl &#209;íguez 84</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932284" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>36 612</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ciro Immobile 45</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932299" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 18:45 (<nobr>50 555</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ciro Immobile 82, 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932300" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>43 992</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mats Wieffer 77 - Lutsharel Geertruida 14 (s), Mario Hermoso 57, Santiago Giménez 81 (s)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932315" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>63 574</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antoine Griezmann 6, Samuel Lino 51</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932316" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>56 391</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luis Palma 33 (k), Gustaf Lagerbielke 90 - Yankuba Minteh 82</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa E</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=474&id_sezon=103" class="main">Club Atlético de Madrid</a></td>
+<td>6</td>
+<td><b>14</b></td>
+<td>4</td>
+<td>2</td>
+<td>0</td>
+<td>17-6</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>11-2</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>6-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2013&id_sezon=103" class="main">SS Lazio</a></td>
+<td>6</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>2</td>
+<td>7-7</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>4-1</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=545&id_sezon=103" class="main">Feyenoord Rotterdam</a></td>
+<td>6</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>4</td>
+<td>9-10</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>6-4</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>3-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=498&id_sezon=103" class="main">Celtic FC</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>5-15</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>5-5</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>0-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa F</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932237" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 18:45 (<nobr>65 695</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932238" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>47 379</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 49 (k), Achraf Hakimi 58</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932253" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932254" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>52 009</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Miguel Almirón 17, Dan Burn 39, Sean Longstaff 50, Fabian Schär 90 - Lucas Hernández 56</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932269" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>45 962</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 32, Randal Kolo Muani 53, Lee Kang-in 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932270" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>52 024</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Felix Nmecha 45</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932285" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 18:45 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Niclas Füllkrug 26, Julian Brandt 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932286" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>75 649</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rafael Le&#227;o 12, Olivier Giroud 50 - Milan Škriniar 9</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932301" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>46 435</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 90 (k) - Alexander Isak 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932302" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>75 292</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Samuel Chukwueze 37 - Marco Reus 10 (k), Jamie Bynoe-Gittens 59, Karim Adeyemi 69</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932317" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Karim Adeyemi 51 - Warren Za&#239;re-Emery 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932318" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AC Milan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>52 037</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joelinton 33 - Christian Pulišić 59, Samuel Chukwueze 84</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa F</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2006&id_sezon=103" class="main">BV Borussia 1909 (Dortmund)</a></td>
+<td>6</td>
+<td><b>11</b></td>
+<td>3</td>
+<td>2</td>
+<td>1</td>
+<td>7-4</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>3-1</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>4-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2077&id_sezon=103" class="main">Paris Saint-Germain FC</a></td>
+<td>6</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>2</td>
+<td>9-8</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>6-1</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-7</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>4-2</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2043&id_sezon=103" class="main">AC Milan</a></td>
+<td>6</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>2</td>
+<td>5-8</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>3-4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>2-4</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2155&id_sezon=103" class="main">Newcastle United FC</a></td>
+<td>6</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>3</td>
+<td>6-7</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>5-4</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>1-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa G</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932239" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 18:45 (<nobr>31 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Meschack Elia 33 - Mohamed Simakan 3, Xaver Schlager 73, Benjamin Šeško 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932240" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>50 204</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julián Álvarez 47, 60, Rodri Hernández 73 - Osman Bukari 45</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932255" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>45 228</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lo&#239;s Openda 48 - Phil Foden 25, Julián Álvarez 84, Jérémy Doku 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932256" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>47 201</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cherif N'Diaye 35, Osman Bukari 88 - Filip Ugrinic 48, Cédric Itten 61 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932271" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>42 209</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Raum 12, Xavi Simons 59, Dani Olmo 84 - Marko Stamenic 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932272" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>31 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Meschack Elia 52 - Manuel Akanji 48, Erling H&#229;land 67 (k), 86</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932287" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>51 049</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 23 (k), 51, Phil Foden 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932288" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>41 961</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Benjamin Henrichs 81 (s) - Xavi Simons 8, Lo&#239;s Openda 77</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932303" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>51 402</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 54, Phil Foden 70, Julián Álvarez 87 - Lo&#239;s Openda 13, 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932304" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>31 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kosta Nedeljković 8 (s), Lewin Blum 29</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932319" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BSC Young Boys Berno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 18:45 (<nobr>43 331</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Benjamin Šeško 51, Emil Forsberg 56 - Ebrima Colley 53</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932320" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 18:45 (<nobr>49 443</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hwang In-beom 76, Aleksandar Katai 90 - Micah Hamilton 19, Oscar Bobb 62, Kalvin Phillips 85 (k)</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa G</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4945&id_sezon=103" class="main">Manchester City FC</a></td>
+<td>6</td>
+<td><b>18</b></td>
+<td>6</td>
+<td>0</td>
+<td>0</td>
+<td>18-7</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>9-3</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>9-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=15741&id_sezon=103" class="main">RB Leipzig</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>2</td>
+<td>13-10</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>6-5</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>7-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=751&id_sezon=103" class="main">BSC Young Boys Berno</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>4</td>
+<td>7-13</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-6</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=1998&id_sezon=103" class="main">FK Crvena zvezda (Belgrad)</a></td>
+<td>6</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>5</td>
+<td>7-15</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>5-7</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>2-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa H</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 19-20 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 31 sierpnia 2023, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932241" class="main"><b>5-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>40 989</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jo&#227;o Félix 11, 66, Robert Lewandowski 19, Jelle Bataille 22 (s), Gavi 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932242" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 września, 21:00 (<nobr>46 729</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kevin Kelsy 13 - Wenderson Galeno 8, 15, Mehdi Taremi 29</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Hamburg</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 3-4 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932257" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 18:45 (<nobr>13 509</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Arbnor Muja 3, Michel-Ange Balikwisha 33 - Danyło Sikan 48, 76, Jarosław Rakićkyj 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932258" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 października, 21:00 (<nobr>49 722</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ferran Torres 45</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 24-25 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932273" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 18:45 (<nobr>41 409</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ferran Torres 28, Fermin López 36 - Heorhij Sudakow 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932274" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 października, 21:00 (<nobr>13 651</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alhassan Yusuf 37 - Evanilson 46, 69, 84, Stephen Eustáquio 54</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 7-8 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932289" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 18:45 (<nobr>49 147</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Danyło Sikan 40</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Hamburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932290" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 listopada, 21:00 (<nobr>44 830</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Evanilson 32 (k), Pepe 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 28-29 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932305" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 18:45 (<nobr>47 209</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mykoła Matwijenko 12</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Hamburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932306" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 listopada, 21:00 (<nobr>43 533</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jo&#227;o Cancelo 32, Jo&#227;o Félix 57 - Pep&#234; 30</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 12-13 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932321" class="main"><b>5-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szachtar Donieck  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>48 113</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Wenderson Galeno 9, 43, Mehdi Taremi 62, Pepe 75, Francisco Conceiç&#227;o 82 - Danyło Sikan 29, Stephen Eustáquio 72 (s), Eguinaldo 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royal Antwerp FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1932322" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 grudnia, 21:00 (<nobr>13 550</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Arthur Vermeeren 2, Vincent Janssen 56, George Ilenikhena 90 - Ferran Torres 35, Marc Guiu 90</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa H</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA21 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2005&id_sezon=103" class="main">FC Barcelona</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>2</td>
+<td>12-6</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>9-2</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-4</td>
+<td>2</td>
+<td>6</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>3-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=540&id_sezon=103" class="main">FC Porto</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>2</td>
+<td>15-8</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>7-4</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>8-4</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>1-3</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=686&id_sezon=103" class="main">Szachtar Donieck</a></td>
+<td>6</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>3</td>
+<td>10-12</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>3-3</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>7-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=679&id_sezon=103" class="main">Royal Antwerp FC</a></td>
+<td>6</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>5</td>
+<td>6-17</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>6-9</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>0-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/8 finału - 13-21 lutego, 5-13 marca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 18 grudnia 2023, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933937" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 lutego, 21:00 (<nobr>49 111</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Wenderson Galeno 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933939" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 lutego, 21:00 (<nobr>49 529</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Osimhen 75 - Robert Lewandowski 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933941" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 lutego, 21:00 (<nobr>46 435</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 58, Bradley Barcola 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933943" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 lutego, 21:00 (<nobr>73 709</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marko Arnautović 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933945" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 lutego, 21:00 (<nobr>34 950</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luuk de Jong 56 (k) - Donyell Malen 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933947" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 lutego, 21:00 (<nobr>57 470</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ciro Immobile 69 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933949" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 lutego, 21:00 (<nobr>35 853</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Magnus Mattsson 34 - Kevin De Bruyne 10, Bernardo Silva 45, Phil Foden 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933951" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 lutego, 21:00 (<nobr>45 028</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Brahim Díaz 48</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Arsenal FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933938" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Porto  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 marca, 21:00 (<nobr>60 257</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933938" class="main"><b>pd. k. 4-2</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leandro Trossard 41</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Barcelona  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933940" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 marca, 21:00 (<nobr>50 301</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fermín López 15, Jo&#227;o Cancelo 17, Robert Lewandowski 83 - Amir Rrahmani 30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Sociedad de Fútbol  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933942" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 marca, 21:00 (<nobr>39 336</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Merino 89 - Kylian Mbappé 15, 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Atlético de Madrid  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933944" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 marca, 21:00 (<nobr>69 196</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933944" class="main"><b>pd. k. 3-2</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antoine Griezmann 35, Memphis Depay 87 - Federico Dimarco 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  BV Borussia 1909 (Dortmund)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933946" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 marca, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jadon Sancho 3, Marco Reus 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Bayern München  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933948" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SS Lazio  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 marca, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 38, 66, Thomas Müller 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Manchester City FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933950" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 21:00 (<nobr>51 531</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Manuel Akanji 5, Julián Álvarez 9, Erling H&#229;land 45 - Mohamed Elyounoussi 29</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933952" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  RB Leipzig  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 21:00 (<nobr>76 126</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vinícius Júnior 65 - Willi Orbán 68</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/4 finału - 9-10 kwietnia, 16-17 kwietnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 15 marca 2024, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934789" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 kwietnia, 21:00 (<nobr>60 221</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 12, Leandro Trossard 76 - Serge Gnabry 18, Harry Kane 32 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934791" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 kwietnia, 21:00 (<nobr>68 641</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rodrigo De Paul 4, Samuel Lino 32 - Sébastien Haller 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934793" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 kwietnia, 21:00 (<nobr>76 680</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rúben Dias 12 (s), Rodrygo 14, Federico Valverde 79 - Bernardo Silva 2, Phil Foden 66, Joško Gvardiol 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934795" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 kwietnia, 21:00 (<nobr>47 470</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ousmane Dembélé 48, Vitinha 51 - Raphinha 37, 62, Andreas Christensen 77</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Bayern München  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934790" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 kwietnia, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joshua Kimmich 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  BV Borussia 1909 (Dortmund)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934792" class="main"><b>4-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 kwietnia, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julian Brandt 34, Ian Maatsen 39, Niclas Füllkrug 71, Marcel Sabitzer 74 - Mats Hummels 49 (s), Ángel Correa 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934794" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 kwietnia, 21:00 (<nobr>52 306</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1934794" class="main"><b>pd. k. 3-4</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kevin De Bruyne 76 - Rodrygo 12</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934796" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 kwietnia, 21:00 (<nobr>50 309</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Raphinha 12 - Ousmane Dembélé 40, Vitinha 54, Kylian Mbappé 61 (k), 89</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału - 30 kwietnia-1 maja, 7-8 maja</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 15 marca 2024, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934954" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 maja, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Niclas Füllkrug 36</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934956" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 kwietnia, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leroy Sané 53, Harry Kane 57 (k) - Vinícius Júnior 24, 83 (k)</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934955" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  BV Borussia 1909 (Dortmund)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 maja, 21:00 (<nobr>46 435</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mats Hummels 50</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934957" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 maja, 21:00 (<nobr>76 579</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joselu 88, 90 - Alphonso Davies 68</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał - 1 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1934986" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 czerwca, 21:00 (<nobr>86 212</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Daniel Carvajal 74, Vinícius Júnior 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Londyn, Wembley Stadium</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+</table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Paweł Mogielnicki
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_13459.html
+++ b/internal/site/testdata/fixtures/league_13459.html
@@ -1,0 +1,2559 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Mistrzostwa Europy - Niemcy 2024</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async=true>
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://cmp.inmobi.com'
+    .concat('/choice/', 't_XST3kwtPra_', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=13482"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=13483"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez24-25.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13482" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13483" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13484" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13482" class="menulnk" title="Sparingi - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13483" class="menulnk" title="Sparingi - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13484" class="menulnk" title="Sparingi - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13482&runda=1" class="menulnk" title="Przygotowania - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13483&runda=1" class="menulnk" title="Przygotowania - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13484&runda=1" class="menulnk" title="Przygotowania - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=103" class="menulnk" title="Baraże 2024" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13482.html" class="menulnk" title="Ekstraklasa 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13483.html" class="menulnk" title="I liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13484.html" class="menulnk" title="II liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=105" class="menulnk" title="III Liga 2024/2025 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13556.html" class="menulnk" title="III Liga 2024/2025 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13557.html" class="menulnk" title="III Liga 2024/2025 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13558.html" class="menulnk" title="III Liga 2024/2025 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13559.html" class="menulnk" title="III Liga 2024/2025 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13870.html" class="menulnk" title="Centralna Liga Juniorów 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13871.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13872.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13486.html" class="menulnk" title="Puchar Polski 2024/2025 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13485.html" class="menulnk" title="Superpuchar 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=105" class="menulnk" title="Rozgrywki pucharowe w Polsce 2024/2025 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2024/2025 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13487.html" class="menulnk" title="Liga Mistrzów 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13488.html" class="menulnk" title="Liga Europy 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13489.html" class="menulnk" title="Liga Konferencji 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13552.html" class="menulnk" title="Liga Młodzieżowa 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_reprezentacji_uefa.php?rok=2017" class="menulnk" title="Ranking reprezentacyjny UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprez. UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=105" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=105" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=105" class="menulnk" title="Reprezentacja Polski 2024/2025 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga11718.html" class="menulnk" title="Eliminacje mistrzostw świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12322.html" class="menulnk" title="Mistrzostwa świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13467.html" class="menulnk" title="Liga Narodów 2024/2025 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 24/25</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=105" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=105" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/empty2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga13459.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=13459" class="main">Strzelcy</a> | <a href="/stats.php?id=13459" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Mistrzostwa Europy - Niemcy 2024</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_UEFA_neutral -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>I faza grupowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr>
+<td>&nbsp;</td></tr>
+<tr>
+<td></td><td colspan="4"><b>2024</b></td></tr>
+<tr>
+<td>&nbsp;</td></tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933832" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 czerwca, 21:00 (<nobr>65 052</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Florian Wirtz 10, Jamal Musiala 19, Kai Havertz 45 (k), Niclas Füllkrug 68, Emre Can 90 - Antonio Rüdiger 87 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A1-A2 / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933833" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 czerwca, 15:00 (<nobr>41 676</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Barnabás Varga 66 - Kwadwo Duah 12, Michel Aebischer 45, Breel Embolo 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A3-A4 / Kolonia, RheinEnergieStadion</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933844" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 czerwca, 18:00 (<nobr>54 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jamal Musiala 22, &#304;lkay Gündo&#287;an 67</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A1-A3 / Stuttgart, MHPArena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933845" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 czerwca, 21:00 (<nobr>42 711</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Scott McTominay 13 - Xherdan Shaqiri 26</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A2-A4 / Kolonia, RheinEnergieStadion</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933856" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 czerwca, 21:00 (<nobr>54 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kevin Csoboth 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A2-A3 / Stuttgart, MHPArena / żółtą kartką został także ukarany rezerwowy zawodnik Węgier - László Kleinheisler</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933857" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 czerwca, 21:00 (<nobr>46 685</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dan Ndoye 28 - Niclas Füllkrug 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A4-A1 / Frankfurt nad Menem, Deutsche Bank Park</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4179&id_sezon=103" class="main">Niemcy</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>8-2</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>7-1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4202&id_sezon=103" class="main">Szwajcaria</a></td>
+<td>3</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>5-3</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>4-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4181&id_sezon=103" class="main">Węgry</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>2-5</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>1-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4199&id_sezon=103" class="main">Szkocja</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>2-7</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>1-2</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933834" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 czerwca, 18:00 (<nobr>68 844</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Álvaro Morata 29, Fabián Ruiz 32, Daniel Carvajal 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B1-B2 / Berlin, Olympiastadion Berlin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933835" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 czerwca, 21:00 (<nobr>60 512</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alessandro Bastoni 11, Nicol&#242; Barella 16 - Nedim Bajrami 1</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B3-B4 / Dortmund, Signal Iduna Park</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933847" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 czerwca, 15:00 (<nobr>46 784</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andrej Kramarić 74, Klaus Gjasula 76 (s) - Qazim Laçi 11, Klaus Gjasula 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B2-B4 / Hamburg, Volksparkstadion / żółtą kartką został także ukarany rezerwowy zawodnik Chorwacji - Ivica Ivušić</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933846" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 czerwca, 21:00 (<nobr>49 528</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Riccardo Calafiori 55 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B1-B3 / Gelsenkirchen, Veltins-Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933858" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 czerwca, 21:00 (<nobr>38 322</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luka Modrić 55 - Mattia Zaccagni 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B2-B3 / Lipsk, Red Bull Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933859" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 czerwca, 21:00 (<nobr>46 586</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ferran Torres 13</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B4-B1 / Düsseldorf, Merkur Spiel-Arena</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4173&id_sezon=103" class="main">Hiszpania</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>5-0</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>4-0</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>1-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4185&id_sezon=103" class="main">Włochy</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>3-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>1-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4168&id_sezon=103" class="main">Chorwacja</a></td>
+<td>3</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>3-6</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>3-3</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4160&id_sezon=103" class="main">Albania</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-5</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-1</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>3-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa C</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933836" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 czerwca, 18:00 (<nobr>54 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erik Janža 77 - Christian Eriksen 17</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C1-C2 / Stuttgart, MHPArena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933837" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 czerwca, 21:00 (<nobr>48 953</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jude Bellingham 13</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C3-C4 / Gelsenkirchen, Veltins-Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933848" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 czerwca, 15:00 (<nobr>63 028</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Žan Karničnik 69 - Luka Jović 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C1-C3 / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933849" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 czerwca, 18:00 (<nobr>46 177</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Morten Hjulmand 34 - Harry Kane 18</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C2-C4 / Frankfurt nad Menem, Deutsche Bank Park</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933860" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 czerwca, 21:00 (<nobr>64 288</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C2-C3 / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933861" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 czerwca, 21:00 (<nobr>41 536</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C4-C1 / Kolonia, RheinEnergieStadion</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa C</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4172&id_sezon=103" class="main">Anglia</a></td>
+<td>3</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>2-1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>2-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4171&id_sezon=103" class="main">Dania</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>0</td>
+<td>3</td>
+<td>0</td>
+<td>2-2</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>1-1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b></b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4200&id_sezon=103" class="main">Słowenia</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>0</td>
+<td>3</td>
+<td>0</td>
+<td>2-2</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>2-2</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=10570&id_sezon=103" class="main">Serbia</a></td>
+<td>3</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>1-2</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-1</td>
+<td>0</td>
+<td>2</td>
+<td>0</td>
+<td>1-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa D</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933838" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 czerwca, 15:00 (<nobr>48 117</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adam Buksa 16 - Cody Gakpo 29, Wout Weghorst 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D1-D2 / Hamburg, Volksparkstadion</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933839" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 czerwca, 21:00 (<nobr>46 425</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Maximilian Wöber 38 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D3-D4 / Düsseldorf, Merkur Spiel-Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933850" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 czerwca, 18:00 (<nobr>69 455</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Krzysztof Piątek 30 - Gernot Trauner 9, Christoph Baumgartner 66, Marko Arnautović 78 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D1-D3 / Berlin, Olympiastadion Berlin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933851" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 czerwca, 21:00 (<nobr>38 531</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D2-D4 / Lipsk, Red Bull Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933862" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 czerwca, 18:00 (<nobr>68 363</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cody Gakpo 47, Memphis Depay 75 - Donyell Malen 6 (s), Romano Schmid 59, Marcel Sabitzer 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D2-D3 / Berlin, Olympiastadion Berlin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933863" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 czerwca, 18:00 (<nobr>59 728</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 56 (k) - Robert Lewandowski 79 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D4-D1 / Dortmund, Signal Iduna Park</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa D</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4163&id_sezon=103" class="main">Austria</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>6-4</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-1</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>6-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4177&id_sezon=103" class="main">Francja</a></td>
+<td>3</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>2-1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4193&id_sezon=103" class="main">Holandia</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-4</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>2-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=3462&id_sezon=103" class="main">Polska</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-6</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>2-5</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa E</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933841" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 czerwca, 15:00 (<nobr>61 591</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nicolae Stanciu 29, Răzvan Marin 53, Denis Drăgu&#537; 57</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E3-E4 / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933840" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 czerwca, 18:00 (<nobr>45 181</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ivan Schranz 7</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E1-E2 / Frankfurt nad Menem, Deutsche Bank Park</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933853" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 czerwca, 15:00 (<nobr>43 910</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ivan Schranz 17 - Mykoła Szaparenko 54, Roman Jaremczuk 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E2-E4 / Düsseldorf, Merkur Spiel-Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933852" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 czerwca, 21:00 (<nobr>42 535</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Youri Tielemans 2, Kevin De Bruyne 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E1-E3 / Kolonia, RheinEnergieStadion</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933864" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 czerwca, 18:00 (<nobr>45 033</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ondrej Duda 24 - Răzvan Marin 37 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E2-E3 / Frankfurt nad Menem, Deutsche Bank Park</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933865" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 czerwca, 18:00 (<nobr>54 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>E4-E1 / Stuttgart, MHPArena</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa E</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4197&id_sezon=103" class="main">Rumunia</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>3-0</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>1-3</td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=3463&id_sezon=103" class="main">Belgia</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>2-1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>2-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4208&id_sezon=103" class="main">Słowacja</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>3-3</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>2-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>1-0</td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4205&id_sezon=103" class="main">Ukraina</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>2-4</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>2-4</td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa F</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933842" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 czerwca, 18:00 (<nobr>59 127</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mert Müldür 25, Arda Güler 65, Kerem Aktürko&#287;lu 90 - Georges Mikautadze 32</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F1-F2 / Dortmund, Signal Iduna Park</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933843" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 czerwca, 21:00 (<nobr>38 421</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Robin Hranáč 69 (s), Francisco Conceiç&#227;o 90 - Lukáš Provod 62</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F3-F4 / Lipsk, Red Bull Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933855" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 czerwca, 15:00 (<nobr>46 524</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Georges Mikautadze 45 (k) - Patrik Schick 59</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F2-F4 / Hamburg, Volksparkstadion</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933854" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 czerwca, 18:00 (<nobr>61 047</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bernardo Silva 21, Samet Akaydin 28 (s), Bruno Fernandes 56</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F1-F3 / Dortmund, Signal Iduna Park</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933866" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 czerwca, 21:00 (<nobr>49 616</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chwicza Kwaracchelia 2, Georges Mikautadze 57 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F2-F3 / Gelsenkirchen, Veltins-Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933867" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 czerwca, 21:00 (<nobr>47 683</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tomáš Souček 66 - Hakan Çalhano&#287;lu 51, Cenk Tosun 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>F4-F1 / Hamburg, Volksparkstadion / po meczu czerwoną kartką ukarany został zawodnik Czech - Tomáš Chorý, żółtymi kartkami zostali także ukarani rezerwowi zawodnicy Czech - Patrik Schick, Vítězslav Jaroš i Lukáš Červ oraz Turcji - U&#287;urcan Çak&#305;r</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa F</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4196&id_sezon=103" class="main">Portugalia</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>5-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-2</td>
+<td>1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>3-0</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4204&id_sezon=103" class="main">Turcja</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>5-5</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-4</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-3</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4178&id_sezon=103" class="main">Gruzja</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>3-1</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4170&id_sezon=103" class="main">Czechy</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-5</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-2</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>2-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/8 finału</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933869" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 czerwca, 18:00 (<nobr>68 172</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Remo Freuler 37, Rubén Vargas 46</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(38) 2A-2B / Berlin, Olympiastadion Berlin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933868" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 czerwca, 21:00 (<nobr>61 612</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kai Havertz 53 (k), Jamal Musiala 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(37) 1A-2C / Dortmund, Signal Iduna Park / przerwany w 35. minucie na 24 minuty z powodu burzy</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933871" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 czerwca, 18:00 (<nobr>47 244</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933871" class="main"><b>pd. </b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jude Bellingham 90, Harry Kane 91 - Ivan Schranz 25</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(40) 1C-3DEF / Gelsenkirchen, Veltins-Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933870" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 czerwca, 21:00 (<nobr>42 233</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rodri Hernández 39, Fabián Ruiz 51, Nico Williams 75, Dani Olmo 83 - Robin Le Normand 18 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(39) 1B-3ADEF / Kolonia, RheinEnergieStadion</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933873" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 lipca, 18:00 (<nobr>46 810</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jan Vertonghen 85 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(42) 2D-2E / Düsseldorf, Merkur Spiel-Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933872" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 lipca, 21:00 (<nobr>46 576</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933872" class="main"><b>pd. k. 3-0</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(41) 1F-3ABC / Frankfurt nad Menem, Deutsche Bank Park</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933874" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 lipca, 18:00 (<nobr>65 012</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cody Gakpo 20, Donyell Malen 83, 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(43) 1E-3ABCD / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933875" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 lipca, 21:00 (<nobr>38 305</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Michael Gregoritsch 66 - Merih Demiral 1, 59</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(44) 1D-2F / Lipsk, Red Bull Arena</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/4 finału</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933876" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 lipca, 18:00 (<nobr>54 000</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933876" class="main"><b>pd. </b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dani Olmo 51, Mikel Merino 119 - Florian Wirtz 89</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(45) 39-37 / Stuttgart, MHPArena / żółtymi kartkami zostali także ukarani rezerwowi zawodnicy Niemiec - Nico Schlotterbeck i Deniz Undav</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933877" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 lipca, 21:00 (<nobr>47 789</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933877" class="main"><b>pd. k. 3-5</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(46) 41-42 / Hamburg, Volksparkstadion</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933879" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 lipca, 18:00 (<nobr>46 907</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=1933879" class="main"><b>pd. k. 5-3</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 80 - Breel Embolo 75</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(48) 40-38 / Düsseldorf, Merkur Spiel-Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933878" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 lipca, 21:00 (<nobr>70 091</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Stefan de Vrij 70, Mert Müldür 76 (s) - Samet Akaydin 35</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>(47) 43-44 / Berlin, Olympiastadion Berlin / w 90. minucie czerwoną kartką ukarany został zawodnik Turcji - Bertu&#287; Y&#305;ld&#305;r&#305;m</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933880" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 lipca, 21:00 (<nobr>62 042</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lamine Yamal Nasraoui 21, Dani Olmo 25 - Randal Kolo Muani 9</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>45-46 / Monachium, Allianz Arena</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933881" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 lipca, 21:00 (<nobr>60 926</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Xavi Simons 7 - Harry Kane 18 (k), Ollie Watkins 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>47-48 / Dortmund, Signal Iduna Park</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=1933882" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 lipca, 21:00 (<nobr>65 600</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nico Williams 47, Mikel Oyarzabal 86 - Cole Palmer 73</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Berlin, Olympiastadion Berlin</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<a class="main" href="/liga/1/liga12873.html">eliminacje do Mistrzostw Europy Niemcy 2024</a>
+</td></tr>
+</table>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 2 grudnia 2023, 18:00 - Hamburg, Elbphilharmonie)</td></tr></table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Maciej Kusina
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_14042.html
+++ b/internal/site/testdata/fixtures/league_14042.html
@@ -1,0 +1,6956 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>eliminacje do Mistrzostw Świata Kanada/Meksyk/USA 2026</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async=true>
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://cmp.inmobi.com'
+    .concat('/choice/', 't_XST3kwtPra_', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=14072"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=14073"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez25-26.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14072" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14073" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14074" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14072" class="menulnk" title="Sparingi - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14073" class="menulnk" title="Sparingi - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14074" class="menulnk" title="Sparingi - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14072&runda=2" class="menulnk" title="Przygotowania - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14073&runda=2" class="menulnk" title="Przygotowania - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14074&runda=2" class="menulnk" title="Przygotowania - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=107" class="menulnk" title="Baraże 2026" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14072.html" class="menulnk" title="Ekstraklasa 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14073.html" class="menulnk" title="I liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14074.html" class="menulnk" title="II liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=107" class="menulnk" title="III Liga 2025/2026 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14154.html" class="menulnk" title="III Liga 2025/2026 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14155.html" class="menulnk" title="III Liga 2025/2026 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14156.html" class="menulnk" title="III Liga 2025/2026 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14157.html" class="menulnk" title="III Liga 2025/2026 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14384.html" class="menulnk" title="Centralna Liga Juniorów 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14385.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14386.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14076.html" class="menulnk" title="Puchar Polski 2025/2026 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14075.html" class="menulnk" title="Superpuchar 2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=107" class="menulnk" title="Rozgrywki pucharowe w Polsce 2025/2026 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2025/2026 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14077.html" class="menulnk" title="Liga Mistrzów 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14078.html" class="menulnk" title="Liga Europy 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14079.html" class="menulnk" title="Liga Konferencji 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14634.html" class="menulnk" title="Liga Młodzieżowa 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=107" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=107" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=107" class="menulnk" title="Reprezentacja Polski 2025/2026 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14042.html" class="menulnk" title="Eliminacje mistrzostw świata - USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14645.html" class="menulnk" title="Mistrzostwa świata - Kanada/Meksyk/USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14658.html" class="menulnk" title="Liga Narodów 2026/2027 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 26/27</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=107" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=107" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=107" class="menulnk" title="Archiwum wyników z sezonu 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2025 / 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/empty2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga14042.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=14042" class="main">Strzelcy</a> | <a href="/stats.php?id=14042" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>eliminacje do Mistrzostw Świata Kanada/Meksyk/USA 2026</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<!-- <div align="center"><a target="_blank" href="https://bilety.laczynaspilka.pl/"><img src="/banery/ban-pzpn-2025-10-20-468x60.jpg" border="0" vspace="3"></a></div> --><div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_FIFA18 -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>I faza grupowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr>
+<td>&nbsp;</td></tr>
+<tr>
+<td></td><td colspan="4"><b>2025</b></td></tr>
+<tr>
+<td>&nbsp;</td></tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 20:45 (9214)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aiman Dardari 30 - Jamie Reid 7, Shea Charles 46, Justin Devenny 69</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Luksemburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 20:45 (<nobr>20 013</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dávid Hancko 42, David Strelec 55</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bratysława</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 20:45 (8487)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tomáš Rigo 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Luksemburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 20:45 (<nobr>43 169</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Serge Gnabry 7, Nadiem Amiri 69, Florian Wirtz 72 - Isaac Price 34</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolonia</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>18 109</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Patrik Hrošovský 18 (s), Trai Hume 81</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Belfast</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>25 249</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Raum 12, Joshua Kimmich 21 (k), 50, Serge Gnabry 48</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sinsheim</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>17 926</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nick Woltemade 31</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Belfast</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>13 010</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adam Obert 55, Ivan Schranz 72</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Trnava</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 20:45 (9214)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nick Woltemade 49, 69</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Luksemburg</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 20:45 (<nobr>12 093</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tomáš Bobček 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Koszyce</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Luksemburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (<nobr>18 037</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jamie Donley 44 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Belfast</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Niemcy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-0</b></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (<nobr>40 120</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nick Woltemade 18, Serge Gnabry 29, Leroy Sané 36, 41, Ridle Baku 67, Assan Ouédraogo 79</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lipsk</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4179&id_sezon=107" class="main">Niemcy</a></td>
+<td>6</td>
+<td><b>15</b></td>
+<td>5</td>
+<td>0</td>
+<td>1</td>
+<td>16-3</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>13-1</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>3-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4208&id_sezon=107" class="main">Słowacja</a></td>
+<td>6</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>2</td>
+<td>6-8</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>5-0</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>1-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4194&id_sezon=107" class="main">Irlandia Północna</a></td>
+<td>6</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>3</td>
+<td>7-6</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>3-1</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4189&id_sezon=107" class="main">Luksemburg</a></td>
+<td>6</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>6</td>
+<td>1-13</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>1-6</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>0-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>15 679</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sandi Lovrić 46, Žan Vipotnik 90 - Anthony Elanga 18, Yasin Ayari 73</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>33 996</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Manuel Akanji 22, Breel Embolo 25, 45, Silvan Widmer 39</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bazylea</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (<nobr>12 887</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Elvis Rexhbeçaj 26, Vedat Muriqi 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (<nobr>12 757</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nico Elvedi 18, Breel Embolo 33, Dan Ndoye 38</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bazylea</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>12 268</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>50 151</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Granit Xhaka 65 (k), Johan Manzambi 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Solna</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>14 637</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>36 571</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fisnik Asllani 32</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Göteborg</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 20:45 (<nobr>15 382</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fisnik Asllani 6, Žan Karničnik 64 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 20:45 (<nobr>26 458</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Breel Embolo 13, Granit Xhaka 60 (k), Dan Ndoye 75, Johan Manzambi 90 - Benjamin Nygren 33</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lancy</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Szwajcaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>11 215</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Florent Muslija 74 - Rubén Vargas 47</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Słowenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>25 724</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gustav Lundgren 87 - Timi Max Elšnik 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Solna</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4202&id_sezon=107" class="main">Szwajcaria</a></td>
+<td>6</td>
+<td><b>14</b></td>
+<td>4</td>
+<td>2</td>
+<td>0</td>
+<td>14-2</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>11-1</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>3-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=19765&id_sezon=107" class="main">Kosowo</a></td>
+<td>6</td>
+<td><b>11</b></td>
+<td>3</td>
+<td>2</td>
+<td>1</td>
+<td>6-5</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>3-1</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>3-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4200&id_sezon=107" class="main">Słowenia</a></td>
+<td>6</td>
+<td><b>4</b></td>
+<td>0</td>
+<td>4</td>
+<td>2</td>
+<td>3-8</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>2-4</td>
+<td>0</td>
+<td>2</td>
+<td>1</td>
+<td>1-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4203&id_sezon=107" class="main">Szwecja</a></td>
+<td>6</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>4</td>
+<td>4-12</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>1-4</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>3-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa C</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>14 936</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Konstantinos Karetsas 3, Vangélis Pavlídis 17, Tássos Bakassétas 21, Dimítris Kourbélis 36, Chrístos Tzólis 63 - Gierman Barkowskij 72 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pireus</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>35 369</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kopenhaga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ché Adams 43, Zachar Wołkow 65 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zalaegerszeg / bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (<nobr>31 172</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikkel Damsgaard 32, Andreas Christensen 62, Rasmus H&#248;jlund 81</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pireus</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-6</b></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Froholdt 14, Rasmus H&#248;jlund 19, 45, Patrick Dorgu 45, Anders Dreyer 66, 78</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zalaegerszeg / bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (<nobr>46 006</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ryan Christie 64, Lewis Ferguson 80, Lyndon Dykes 90 - Kóstas Tsimíkas 62</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Glasgow</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 18:00 (<nobr>49 346</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ché Adams 15, Scott McTominay 84 - Gleb Kuczko 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Glasgow</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 20:45 (<nobr>35 623</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rasmus H&#248;jlund 21, Joachim Andersen 40, Mikkel Damsgaard 41 - Chrístos Tzólis 63</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kopenhaga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-2</b></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 20:45 (<nobr>18 405</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tássos Bakassétas 7, Konstantinos Karetsas 57, Chrístos Tzólis 63 - Ben Doak 65, Ryan Christie 70</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pireus</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 20:45 (<nobr>35 493</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikkel Damsgaard 11, Gustav Isaksen 79 - Walerij Gromyko 62, Nikita Diemczenko 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kopenhaga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Białoruś  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Grecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zalaegerszeg / bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szkocja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-2</b></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>49 587</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Scott McTominay 3, Lawrence Shankland 78, Kieran Tierney 90, Kenny McLean 90 - Rasmus H&#248;jlund 57 (k), Patrick Dorgu 82</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Glasgow</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa C</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4199&id_sezon=107" class="main">Szkocja</a></td>
+<td>6</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>13-7</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>9-4</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>4-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4171&id_sezon=107" class="main">Dania</a></td>
+<td>6</td>
+<td><b>11</b></td>
+<td>3</td>
+<td>2</td>
+<td>1</td>
+<td>16-7</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>5-3</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>11-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4180&id_sezon=107" class="main">Grecja</a></td>
+<td>6</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>3</td>
+<td>10-12</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>8-6</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>2-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4165&id_sezon=107" class="main">Białoruś</a></td>
+<td>6</td>
+<td><b>2</b></td>
+<td>0</td>
+<td>2</td>
+<td>4</td>
+<td>4-17</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>0-8</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>4-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa D</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (4021)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Pálsson 45, Ísak Bergmann Jóhannesson 47, 56, Albert Gu&#240;mundsson 66, Kristian Hlynsson 73</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Reykjavík</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>38 973</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Michael Olise 10, Kylian Mbappé 82</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Wrocław</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 18:00 (8450)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Emin Mahmudov 72 (k) - Heorhij Sudakow 51</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>40 150</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 45 (k), Bradley Barcola 62 - Andri Gu&#240;johnsen 21</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Paryż</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-5</b></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (9111)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikael Egill Ellertsson 35, Albert Gu&#240;mundsson 59, 75 - Rusłan Malinowśkyj 14, 45, Ołeksij Huculak 45, Iwan Kalużnyj 85, Ołeh Oczeretko 88</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Reykjavík</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>40 150</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 45, Adrien Rabiot 69, Florian Thauvin 84</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Paryż</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (9151)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Pálsson 39, Kristian Hlynsson 70 - Christopher Nkunku 63, Jean-Philippe Mateta 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Reykjavík</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (6995)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ołeksij Huculak 30, Rusłan Malinowśkyj 64 - Witalij Mykołenko 45 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kraków</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 18:00 (4300)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Albert Gu&#240;mundsson 20, Sverrir Ingi Ingason 39</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 20:45 (<nobr>41 055</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 55 (k), 83, Michael Olise 76, Hugo Ekitiké 88</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Paryż</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Azerbejdżan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Francja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 18:00 (<nobr>29 700</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Renat Dadaşov 4 - Jean-Philippe Mateta 17, Maghnes Akliouche 30, Şahrudin M&#601;h&#601;mm&#601;d&#601;liyev 45 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Islandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 18:00 (<nobr>20 004</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ołeksandr Zubkow 83, Ołeksij Huculak 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Warszawa</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa D</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4177&id_sezon=107" class="main">Francja</a></td>
+<td>6</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>0</td>
+<td>16-4</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>9-1</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>7-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4205&id_sezon=107" class="main">Ukraina</a></td>
+<td>6</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>2</td>
+<td>10-11</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>4-3</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>6-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4183&id_sezon=107" class="main">Islandia</a></td>
+<td>6</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>3</td>
+<td>13-11</td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>10-7</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4164&id_sezon=107" class="main">Azerbejdżan</a></td>
+<td>6</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>5</td>
+<td>3-16</td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>2-6</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>1-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa E</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 18:00 (<nobr>44 238</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Zuriko Dawitaszwili 63, Chwicza Kwaracchelia 90 - Mert Müldür 3, Kerem Aktürko&#287;lu 41, 52</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tbilisi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 20:45 (<nobr>40 582</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Oyarzabal 5, Marc Cucurella 30, Mikel Merino 38</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 15:00 (<nobr>44 077</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chwicza Kwaracchelia 30, Nika Gagnidze 44, Georges Mikautadze 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tbilisi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-6</b></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 20:45 (<nobr>32 059</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Pedri González 6, 62, Mikel Merino 22, 45, 57, Ferran Torres 53</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Konya</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-6</b></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 20:45 (<nobr>10 059</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Radosław Kiriłow 13 - Arda Güler 11, Wiktor Popow 49 (s), Kenan Y&#305;ld&#305;z 51, 56, Zeki Çelik 65, &#304;rfan Kahveci 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 20:45 (<nobr>28 661</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Yeremy Pino 24, Mikel Oyarzabal 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Elche</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (<nobr>26 633</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kenan Y&#305;ld&#305;z 14, Merih Demiral 22, 52, Yunus Akgün 35 - Giorgi Koczoraszwili 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>&#304;zmit</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (<nobr>24 526</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Merino 35, 57, Atanas Czernew 79 (s), Mikel Oyarzabal 90 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Valladolid</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 18:00 (<nobr>44 314</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikel Oyarzabal 11 (k), 63, Martín Zubimendi 22, Ferran Torres 35</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tbilisi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 18:00 (<nobr>42 756</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hakan Çalhano&#287;lu 18 (k), Atanas Czernew 83 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bursa</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bułgaria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Gruzja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (1980)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Georgi Rusew 10, Filip Krystew 24 - Luka Loczoszwili 88</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hiszpania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>30 812</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dani Olmo 4, Mikel Oyarzabal 62 - Deniz Gül 42, Salih Özcan 54</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sewilla</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa E</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4173&id_sezon=107" class="main">Hiszpania</a></td>
+<td>6</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>0</td>
+<td>21-2</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>8-2</td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>13-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4204&id_sezon=107" class="main">Turcja</a></td>
+<td>6</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>17-12</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>6-7</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>11-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4178&id_sezon=107" class="main">Gruzja</a></td>
+<td>6</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>5</td>
+<td>7-15</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>5-7</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>2-8</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>4-2</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4167&id_sezon=107" class="main">Bułgaria</a></td>
+<td>6</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>5</td>
+<td>3-19</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>3-10</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>0-9</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa F</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 18:00 (<nobr>14 403</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jo&#227;o Félix 10, 61, Cristiano Ronaldo 21, 46, Jo&#227;o Cancelo 32</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Erewan</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 20:45 (<nobr>51 137</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Evan Ferguson 49, Adam Idah 90 - Barnabás Varga 2, Roland Sallai 15</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Dublin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 18:00 (<nobr>13 144</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Eduard Spiercian 45 (k), Grant-Leon Ranos 51 - Evan Ferguson 57</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Erewan</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>61 473</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Barnabás Varga 21, 84 - Bernardo Silva 36, Cristiano Ronaldo 58 (k), Jo&#227;o Cancelo 86</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Budapeszt</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 18:00 (<nobr>57 285</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dániel Lukács 56, Zsombor Gruber 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Budapeszt</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 20:45 (<nobr>48 821</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rúben Neves 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lizbona</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (<nobr>42 292</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Evan Ferguson 70</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Dublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (<nobr>47 854</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cristiano Ronaldo 22, 45 - Attila Szalai 8, Dominik Szoboszlai 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lizbona</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 18:00 (<nobr>14 247</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Barnabás Varga 33</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Erewan</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 20:45 (<nobr>50 717</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Troy Parrott 17, 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Dublin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Węgry  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 15:00 (<nobr>59 411</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dániel Lukács 4, Barnabás Varga 37 - Troy Parrott 15 (k), 80, 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Budapeszt</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Portugalia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-1</b></td>
+<td nowrap valign="top" width="165"><b>  Armenia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 15:00 (<nobr>46 702</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Renato Veiga 7, Gonçalo Ramos 28, Jo&#227;o Neves 30, 41, 81, Bruno Fernandes 45 (k), 51, 72 (k), Francisco Conceiç&#227;o 90 - Eduard Spiercian 18</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Porto</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa F</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4196&id_sezon=107" class="main">Portugalia</a></td>
+<td>6</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>20-7</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>12-3</td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>8-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4182&id_sezon=107" class="main">Irlandia</a></td>
+<td>6</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>2</td>
+<td>9-7</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>5-2</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4181&id_sezon=107" class="main">Węgry</a></td>
+<td>6</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>2</td>
+<td>11-10</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>6-6</td>
+<td>1</td>
+<td>2</td>
+<td>0</td>
+<td>5-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4162&id_sezon=107" class="main">Armenia</a></td>
+<td>6</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>5</td>
+<td>3-19</td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>2-7</td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>1-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa G</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 20:45 (5106)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Oliver Antman 38</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021108" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 20:45 (<nobr>55 738</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Robert Lewandowski 81</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Warszawa</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 18:00 (<nobr>10 421</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Armandas Kučys 39, Gvidas Gineitis 69 - Kaan Kairinen 4, Joel Pohjanpalo 17 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kowno</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021120" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 20:45 (<nobr>45 872</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Karol Świderski 27, 51</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Warszawa</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 18:00 (2785)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 20:45 (<nobr>29 483</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Memphis Depay 6, Denzel Dumfries 23</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Helsinki</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021149" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (<nobr>16 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joel Pohjanpalo 31 (k), Benjamin Källman 64 - Jakub Kiwior 69</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Helsinki / mecz został przerwany w 73. minucie na 45 minut z powodu interwencji medycznej na trybunach</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>8-0</b></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (<nobr>21 006</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Memphis Depay 9 (k), 16, Virgil van Dijk 20, Xavi Simons 61, Donyell Malen 74, 80, Noa Lang 78, Micky van de Ven 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Groningen</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 18:00 (7854)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gvidas Gineitis 90 (k) - Alexander Satariano 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kowno</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021161" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 20:45 (<nobr>40 904</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Denzel Dumfries 28 - Matty Cash 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Rotterdam</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 18:00 (<nobr>14 797</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gvidas Gineitis 36, Edvinas Girdvainis 43 - Memphis Depay 11, 63, Quinten Timber 33</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kowno</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021185" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 20:45 (<nobr>50 897</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Matty Cash 27, Robert Lewandowski 45, Jakub Kamiński 54 - Benjamin Källman 88</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Chorzów</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 18:00 (<nobr>15 819</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Benjamin Källman 48, Adam Marchijew 55 - Pijus Širvys 25</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Helsinki</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (9254)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cody Gakpo 12 (k), 49 (k), Tijjani Reijnders 57, Memphis Depay 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 18:00 (<nobr>52 387</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Donyell Malen 8, Virgil van Dijk 17, Memphis Depay 38 (k), Cody Gakpo 84</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Amsterdam</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021231" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 20:45 (<nobr>11 741</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sebastian Szymański 15, Robert Lewandowski 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kowno</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Finlandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 18:00 (<nobr>13 577</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jake Grech 81</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Helsinki</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021262" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 20:45 (<nobr>56 278</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jakub Kamiński 43 - Memphis Depay 47</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Warszawa</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Malta  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2021285" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (<nobr>10 326</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Irvin Cardona 36, Teddy Teuma 68 (k) - Robert Lewandowski 32, Paweł Wszołek 59, Piotr Zieliński 85</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Holandia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Litwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (<nobr>46 913</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tijjani Reijnders 16, Cody Gakpo 58 (k), Xavi Simons 60, Donyell Malen 62</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Amsterdam</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa G</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4193&id_sezon=107" class="main">Holandia</a></td>
+<td>8</td>
+<td><b>20</b></td>
+<td>6</td>
+<td>2</td>
+<td>0</td>
+<td>27-4</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>17-1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>10-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=3462&id_sezon=107" class="main">Polska</a></td>
+<td>8</td>
+<td><b>17</b></td>
+<td>5</td>
+<td>2</td>
+<td>1</td>
+<td>14-7</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>7-2</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>7-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4176&id_sezon=107" class="main">Finlandia</a></td>
+<td>8</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>4</td>
+<td>8-14</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>4-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4192&id_sezon=107" class="main">Malta</a></td>
+<td>8</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>5</td>
+<td>4-19</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>2-8</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>2-11</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4188&id_sezon=107" class="main">Litwa</a></td>
+<td>8</td>
+<td><b>3</b></td>
+<td>0</td>
+<td>3</td>
+<td>5</td>
+<td>6-15</td>
+<td>0</td>
+<td>2</td>
+<td>2</td>
+<td>5-8</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>1-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa H</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 18:00 (2336)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Giánnis Píttas 55, Andrónikos Kakoullís 86</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Larnaka</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 20:45 (<nobr>49 413</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Armin Gigović 14</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bukareszt</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 20:45 (7464)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ermedin Demirović 22, Haris Hajradinović 56 - Giánnis Píttas 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zenica</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-5</b></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 20:45 (3556)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Samuele Zannoni 67 - Michele Cevoli 6 (s), Mihai Popescu 44, Răzvan Marin 55 (k), Ianis Hagi 75 (k), Denis Alibec 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Serravalle</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 15:00 (<nobr>11 828</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Edin Džeko 66</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zenica</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 20:45 (<nobr>48 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Michael Gregoritsch 42, Marcel Sabitzer 60 - Denis Alibec 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Wiedeń</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (<nobr>45 324</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Florin Tănase 43, Dennis Man 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bukareszt</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (3075)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marko Arnautović 3, 15, Michael Gregoritsch 11, Christoph Baumgartner 27</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Serravalle</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 20:45 (<nobr>16 300</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marcel Sabitzer 54 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-6</b></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 20:45 (2740)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Benjamin Tahirović 21, Edin Džeko 70, 72, Samed Baždar 81, Kerim Alajbegović 85, Nihad Mujakić 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Serravalle</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>11 700</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Edin Džeko 50 - Marcel Sabitzer 49, Konrad Laimer 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zenica</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (4875)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lo&#7727;zos Lo&#7727;zou 29, Charálabos Charalábous 76 - Denis Drăgu&#537; 2, 18</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Stróvolos</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>10-0</b></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (<nobr>37 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Romano Schmid 7, Marko Arnautović 8, 47, 83, 84, Michael Gregoritsch 24, Stefan Posch 30, 42, Konrad Laimer 45, Nikolaus Wurmbrand 76</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Wiedeń</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (2355)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kóstas La&#7727;fis 45, Giánnis Píttas 90 (k) - Nikola Katić 10, Neófytos Michél 36 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Larnaka</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 15:00 (598)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lo&#7727;zos Lo&#7727;zou 9, Stélios Andréou 59, Grigóris Kástanos 67 (k), Andrónikos Kakoullís 79</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Serravalle</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 20:45 (<nobr>39 581</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Virgil Ghi&#539;ă 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bukareszt</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Cypr  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 18:00 (6012)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marko Arnautović 18 (k), 55</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 20:45 (<nobr>11 459</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Edin Džeko 49, Esmir Bajraktarević 79, Haris Tabaković 90 - Daniel Bîrligea 17</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zenica</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Austria  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>48 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Michael Gregoritsch 77 - Haris Tabaković 12</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Wiedeń</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-1</b></td>
+<td nowrap valign="top" width="165"><b>  San Marino  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (8426)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dante Rossi 13 (s), &#536;tefan Baiaram 29, Dennis Man 42, Giacomo Valentini 57 (s), Ianis Hagi 76, Andrei Ra&#539;iu 82, Louis Munteanu 86 (k) - Nicolas Giacopetti 2</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ploeszti</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa H</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4163&id_sezon=107" class="main">Austria</a></td>
+<td>8</td>
+<td><b>19</b></td>
+<td>6</td>
+<td>1</td>
+<td>1</td>
+<td>22-4</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>14-2</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>8-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4166&id_sezon=107" class="main">Bośnia i Hercegowina</a></td>
+<td>8</td>
+<td><b>17</b></td>
+<td>5</td>
+<td>2</td>
+<td>1</td>
+<td>17-7</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>7-4</td>
+<td>2</td>
+<td>2</td>
+<td>0</td>
+<td>10-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4197&id_sezon=107" class="main">Rumunia</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>3</td>
+<td>19-10</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>10-2</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>9-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4169&id_sezon=107" class="main">Cypr</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>11-11</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>6-6</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>5-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4201&id_sezon=107" class="main">San Marino</a></td>
+<td>8</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>8</td>
+<td>2-39</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>1-19</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>1-20</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa I</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 18:00 (9342)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julian Ryerson 5, Erling H&#229;land 23, Thelo Aasgaard 38, Alexander S&#248;rloth 43, Aron D&#248;nnum 69</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kiszyniów</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 20:45 (270)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Karl Jakob Hein 23 (s), Eli Dasa 75 - Maksim Paskotši 10</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Debreczyn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 18:00 (6112)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ion Nicolaescu 67, Mihail Caimacov 90 - Rasmus Peetson 19, Rauno Sappinen 30, Mattias Käit 70</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kiszyniów</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-4</b></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 20:45 (1200)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mohammad Abu Fani 55, Dor Turgeman 90 - David M&#248;ller Wolfe 39, Alexander S&#248;rloth 59, Kristoffer Ajer 65, Erling H&#229;land 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Debreczyn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (5967)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mattias Käit 31 - Dan Biton 39, 49, Mohammad Abu Fani 90 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tallin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (<nobr>25 796</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexander S&#248;rloth 14, Antonio Nusa 34, Erling H&#229;land 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Oslo</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 20:45 (<nobr>11 577</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 62</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tallin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 20:45 (<nobr>18 771</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Giacomo Raspadori 40, Andrea Cambiaso 50</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Reggio Emilia</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (7242)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dor Peretz 15, Manor Solomon 35, Tai Baribo 59, Oscar Gloukh 77</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kiszyniów</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (<nobr>22 559</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Moise Kean 58, Mateo Retegui 69, 89, Giacomo Raspadori 71, Alessandro Bastoni 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bergamo</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-5</b></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (2540)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Manuel Locatelli 16 (s), Dor Peretz 52, 89, Alessandro Bastoni 87 (s) - Moise Kean 40, 54, Matteo Politano 58, Giacomo Raspadori 81, Sandro Tonali 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Debreczyn</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>11-1</b></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>24 605</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Felix Myhre 6, Erling H&#229;land 11, 36, 43, 52, 83, Martin &#216;degaard 45, Thelo Aasgaard 68, 76, 79 (k), 90 - Leo &#216;stig&#229;rd 74 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Oslo</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 18:00 (<nobr>19 363</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anan Khalaili 18 (s), Erling H&#229;land 27, 63, 72, Idan Nachmias 28 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Oslo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 20:45 (<nobr>11 913</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rauno Sappinen 76 - Moise Kean 4, Mateo Retegui 38, Francesco Pio Esposito 74</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tallin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 18:00 (4731)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mattias Käit 12 - &#536;tefan Bodi&#537;teanu 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tallin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (9965)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mateo Retegui 45 (k), 74, Gianluca Mancini 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Udine</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Estonia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 18:00 (<nobr>25 493</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexander S&#248;rloth 50, 52, Erling H&#229;land 56, 62 - Robi Saarma 64</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Oslo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 20:45 (9526)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gianluca Mancini 88, Francesco Pio Esposito 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kiszyniów</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Izrael  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Mołdawia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 20:45 (3312)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dor Turgeman 21 (k), Roy Revivo 65, Eliel Peretz 85, Władysław Babohło 88 (s) - Ion Nicolaescu 37</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kiszyniów</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  Norwegia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 20:45 (<nobr>69 020</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Francesco Pio Esposito 11 - Antonio Nusa 63, Erling H&#229;land 78, 79, J&#248;rgen Strand Larsen 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Mediolan</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa I</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4195&id_sezon=107" class="main">Norwegia</a></td>
+<td>8</td>
+<td><b>24</b></td>
+<td>8</td>
+<td>0</td>
+<td>0</td>
+<td>37-5</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>23-2</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>14-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4185&id_sezon=107" class="main">Włochy</a></td>
+<td>8</td>
+<td><b>18</b></td>
+<td>6</td>
+<td>0</td>
+<td>2</td>
+<td>21-12</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>11-4</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>10-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4184&id_sezon=107" class="main">Izrael</a></td>
+<td>8</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>4</td>
+<td>19-20</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>12-11</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>7-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4174&id_sezon=107" class="main">Estonia</a></td>
+<td>8</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>6</td>
+<td>8-21</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>3-8</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>5-13</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4191&id_sezon=107" class="main">Mołdawia</a></td>
+<td>8</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>7</td>
+<td>5-32</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>2-14</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>3-18</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa J</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 15:00 (4094)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Trajkovski 7, Visar Musliu 42, Bojan Miovski 84</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Vaduz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 20:45 (<nobr>32 473</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Daniel James 9, Ben Davies 47, Rabbi Matondo 90 - Aschat Tagybiergien 32 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cardiff</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 20:45 (1123)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Maksim Samorodow 42, Aleksandr Maroczkin 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Vaduz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 20:45 (<nobr>23 114</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bojan Miovski 90 - David Brooks 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (<nobr>23 070</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ez&#501;an Alioski 86 - Maxim De Cuyper 28</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (<nobr>30 646</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joe Rodon 40, Harry Wilson 65, Kieffer Moore 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cardiff</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 16:00 (<nobr>27 694</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Trajkovski 33</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-3</b></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 20:45 (<nobr>33 653</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Romelu Lukaku 15 (k), Youri Tielemans 19, Jérémy Doku 27, Kevin De Bruyne 88 - Harry Wilson 45 (k), Sorba Thomas 51, Brennan Johnson 70</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bruksela</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 16:00 (<nobr>28 219</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kieffer Moore 24</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-6</b></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 września, 20:45 (3158)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Maxim De Cuyper 29, Youri Tielemans 46, 70 (k), Arthur Theate 60, Kevin De Bruyne 62, Malick Fofana 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Vaduz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 18:00 (8693)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Benjamin Büchel 15 (s), Enis Bardi 52, Darko Čurlinov 56, Lirim Qamili 82, Luka Stankovski 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-0</b></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 września, 20:45 (<nobr>15 119</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kevin De Bruyne 42, 84, Jérémy Doku 44, 60, Nicolas Raskin 51, Thomas Meunier 87</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Anderlecht</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 16:00 (<nobr>26 539</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 października, 20:45 (<nobr>18 583</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gandawa</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>19 929</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Enis Bardi 74 - Dinmuchamied Karaman 54</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-4</b></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 października, 20:45 (<nobr>32 803</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joe Rodon 8, Nathan Broadhead 89 - Kevin De Bruyne 18 (k), 76 (k), Thomas Meunier 24, Leandro Trossard 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cardiff</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kazachstan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 15:00 (<nobr>28 012</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dastan Satpajew 9 - Hans Vanaken 48</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 listopada, 18:00 (5563)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jordan James 61</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Vaduz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Belgia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-0</b></td>
+<td nowrap valign="top" width="165"><b>  Liechtenstein  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lie.jpg" title="Liechtenstein" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>26 253</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hans Vanaken 3, Jérémy Doku 34, 41, Brandon Mechele 52, Alexis Saelemaekers 55, Charles De Ketelaere 57, 59</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Li&#232;ge</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-1</b></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 listopada, 20:45 (<nobr>32 154</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Wilson 18 (k), 75, 81 (k), David Brooks 21, Brennan Johnson 37, Daniel James 57, Nathan Broadhead 88 - Bojan Miovski 23</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cardiff</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa J</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=3463&id_sezon=107" class="main">Belgia</a></td>
+<td>8</td>
+<td><b>18</b></td>
+<td>5</td>
+<td>3</td>
+<td>0</td>
+<td>29-7</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>17-3</td>
+<td>2</td>
+<td>2</td>
+<td>0</td>
+<td>12-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4206&id_sezon=107" class="main">Walia</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>21-11</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>15-6</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>6-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22126&id_sezon=107" class="main">Macedonia Północna</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>13-10</td>
+<td>1</td>
+<td>3</td>
+<td>0</td>
+<td>8-3</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>5-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=5821&id_sezon=107" class="main">Kazachstan</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>9-13</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>5-3</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>4-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4187&id_sezon=107" class="main">Liechtenstein</a></td>
+<td>8</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>8</td>
+<td>0-31</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>0-12</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>0-19</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa K</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 20:45 (957)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dario Šits 58</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Andora</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 marca, 20:45 (<nobr>82 378</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Myles Lewis-Skelly 20, Harry Kane 77</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Londyn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 20:45 (<nobr>17 183</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rey Manaj 9, 19, Myrto Uzuni 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 marca, 20:45 (<nobr>79 572</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Reece James 38, Harry Kane 68, Eberechi Eze 76</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Londyn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 18:00 (8872)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 50</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Barcelona</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 czerwca, 20:45 (<nobr>20 427</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (6083)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antonijs Černomordijs 45 - Antonijs Černomordijs 29 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ryga</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 czerwca, 20:45 (7576)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Mitrović 12, 24, 53 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Leskovac</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 15:00 (6238)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dušan Vlahović 12</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ryga</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 września, 18:00 (<nobr>39 202</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Christian García 25 (s), Declan Rice 67</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Birmingham</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>16 568</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kristjan Asllani 25 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 września, 20:45 (<nobr>39 789</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 33, Noni Madueke 35, Ezri Konsa 52, Marc Guéhi 75, Marcus Rashford 90 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Belgrad</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 15:00 (5027)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dmitrijs Zelenkovs 41, Vladislavs Gutkovskis 55 (k) - Moisés San Nicolás 33, Ian Olivera 78</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ryga</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 października, 20:45 (4320)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rey Manaj 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Leskovac</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (987)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Guillaume Lopez 17 - Christian García 19 (s), Dušan Vlahović 54, Aleksandar Mitrović 77 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Encamp</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 października, 20:45 (<nobr>10 404</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anthony Gordon 26, Harry Kane 44, 45 (k), Maksims To&#326;iševs 58 (s), Eberechi Eze 86</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ryga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Andora  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 20:45 (2225)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kristjan Asllani 67</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Encamp</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">13 listopada, 20:45 (<nobr>74 289</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 28, Eberechi Eze 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Londyn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Anglia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 18:00 (<nobr>21 459</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 74, 82</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Serbia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Łotwa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 listopada, 18:00 (3894)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Katai 49, Aleksandar Stanković 60 - Vladislavs Gutkovskis 12</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Leskovac</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa K</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4172&id_sezon=107" class="main">Anglia</a></td>
+<td>8</td>
+<td><b>24</b></td>
+<td>8</td>
+<td>0</td>
+<td>0</td>
+<td>22-0</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>9-0</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>13-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4160&id_sezon=107" class="main">Albania</a></td>
+<td>8</td>
+<td><b>14</b></td>
+<td>4</td>
+<td>2</td>
+<td>2</td>
+<td>7-5</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>4-2</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>3-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=10570&id_sezon=107" class="main">Serbia</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>3</td>
+<td>9-10</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>5-7</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>4-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4186&id_sezon=107" class="main">Łotwa</a></td>
+<td>8</td>
+<td><b>5</b></td>
+<td>1</td>
+<td>2</td>
+<td>5</td>
+<td>5-15</td>
+<td>0</td>
+<td>2</td>
+<td>2</td>
+<td>3-9</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>2-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4161&id_sezon=107" class="main">Andora</a></td>
+<td>8</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>7</td>
+<td>3-16</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>1-6</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>2-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa L</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 21-22 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 18:00 (3021)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Stevan Jovetić 22, Marko Tući 70, Adam Marušić 73 - Dan Bent 13</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Nikšić</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 marca, 20:45 (8978)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Patrik Schick 25, 85 - Gunnar Vatnhamar 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Hradec Králové</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 24-25 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 20:45 (583)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Václav Černý 21, Patrik Schick 50, Pavel Šulc 72, Jan Kliment 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Faro</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 marca, 20:45 (3226)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Edvin Kuč 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Nikšić</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 6-7 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (<nobr>10 889</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adam Hložek 23, Patrik Schick 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pilzno</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-7</b></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 czerwca, 20:45 (1516)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mario Pašalić 28, Ante Budimir 30, Franjo Ivanović 60, 63, Ivan Perišić 73, Andrej Kramarić 77, 79</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Faro</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 9-10 czerwca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 20:45 (2632)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Árni Frederiksberg 71, Patrik Johannesen 86 - James Scanlon 23</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Thorshavn</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 czerwca, 20:45 (<nobr>12 207</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andrej Kramarić 42, 75, Luka Modrić 62 (k), Ivan Perišić 68, Ante Budimir 72 (k) - Tomáš Souček 58</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Osijek</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 4-6 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (4632)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andrej Kramarić 31</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Thorshavn</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 września, 20:45 (6315)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lukáš Červ 3, Václav Černý 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Podgorica</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 7-9 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (1603)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Martin Agnarsson 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gibraltar</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 września, 20:45 (<nobr>21 209</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kristijan Jakić 35, Andrej Kramarić 51, Edvin Kuč 85 (s), Ivan Perišić 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Zagrzeb</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 9-11 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (<nobr>18 870</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Praga</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 października, 20:45 (2034)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hanus S&#248;rensen 16, 55, Milan Roganović 36 (s), Árni Frederiksberg 72 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Thorshavn</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 12-14 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 18:00 (2980)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Hanus S&#248;rensen 67, Martin Agnarsson 81 - Adam Karabec 78</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Thorshavn</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 października, 20:45 (7579)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Toni Fruk 30, Luka Sučić 78, Martin Erlić 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Varaždin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 13-15 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 20:45 (668)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Liam Jessop 20 - Vasilije Adžić 33, Nikola Krstović 42 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gibraltar</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Wyspy Owcze  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 listopada, 20:45 (7846)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joško Gvardiol 23, Petar Musa 57, Nikola Vlašić 70 - Géza Dávid Turi 16</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Rijeka</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 16-18 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-0</b></td>
+<td nowrap valign="top" width="165"><b>  Gibraltar  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (6587)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Douděra 5, Tomáš Chorý 18, Vladimír Coufal 32, Adam Karabec 39, Tomáš Souček 44, Robin Hranáč 51</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ołomuniec</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czarnogóra  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Chorwacja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 listopada, 20:45 (4673)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Milutin Osmajić 3, Nikola Krstović 17 - Ivan Perišić 37 (k), Kristijan Jakić 72, Nikola Vlašić 87</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Podgorica</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa L</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_FIFA18 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4168&id_sezon=107" class="main">Chorwacja</a></td>
+<td>8</td>
+<td><b>22</b></td>
+<td>7</td>
+<td>1</td>
+<td>0</td>
+<td>26-4</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>15-2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>11-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4170&id_sezon=107" class="main">Czechy</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>18-8</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>10-1</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>8-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4175&id_sezon=107" class="main">Wyspy Owcze</a></td>
+<td>8</td>
+<td><b>12</b></td>
+<td>4</td>
+<td>0</td>
+<td>4</td>
+<td>11-9</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>8-3</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>3-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=10571&id_sezon=107" class="main">Czarnogóra</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>5</td>
+<td>8-17</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>6-6</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>2-11</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=17609&id_sezon=107" class="main">Gibraltar</a></td>
+<td>8</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>8</td>
+<td>3-28</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>1-14</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>2-14</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału - 26 marca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 20 listopada 2025, 13:00 - Zurych)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr>
+<td>&nbsp;</td></tr>
+<tr>
+<td></td><td colspan="4"><b>2026</b></td></tr>
+<tr>
+<td>&nbsp;</td></tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Rumunia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 18:00 (<nobr>38 979</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ferdi Kad&#305;o&#287;lu 53</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C / Stambuł</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>23 439</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sandro Tonali 56, Moise Kean 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A / Bergamo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Walia  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>32 487</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 2-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Daniel James 51 - Edin Džeko 86</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A / Cardiff</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ukraina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>18 846</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Matwij Ponomarenko 90 - Viktor Gyökeres 6, 51, 73 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B / Walencja</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2111364" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Albania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>56 412</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Robert Lewandowski 63, Piotr Zieliński 73 - Arbër Hoxha 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B / Warszawa</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Słowacja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-4</b></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>20 113</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Martin Valjent 6, Lukáš Haraslín 45, David Strelec 90 - Veldin Hodža 21, Fisnik Asllani 47, Florent Muslija 60, Kreshnik Hajrizi 72</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C / Bratysława</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Macedonia Północna  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>35 746</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikkel Damsgaard 49, Gustav Isaksen 58, 59, Christian N&#248;rgaard 75</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D / Kopenhaga</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Irlandia  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 marca, 20:45 (<nobr>19 137</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 4-3</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Patrik Schick 27 (k), Ladislav Krejčí II 86 - Troy Parrott 19 (k), Matěj Kovář 23 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D / Praga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał - 31 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bośnia i Hercegowina  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Włochy  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 marca, 20:45 (9500)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 4-1</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Haris Tabaković 79 - Moise Kean 15</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>A / Zenica</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Szwecja  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2111370" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Polska </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 marca, 20:45 (<nobr>49 627</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anthony Elanga 19, Gustaf Lagerbielke 44, Viktor Gyökeres 88 - Nicola Zalewski 33, Karol Świderski 55</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>B / Solna</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kosowo  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Turcja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 marca, 20:45 (<nobr>12 887</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kerem Aktürko&#287;lu 53</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>C / Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Czechy  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Dania  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 marca, 20:45 (<nobr>18 215</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 3-1</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Pavel Šulc 3, Ladislav Krejčí II 100 - Joachim Andersen 72, Kasper H&#248;gh 111</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>D / Praga</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<a class="main" href="/liga/1/liga14645.html">Mistrzostwa Świata - Kanada/Meksyk/USA 2026</a>
+</td></tr>
+</table>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 13 grudnia 2024, 12:00 - Zurych)</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Do turnieju finałowego bezpośrednio awansują zwycięzcy grup. Drużyny z drugich miejsc w grupach oraz czterech najlepszych zwycięzców grup w Lidze Narodów 2024/25 (łącznie 16 drużyn) zagrają w dwurundowych barażach.</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Przed losowaniem grup 54 federacje podzielono na pięć koszyków na podstawie rankingu FIFA z 28 listopada 2024:</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Koszyk 1 - Francja, Hiszpania, Anglia, Portugalia, Holandia, Belgia, Włochy, Niemcy, Chorwacja, Szwajcaria, Dania, Austria</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Koszyk 2 - Ukraina, Szwecja, Turcja, Walia, Węgry, Serbia, Polska, Grecja, Rumunia, Słowacja, Czechy, Norwegia</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Koszyk 3 - Szkocja, Słowenia, Irlandia, Albania, Macedonia Północna, Gruzja, Finlandia, Islandia, Irlandia Północna, Czarnogóra, Bośnia i Hercegowina, Izrael</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Koszyk 4 - Bułgaria, Luksemburg, Białoruś, Armenia, Kosowo, Kazachstan, Azerbejdżan, Estonia, Cypr, Wyspy Owcze, Łotwa, Litwa</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Koszyk 5 - Mołdawia, Malta, Andora, Gibraltar, Liechtenstein, San Marino</td></tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Rosja została wykluczona z rozgrywek z powodu inwazji na Ukrainę.</td></tr></table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Maciej Kusina
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_14077.html
+++ b/internal/site/testdata/fixtures/league_14077.html
@@ -1,0 +1,5361 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Liga Mistrzów 2025/2026</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=14072"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=14073"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez25-26.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14072" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14073" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14074" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14675" class="menulnk" title="Sparingi - Ekstraklasa - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14676" class="menulnk" title="Sparingi - I liga - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14677" class="menulnk" title="Sparingi - II liga - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=109&runda=1" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=109&runda=1&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=109&runda=1&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=109&runda=1&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14675&runda=1" class="menulnk" title="Przygotowania - Ekstraklasa - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14676&runda=1" class="menulnk" title="Przygotowania - I liga - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14677&runda=1" class="menulnk" title="Przygotowania - II liga - lato 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=109&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=109&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=107" class="menulnk" title="Baraże 2026" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14675.html" class="menulnk" title="Ekstraklasa 2026/2027 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14676.html" class="menulnk" title="I liga 2026/2027 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14074.html" class="menulnk" title="II liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=107" class="menulnk" title="III Liga 2025/2026 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14154.html" class="menulnk" title="III Liga 2025/2026 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14155.html" class="menulnk" title="III Liga 2025/2026 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14156.html" class="menulnk" title="III Liga 2025/2026 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14157.html" class="menulnk" title="III Liga 2025/2026 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14384.html" class="menulnk" title="Centralna Liga Juniorów 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14385.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14386.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14679.html" class="menulnk" title="Puchar Polski 2026/2027 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14678.html" class="menulnk" title="Superpuchar 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=107" class="menulnk" title="Rozgrywki pucharowe w Polsce 2025/2026 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2025/2026 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14077.html" class="menulnk" title="Liga Mistrzów 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14078.html" class="menulnk" title="Liga Europy 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14079.html" class="menulnk" title="Liga Konferencji 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14634.html" class="menulnk" title="Liga Młodzieżowa 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=107" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=107" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=107" class="menulnk" title="Reprezentacja Polski 2025/2026 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14042.html" class="menulnk" title="Eliminacje mistrzostw świata - USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14645.html" class="menulnk" title="Mistrzostwa świata - Kanada/Meksyk/USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14658.html" class="menulnk" title="Liga Narodów 2026/2027 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 26/27</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=107" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=107" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=109" class="menulnk" title="Archiwum wyników z sezonu 2026/2027" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2026 / 2027</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=107" class="menulnk" title="Archiwum wyników z sezonu 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2025 / 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/eurcups2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga14077.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=14077" class="main">Strzelcy</a> | <a href="/stats.php?id=14077" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Liga Mistrzów 2025/2026</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<!-- <div align="center"><a target="_blank" href="https://bilety.laczynaspilka.pl/"><img src="/banery/ban-pzpn-2025-10-20-468x60.jpg" border="0" vspace="3"></a></div> --><div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_UEFA24 -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>I runda eliminacyjna - 8-9 lipca, 15-16 lipca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 17 czerwca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Wilno  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  &#294;amrun Spartans FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 lipca, 18:00 (3176)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Liviu Antal 59, Kassim Hadji 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kuopion Palloseura  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Milsami Orhei  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 17:00 (2316)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Otto Ruoppi 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  The New Saints FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  FK Škendija 79 (Tetovo)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 20:00 (1090)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Iberia 1999 Tbilisi  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Malmö FF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 18:00 (7449)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anes Rušević 86 - Busanello 8, Hugo Bolin 58, Taha Ali 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Levadia Tallin  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  RFS Ryga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 18:30 (2895)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Stefan Panić 56 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Drita Gnjilane  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  FC Differdange 03  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 20:00 (4156)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Arb Manaj 74</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Víkingur  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Lincoln Red Imps FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 20:00 (740)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jákup Johansen 28, S&#248;lvi Vatnhamar 45 (k) - Bernardo Lopes 19, 31, Tjay De Barr 38 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Klaksvík</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Egnatia Rrogozhinë  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 21:00 (3563)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ildi Gruda 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Shelbourne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Linfield FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 lipca, 20:45 (3655)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mipo Odubeko 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FCSB Bukareszt  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Inter Club d'Escaldes  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 lipca, 19:30 (<nobr>13 080</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Miculescu 37, Darius Olaru 45 (k), Marius &#536;tefănescu 53 - Rafinha 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AC Virtus  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 21:00 (864)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nemanja Bilbija 45 (k), 79</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Serravalle</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 19:00 (4877)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Diogo Pinto 66 - Dastan Satpajew 59</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Noa Erewan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  FK Budućnost (Podgorica)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 lipca, 18:00 (2905)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Imrane Oulad Omar 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Abowian</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Dinamo Mińsk  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 lipca, 19:30 (4522)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Filip Kaloč 87</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  &#294;amrun Spartans FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Wilno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 19:00 (1247)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 11-10</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Saliou Thioune 35, Joseph Mbong 41</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ta' Qali</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Milsami Orhei  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kuopion Palloseura  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 19:00 (3105)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Škendija 79 (Tetovo)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  The New Saints FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 20:00 (2589)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fabrice Tamba 18, Aleksandër Trumçi 116 - Jordan Williams 38</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Malmö FF  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Iberia 1999 Tbilisi  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 19:00 (<nobr>13 819</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Taha Ali 55, 89, Pontus Jansson 60 - Amiran Dzagania 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  RFS Ryga  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  FC Levadia Tallin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 19:00 (1700)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Stefan Panić 68</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Differdange 03  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Drita Gnjilane  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 20:00 (1922)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Théo Brusco 28, Samir Hadji 90 (k) - Arb Manaj 4, 17, Veton Tusha 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Lincoln Red Imps FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Víkingur  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fro.jpg" title="Wyspy Owcze" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 17:30 (758)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tjay De Barr 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Brei&#240;ablik (Kópavogur)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Egnatia Rrogozhinë  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 21:00 (1150)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ágúst Orri &#222;orsteinsson 15, 27, Viktor Karl Einarsson 23, 38, Óli Valur Ómarsson 69</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Linfield FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Shelbourne FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 lipca, 20:45 (7137)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chris Shields 45 (k) - Ali Coote 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Inter Club d'Escaldes  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FCSB Bukareszt  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 20:30 (509)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sascha Andreu 67, Alexandre Llovet 88 - Risto Radunović 51</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Encamp</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  HŠK Zrinjski (Mostar)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  AC Virtus  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 21:00 (4600)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Petar Mamić 40, Nemanja Bilbija 75 - Stefano Scappini 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kajrat Ałmaty  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  NK Olimpija (Lublana)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 17:00 (<nobr>22 800</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jorginho 5, Aleksandr Mrynskij 31</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Budućnost (Podgorica)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Noa Erewan  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 lipca, 21:00 (6150)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Igor Ivanović 68, Petar Grbić 90 - Imrane Oulad Omar 6, Alen Grgić 29</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dinamo Mińsk  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Łudogorec Razgrad  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 lipca, 20:45</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Moustapha Djimet 54, Pedro Igor 62 - Erick Marcus 41, Yves Erick Bile 100</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Mezőkövesd / bez udziału publiczności</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>II runda eliminacyjna - 22-23 lipca, 29-30 lipca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 18 czerwca 2025, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  &#294;amrun Spartans FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Dynamo Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 19:00 (1760)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Władysław Wanat 13, Witalij Bujalśkyj 76, Nazar Wołoszyn 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Paola</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Tel Awiw  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 19:00 (4557)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mons Bassouamina 81 - Elad Madmon 90</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Lincoln Red Imps FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 18:00 (622)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruno Duarte 30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Noa Erewan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 18:00 (2800)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Stefan Gartenmann 36 (s) - Callum O'Dowda 45, Barnabás Varga 49</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Abowian</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Lech Poznań </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2023317" class="main"><b>7-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 20:30 (<nobr>24 859</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antonio Milić 4, Mikael Ishak 37 (k), 45 (k), 85 (k), Joel Pereira 42, Leo Bengtsson 45, Filip Jagiełło 77 - Höskuldur Gunnlaugsson 28 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Drita Gnjilane  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 19:00 (<nobr>17 897</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Magnus Mattsson 69 (k), 76 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  HNK Rijeka  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 20:45 (7731)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 20:15 (<nobr>18 257</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tigran Barseghjan 39, David Strelec 42, Marko Tolić 62, Mykoła Kucharewycz 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Shelbourne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-3</b></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 lipca, 20:45 (3650)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leândro Andrade 13, Ołeksij Kaszczuk 81, N&#601;riman Axundzad&#601; 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Brann  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 lipca, 19:00 (<nobr>14 587</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">S&#230;var Atli Magnússon 20 - Nene Dorgeles 58, Karim Onisiwo 61, Yorbe Vertessen 87, Maurits Kj&#230;rgaard 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Viktoria Plzeň  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Servette FC Genewa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 19:00 (<nobr>11 055</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Samuel Mráz 13</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 20:45 (<nobr>49 548</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Findlay Curtis 52, Djeidi Gassama 78</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kuopion Palloseura  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 17:00 (2912)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mohamed Touré 49, Jaakko Oksanen 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RFS Ryga  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  Malmö FF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 19:00 (1674)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Darko Lemajić 40 - Otto Rosengren 13, Pontus Jansson 35, Sead Hakšabanović 58, Lasse Berg Johnsen 88 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Škendija 79 (Tetovo)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  FCSB Bukareszt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lipca, 20:00 (4438)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adamu Alhassan 65</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Dynamo Kijów  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  &#294;amrun Spartans FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 lipca, 20:00 (2035)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Władysław Wanat 28, Wołodymyr Brażko 35, Taras Mychawko 82</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Tel Awiw  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Páfos FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 20:00 (654)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jajá 40</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bačka Topola</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Crvena zvezda (Belgrad)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Lincoln Red Imps FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 lipca, 21:00 (<nobr>31 241</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Katai 8, Mirko Ivanić 16, Bruno Duarte 37, Milson 44, Cherif N'Diaye 75 - Tjay De Barr 53</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Ferencvárosi TC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-3</b></td>
+<td nowrap valign="top" width="165"><b>  Noa Erewan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 20:00 (<nobr>17 039</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Pešić 1, Lenny Joseph 12, Kristoffer Zachariassen 52 (k), Barnabás Varga 74 - Hélder Ferreira 7, Matheus Aiás 22, Alen Grgić 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Brei&#240;ablik (Kópavogur)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2023318" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+ <font color="blue"> Lech Poznań </font> </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 20:30 (1471)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikael Ishak 29</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Drita Gnjilane  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 lipca, 20:00 (7255)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andreas Cornelius 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Prisztina</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Łudogorec Razgrad  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  HNK Rijeka  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 19:30 (6382)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. </b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jakub Piotrowski 19 (k), Iwajło Czoczew 107, Stanisław Iwanow 117 - Amer Gojak 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  HŠK Zrinjski (Mostar)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  ŠK Slovan Bratysława  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 lipca, 21:00 (4100)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nemanja Bilbija 72 (k), Jakov Pranjić 76 - David Strelec 80, 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Qaraba&#287; A&#287;dam  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Shelbourne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 18:00 (<nobr>25 573</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">John Martin 44 (s)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Salzburg  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  SK Brann  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 20:45 (<nobr>11 949</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Maurits Kj&#230;rgaard 6 - Emil Kornvig 3</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Servette FC Genewa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Viktoria Plzeň  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 21:00 (<nobr>11 716</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexis Antunes 4 - Karel Spáčil 29, Matěj Vydra 31, Rafiu Durosinmi 87 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Panathina&#239;kós AO  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Rangers FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 20:00 (<nobr>36 121</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Filip Đuričić 54 - Djeidi Gassama 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kajrat Ałmaty  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Kuopion Palloseura  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 lipca, 17:00 (<nobr>22 800</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dastan Satpajew 9, Jorginho 29, Walerij Gromyko 43</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Malmö FF  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  RFS Ryga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 19:00 (<nobr>14 225</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sead Hakšabanović 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FCSB Bukareszt  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Škendija 79 (Tetovo)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 lipca, 19:30 (<nobr>32 457</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Juri Cisotti 28 - Liridon Latifi 33, Vane Krstevski 87</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>III runda eliminacyjna - 5-6 sierpnia, 12-13 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 21 lipca 2025, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 19:00 (<nobr>12 782</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Romeo Vermant 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  OGC Nice-Côte d&#39;Azur  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 21:00 (<nobr>26 443</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Franjo Ivanović 53, Florentino Luís 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Fenerbahçe SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 21:00 (<nobr>42 180</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Quinten Timber 19, Anis Hadj Moussa 90 - Sofyan Amrabat 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 17:00 (<nobr>22 800</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dastan Satpajew 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Malmö FF  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 sierpnia, 19:00 (<nobr>20 175</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Dynamo Kijów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 sierpnia, 20:00 (2020)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ânderson Silva 84</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Lech Poznań </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2097694" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 20:30 (<nobr>39 743</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mikael Ishak 34 - Rade Krunić 9, 51, Bruno Duarte 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Škendija 79 (Tetovo)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-1</b></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 sierpnia, 20:00 (<nobr>15 930</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Toral Bayramov 18 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Skopje</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 sierpnia, 19:30 (6746)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  FC Viktoria Plzeň  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 sierpnia, 20:45 (<nobr>45 730</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Djeidi Gassama 15, 51, Cyriel Dessers 45 (k)</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Brugge KV  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC Salzburg  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 19:30 (<nobr>23 736</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Joaquin Seys 61, Carlos Forbs 83, Hans Vanaken 90 - Jacob Rasmussen 18, Edmund Baidoo 43</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  SL e Benfica  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  OGC Nice-Côte d&#39;Azur  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 21:00 (<nobr>64 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fredrik Aursnes 19, Andreas Schjelderup 27</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Fenerbahçe SK  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-2</b></td>
+<td nowrap valign="top" width="165"><b>  Feyenoord Rotterdam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 19:00 (<nobr>39 497</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Archie Brown 44, Jhon Durán 45, Fred 55, Youssef En-Nesyri 83, Ânderson Talisca 90 - Tsuyoshi Watanabe 41, 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ŠK Slovan Bratysława  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kajrat Ałmaty  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 20:15 (<nobr>21 005</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 3-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Róbert Mak 30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Malmö FF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 19:00 (<nobr>34 233</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rodrigo Huescas 31, Robert 43, 69, Mohamed Elyounoussi 51, Magnus Mattsson 67</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Páfos FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Dynamo Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 19:00 (7601)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mislav Oršić 2, Jo&#227;o Correia 55</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Crvena zvezda (Belgrad)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2097695" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Lech Poznań </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 21:00 (<nobr>45 371</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cherif N'Diaye 45 (k) - Mikael Ishak 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Qaraba&#287; A&#287;dam  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  FK Škendija 79 (Tetovo)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 18:00 (<nobr>30 252</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Klisman Cake 16 (s), Kady 18, N&#601;riman Axundzad&#601; 33, Marko Janković 35 (k), Leândro Andrade 59 - Fabrice Tamba 10</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Ferencvárosi TC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-0</b></td>
+<td nowrap valign="top" width="165"><b>  Łudogorec Razgrad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 20:15 (<nobr>19 111</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Barnabás Varga 38, 79, Gábor Szalai 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Viktoria Plzeň  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Rangers FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">12 sierpnia, 19:00 (<nobr>11 341</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rafiu Durosinmi 41, Svetozar Marković 83 - Lyall Cameron 61</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>IV runda eliminacyjna - 19-20 sierpnia, 26-27 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 4 sierpnia 2025, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  SK Sturm Graz  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 sierpnia, 21:00 (7896)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kasper H&#248;gh 7, Odin Bj&#248;rtuft 10, Ulrik Saltnes 25, H&#229;kon Evjen 54, William B&#248;ving 79 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 sierpnia, 21:00 (<nobr>56 182</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Basel 1893  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 sierpnia, 21:00 (<nobr>25 847</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Xherdan Shaqiri 14 (k) - Gabriel Pereira 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 sierpnia, 21:00 (<nobr>19 675</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Barnabás Varga 29 - Marko Janković 50, Kevin Medina 67, Musa Qurbanl&#305; 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 sierpnia, 21:00 (<nobr>43 411</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruno Duarte 58 - Jo&#227;o Correia 1, P&#234;p&#234; Rodrigues 52 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Fenerbahçe SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 sierpnia, 21:00 (<nobr>41 258</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">19 sierpnia, 21:00 (<nobr>43 731</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Danilo Pereira 50 - Romeo Vermant 3, Jorne Spileers 7, Brandon Mechele 20</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Sturm Graz  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Bod&#248;/Glimt  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 21:00 (9050)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Seedy Jatta 30, Tim Oermann 73 - Mathias J&#248;rgensen 15</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Klagenfurt</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kajrat Ałmaty  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Celtic FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 18:45 (<nobr>22 800</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 3-2</b></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC K&#248;benhavn  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  FC Basel 1893  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 21:00 (<nobr>34 854</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andreas Cornelius 46, Youssoufa Moukoko 84 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Qaraba&#287; A&#287;dam  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Ferencvárosi TC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 18:45 (<nobr>29 744</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leândro Andrade 25, Abdellah Zoubir 45 - Lenny Joseph 12, Barnabás Varga 55 (k), Alex Tóth 82</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Páfos FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  FK Crvena zvezda (Belgrad)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 21:00 (8422)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jajá 89 - Mirko Ivanić 60</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  SL e Benfica  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  Fenerbahçe SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 21:00 (<nobr>64 323</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kerem Aktürko&#287;lu 35</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Brugge KV  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-0</b></td>
+<td nowrap valign="top" width="165"><b>  Rangers FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 21:00 (<nobr>26 252</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nicol&#242; Tresoldi 5, Hans Vanaken 32, Joaquin Seys 41, 45, Aleksandar Stanković 45, Chrístos Tzólis 50</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Faza ligowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa LM</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 16-18 września</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 28 sierpnia 2025, 18:00 - Monako)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109265" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 18:45 (<nobr>51 059</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gabriel Martinelli 72, Leandro Trossard 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109266" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 18:45 (<nobr>35 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ruben van Bommel 90 - Promise David 9 (k), Anouar Ait El Hadj 39, Kevin Mac Allister 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109267" class="main"><b>4-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 21:00 (<nobr>41 497</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kenan Y&#305;ld&#305;z 63, Dušan Vlahović 67, 90, Lloyd Kelly 90 - Karim Adeyemi 52, Felix Nmecha 65, Yan Couto 74, Ramy Bensebaini 86 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109268" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 21:00 (<nobr>74 610</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 29 (k), 81 (k) - Timothy Weah 22</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109269" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 21:00 (<nobr>53 257</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Enzo Barrenechea 6, Vangélis Pavlídis 16 - Leândro Andrade 30, Camilo Durán 48, Ołeksij Kaszczuk 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109270" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">16 września, 21:00 (<nobr>54 755</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luiz Júnior 4 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109271" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 18:45 (<nobr>32 050</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109272" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 18:45 (<nobr>18 922</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Youssoupha Mbodji 23, 74 - Daniel Bassi 78, Sondre Brunstad Fet 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109273" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 21:00 (<nobr>52 288</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marcus Thuram 42, 47</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109274" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Trevoh Chalobah 20 (s), Harry Kane 27 (k), 63 - Cole Palmer 29</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109275" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 21:00 (<nobr>59 507</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andrew Robertson 4, Mohamed Salah 6, Virgil van Dijk 90 - Marcos Llorente 45, 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109276" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 września, 21:00 (<nobr>47 151</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marquinhos 3, Chwicza Kwaracchelia 39, Nuno Mendes 51, Gonçalo Ramos 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109277" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 18:45 (<nobr>25 007</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nicol&#242; Tresoldi 32, Raphael Onyedika 39, Hans Vanaken 42, Mamadou Diakhon 75 - Ansu Fati 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109278" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 18:45 (<nobr>34 504</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jordan Larsson 9, Robert 87 - Álex Grimaldo 82, Pantelís Chatzidiákos 90 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109279" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 21:00 (<nobr>58 700</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dávinson Sánchez 37 (s), Can Uzun 45, Jonathan Burkardt 45, 66, Ansgar Knauff 75 - Yunus Akgün 8</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109280" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 21:00 (<nobr>49 531</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 56, Jérémy Doku 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109281" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 21:00 (<nobr>52 084</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anthony Gordon 90 - Marcus Rashford 58, 67</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109282" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 września, 21:00 (<nobr>38 670</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Francisco Trinc&#227;o 44, 65, Alisson Santos 67, Geovany Quenda 68 - Edmílson Santos 86</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 30 września-1 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109283" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 18:45 (<nobr>21 950</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lazar Samardžić 74 (k), Mario Pašalić 87 - Chrístos Tzólis 38</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109284" class="main"><b>0-5</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 18:45 (<nobr>22 788</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 25 (k), 52, 73, Eduardo Camavinga 83, Brahim Díaz 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109285" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (<nobr>59 401</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Giacomo Raspadori 4, Robin Le Normand 33, Antoine Griezmann 45, Giuliano Simeone 70, Julián Álvarez 82 (k) - Jonathan Burkardt 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109286" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (<nobr>38 636</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Richard Ríos 18 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109287" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (<nobr>62 317</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lautaro Martínez 30, 65, Denzel Dumfries 34</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109288" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (7988)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jens Petter Hauge 53, 66 - Micky van de Ven 68, Jostein Gundersen 89 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109289" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (<nobr>50 651</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Osimhen 16 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109290" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (<nobr>65 771</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Igor Paix&#227;o 6, 12, Mason Greenwood 26, Pierre-Emerick Aubameyang 52</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109291" class="main"><b>1-5</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 września, 21:00 (9187)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mislav Oršić 45 - Harry Kane 15, 34, Raphaël Guerreiro 20, Nicolas Jackson 31, Michael Olise 68</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109292" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 18:45 (<nobr>30 250</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Abdellah Zoubir 28, Emmanuel Addai 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109293" class="main"><b>0-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 18:45 (<nobr>16 038</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nick Woltemade 17, Anthony Gordon 43 (k), 64 (k), Harvey Barnes 80</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Anderlecht</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109294" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>56 820</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gabriel Martinelli 12, Bukayo Saka 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109295" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>11 275</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jordan Teze 18, Eric Dier 90 (k) - Erling H&#229;land 15, 44</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109296" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>30 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Christian Kofane 65 - Ismael Saibari 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109297" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Daniel Svensson 28, Carney Chukwuemeka 50, Serhou Guirassy 82, Julian Brandt 90 - Gorka Guruzeta 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109298" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>50 207</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ferran Torres 19 - Senny Mayulu 38, Gonçalo Ramos 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109299" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>47 364</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rasmus H&#248;jlund 36, 79 - Luis Suárez 62 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109300" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 października, 21:00 (<nobr>20 087</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Georges Mikautadze 18, Renato Veiga 90 - Federico Gatti 49, Francisco Conceiç&#227;o 56</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 21-22 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109301" class="main"><b>6-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 18:45 (<nobr>46 264</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Fermín López 7, 39, 76, Lamine Yamal Nasraoui 68 (k), Marcus Rashford 74, 79 - Ayoub El Kaabi 54 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109302" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 18:45 (<nobr>16 478</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109303" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>59 200</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gabriel Magalh&#227;es 57, Gabriel Martinelli 64, Viktor Gyökeres 67, 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109304" class="main"><b>2-7</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>30 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleix García 38 (k), 54 - Willian Pacho 7, Désiré Doué 41, 45, Chwicza Kwaracchelia 44, Nuno Mendes 50, Ousmane Dembélé 66, Vitinha 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109305" class="main"><b>2-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>35 058</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Waldemar Anton 33 (s), Viktor Da&#240;ason 90 - Felix Nmecha 20, 76, Ramy Bensebaini 61 (k), Fábio Silva 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109306" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>52 073</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anthony Gordon 32, Harvey Barnes 70, 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109307" class="main"><b>6-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>34 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alessandro Buongiorno 35 (s), Ismael Saibari 38, Dennis Man 54, 80, Ricardo Pepi 87, Couhaib Driouech 89 - Scott McTominay 31, 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109308" class="main"><b>0-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>16 632</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Denzel Dumfries 41, Lautaro Martínez 45, Hakan Çalhano&#287;lu 53 (k), Francesco Pio Esposito 76</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Anderlecht</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109309" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 października, 21:00 (<nobr>20 539</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 17, Bernardo Silva 40</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109310" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 18:45 (<nobr>50 741</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gorka Guruzeta 40, 88, Roberto Navarro 70 - Leândro Andrade 1</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109311" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 18:45 (<nobr>45 275</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Osimhen 3, 33, Yunus Akgün 60 - Andreas Helmersen 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109312" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>11 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109313" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>22 152</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109314" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>38 947</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marc Guiu 18, Moisés Caicedo 27, Enzo Fernández 45 (k), Est&#234;v&#227;o 45 (k), Tyrique George 48 - Wout Weghorst 33 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109315" class="main"><b>1-5</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>58 700</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rasmus Nissen 26 - Hugo Ekitiké 35, Virgil van Dijk 39, Ibrahima Konaté 44, Cody Gakpo 66, Dominik Szoboszlai 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109316" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lennart Karl 5, Harry Kane 14, Luis Díaz 34, Nicolas Jackson 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109317" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>76 521</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jude Bellingham 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109318" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 października, 21:00 (<nobr>46 766</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Geny Catamo 69, Alisson Santos 86 - Igor Paix&#227;o 14</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 4-5 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109319" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 18:45 (<nobr>19 222</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 32 (k), Mikel Merino 46, 68</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109320" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 18:45 (<nobr>45 840</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109321" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>59 347</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julián Álvarez 39, Conor Gallagher 72, Marcos Llorente 90 - Ross Sykes 80</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109322" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (7842)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Folarin Balogun 43</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109323" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>40 729</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dušan Vlahović 34 - Maxi Araújo 12</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109324" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>59 916</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexis Mac Allister 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109325" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>32 570</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gelson Martins 17 - Ricardo Pepi 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109326" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>45 747</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jo&#227;o Neves 74 - Luis Díaz 4, 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109327" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 listopada, 21:00 (<nobr>49 565</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Brennan Johnson 19, Wilson Odobert 51, Micky van de Ven 64, Jo&#227;o Palhinha 67</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109328" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 18:45 (6314)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Derrick Luckassen 46</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109329" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 18:45 (<nobr>30 887</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Leândro Andrade 29, Marko Janković 39 (k) - Est&#234;v&#227;o 16, Alejandro Garnacho 53</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109330" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>51 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Victor Osimhen 59, 66 (k), 78 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109331" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>27 037</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Nicol&#242; Tresoldi 6, Carlos Forbs 17, 63 - Ferran Torres 8, Lamine Yamal Nasraoui 61, Chrístos Tzólis 77 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109332" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>69 983</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lautaro Martínez 45, Carlos Augusto 67 - Ofri Arad 55</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109333" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>50 513</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Phil Foden 22, 57, Erling H&#229;land 29, Rayan Cherki 90 - Waldemar Anton 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109334" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>51 923</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dan Burn 11, Joelinton 49</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109335" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>64 319</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Lazar Samardžić 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109336" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 listopada, 21:00 (<nobr>55 796</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Patrik Schick 65</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 25-26 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109337" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 18:45 (<nobr>51 154</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Samuel Dahl 6, Leandro Barreiro 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109338" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 18:45 (<nobr>45 444</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Promise David 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109339" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Serhou Guirassy 45, 54, Karim Adeyemi 58, Daniel Svensson 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109340" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>39 323</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jules Koundé 27 (s), Est&#234;v&#227;o 55, Liam Delap 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109341" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (7824)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ole Didrik Blomberg 27, Sondre Brunstad Fet 87 (k) - Lo&#239;s Openda 48, Weston McKennie 59, Jonathan David 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109342" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>50 592</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Álex Grimaldo 23, Patrik Schick 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109343" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>64 521</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Pierre-Emerick Aubameyang 46, 50 - Harvey Barnes 6</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109344" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>19 169</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109345" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 21:00 (<nobr>32 019</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Scott McTominay 65, Marko Janković 72 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109346" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 18:45 (<nobr>30 231</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Viktor Da&#240;ason 26, Jordan Larsson 59 (k), Robert 73 - Dastan Satpajew 81, Ołżas Bajbiek 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109347" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 18:45 (8347)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Luiz 18, Ivan Šunjić 88 - Takumi Minamino 5, Folarin Balogun 26</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109348" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>58 780</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jurriën Timber 22, Noni Madueke 69, Gabriel Martinelli 77 - Lennart Karl 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109349" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>68 069</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julián Álvarez 9, José María Giménez 90 - Piotr Zieliński 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109350" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>59 500</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ademola Lookman 60, Éderson 62, Charles De Ketelaere 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109351" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>59 964</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dominik Szoboszlai 16 - Ivan Perišić 6 (k), Guus Til 56, Couhaib Driouech 73, 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109352" class="main"><b>3-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>32 325</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chiquinho 8, Mehdi Taremi 52, Ayoub El Kaabi 81 - Kylian Mbappé 22, 24, 29, 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109353" class="main"><b>5-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>47 574</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vitinha 45, 53, 76 (k), Fabián Ruiz 59, Willian Pacho 65 - Richarlison 35, Randal Kolo Muani 50, 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109354" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 listopada, 21:00 (<nobr>41 634</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Geovany Quenda 24, Luis Suárez 31, Francisco Trinc&#227;o 70</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 9-10 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109355" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 16:30 (<nobr>19 463</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gelson Martins 73</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109356" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 18:45 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Serge Gnabry 65, Lennart Karl 69, Jonathan Tah 77 - Joshua Kimmich 54 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109357" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (9887)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Folarin Balogun 68</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109358" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>20 685</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gianluca Scamacca 55, Charles De Ketelaere 83 - Jo&#227;o Pedro 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109359" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>38 439</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jules Koundé 50, 53 - Ansgar Knauff 21</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109360" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>73 892</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dominik Szoboszlai 88 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109361" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>34 800</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Guus Til 10, Ricardo Pepi 85 - Julián Álvarez 37, Dávid Hancko 52, Alexander S&#248;rloth 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109362" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>16 214</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anan Khalaili 5, 71 - Igor Paix&#227;o 15, Mason Greenwood 41, 58</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Anderlecht</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109363" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">9 grudnia, 21:00 (<nobr>47 281</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">David Zima 26 (s), Mohammed Kudus 50 (k), Xavi Simons 79 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109364" class="main"><b>2-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 18:45 (<nobr>31 090</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Camilo Durán 10, Matheus Silva 47 - Kasper Dolberg 39, Oscar Gloukh 79, 90, Anton Gaaei 83</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109365" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 18:45 (<nobr>17 023</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Santi Comesa&#241;a 47, Tani Oluwaseyi 56 - Mohamed Elyounoussi 2, Elias Achouri 48, Andreas Cornelius 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109366" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>51 772</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109367" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>30 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bruno Guimar&#227;es 13 (s), Álex Grimaldo 88 - Anthony Gordon 51 (k), Lewis Miley 74</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109368" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julian Brandt 18, 51 - Haitam Aleesami 42, Jens Petter Hauge 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109369" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>26 464</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Noni Madueke 25, 47, Gabriel Martinelli 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109370" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>40 336</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Weston McKennie 67, Jonathan David 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109371" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>76 977</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Rodrygo 28 - Nico O'Reilly 35, Erling H&#229;land 43 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109372" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 grudnia, 21:00 (<nobr>54 353</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Richard Ríos 20, Leandro Barreiro 49</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 20-21 stycznia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109373" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 16:30 (<nobr>11 324</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Adilet Sadybiekow 90 - Aleksandar Stanković 32, Hans Vanaken 38, Romeo Vermant 74, Brandon Mechele 84</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Astana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109374" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 18:45 (8016)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kasper H&#248;gh 22, 24, Jens Petter Hauge 58 - Rayan Cherki 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109375" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>35 022</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Jordan Larsson 72 - Scott McTominay 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109376" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>72 649</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Petar Sučić 18 - Gabriel Jesus 10, 31, Viktor Gyökeres 84</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109377" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>32 400</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Costinha 2, Mehdi Taremi 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109378" class="main"><b>6-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>73 599</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 5, 26, Franco Mastantuono 51, Thilo Kehrer 55 (s), Vinícius Júnior 63, Jude Bellingham 80 - Jordan Teze 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109379" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>51 428</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Luis Suárez 74, 90 - Chwicza Kwaracchelia 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109380" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>52 713</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Cristián Romero 14, Dom Solanke 37</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109381" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">20 stycznia, 21:00 (<nobr>14 023</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Tani Oluwaseyi 49 - Oscar Gloukh 61, Oliver Edvardsen 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109382" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 18:45 (<nobr>48 443</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marcos Llorente 20 (s) - Giuliano Simeone 4</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109383" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 18:45 (<nobr>27 820</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Camilo Durán 4, 80, B&#601;hlul Mustafazad&#601; 90 - Can Uzun 10, Far&#232;s Cha&#239;bi 78 (k)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109384" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>21 462</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gianluca Scamacca 16, Nikola Krstović 88 - Gorka Guruzeta 58, Nico Serrano 70, Robert Navarro 74</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109385" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>30 774</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Moisés Caicedo 78</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109386" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>66 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 52, 55 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109387" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>41 626</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Khéphren Thuram 55, Weston McKennie 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109388" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>52 076</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Yoane Wissa 8, Anthony Gordon 30, Harvey Barnes 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109389" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>65 631</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dominik Szoboszlai 45, Gerónimo Rulli 72 (s), Cody Gakpo 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109390" class="main"><b>2-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">21 stycznia, 21:00 (<nobr>19 242</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vasil Kušej 10, Robert Lewandowski 44 (s) - Fermín López 34, 42, Dani Olmo 63, Robert Lewandowski 71</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 28 stycznia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AFC Ajax  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109391" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>51 719</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kasper Dolberg 69 (k) - Gelson Martins 52, Santiago Hezze 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109392" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>50 200</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Viktor Gyökeres 3, Kai Havertz 15, Gabriel Martinelli 36 - Jorginho 7 (k), Ricardinho 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109393" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>10 287</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Athletic Club de Bilbao  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109394" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>52 065</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Oihan Sancet 3, Gorka Guruzeta 28 - Ousmane Diomandé 12, Francisco Trinc&#227;o 62, Alisson Santos 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109395" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>58 910</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexander S&#248;rloth 15 - Fredrik Sj&#248;vold 34, Kasper H&#248;gh 59</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109396" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Villarreal CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>30 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Malik Tillman 12, 35, Álex Grimaldo 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109397" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>81 365</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Federico Dimarco 81, Andy Diouf 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109398" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympique de Marseille  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>26 361</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mamadou Diakhon 4, Romeo Vermant 11, Aleksandar Stanković 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Eintracht Frankfurt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109399" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>58 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Randal Kolo Muani 47, Dom Solanke 77</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109400" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC K&#248;benhavn  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>44 609</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Robert Lewandowski 48, Lamine Yamal Nasraoui 60, Raphinha 69 (k), Marcus Rashford 85 - Viktor Da&#240;ason 4</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109401" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>60 043</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexis Mac Allister 15, 61, Florian Wirtz 21, Mohamed Salah 50, Hugo Ekitiké 57, Federico Chiesa 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109402" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>35 259</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 11, Rayan Cherki 29</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Páfos FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109403" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SK Slavia Praga  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (5109)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vlad Dragomir 17, Bruno Felipe 53, Ânderson Silva 84, Mislav Oršić 87 - Štěpán Chaloupek 44</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kolóssi</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109404" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>47 637</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vitinha 8 - Joe Willock 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  PSV Eindhoven  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109405" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>35 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ismael Saibari 78 - Jamal Musiala 58, Harry Kane 84</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Royale Union Saint-Gilloise  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109406" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>15 010</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Anan Khalaili 70</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Anderlecht</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109407" class="main"><b>4-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>64 305</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Andreas Schjelderup 36, 54, Vangélis Pavlídis 45 (k), Anatolij Trubin 90 - Kylian Mbappé 30, 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SSC Napoli  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2109408" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 stycznia, 21:00 (<nobr>46 513</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Antonio Vergara 33, Rasmus H&#248;jlund 43 - Enzo Fernández 19 (k), Jo&#227;o Pedro 61, 82</td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa LM</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA24 -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2019&id_sezon=107" class="main">Arsenal FC</a></td>
+<td>8</td>
+<td><b>24</b></td>
+<td>8</td>
+<td>0</td>
+<td>0</td>
+<td>23-4</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>12-3</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>11-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2027&id_sezon=107" class="main">FC Bayern München</a></td>
+<td>8</td>
+<td><b>21</b></td>
+<td>7</td>
+<td>0</td>
+<td>1</td>
+<td>22-8</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>12-2</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>10-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2017&id_sezon=107" class="main">Liverpool FC</a></td>
+<td>8</td>
+<td><b>18</b></td>
+<td>6</td>
+<td>0</td>
+<td>2</td>
+<td>20-8</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>11-6</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>9-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2304&id_sezon=107" class="main">Tottenham Hotspur FC</a></td>
+<td>8</td>
+<td><b>17</b></td>
+<td>5</td>
+<td>2</td>
+<td>1</td>
+<td>17-7</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>10-0</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>7-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2005&id_sezon=107" class="main">FC Barcelona</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>22-14</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>13-5</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>9-9</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>6.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2091&id_sezon=107" class="main">Chelsea FC</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>17-10</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>10-1</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>7-9</td>
+<td>1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>3-0</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>7.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=697&id_sezon=107" class="main">Sporting Clube de Portugal (Lizbona)</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>17-11</td>
+<td>4</td>
+<td>0</td>
+<td>0</td>
+<td>11-3</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>6-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>8.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4945&id_sezon=107" class="main">Manchester City FC</a></td>
+<td>8</td>
+<td><b>16</b></td>
+<td>5</td>
+<td>1</td>
+<td>2</td>
+<td>15-9</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>8-3</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>7-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>9.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2015&id_sezon=107" class="main">Real Madrid CF</a></td>
+<td>8</td>
+<td><b>15</b></td>
+<td>5</td>
+<td>0</td>
+<td>3</td>
+<td>21-12</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>10-4</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>11-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>10.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2044&id_sezon=107" class="main">FC Internazionale Milano</a></td>
+<td>8</td>
+<td><b>15</b></td>
+<td>5</td>
+<td>0</td>
+<td>3</td>
+<td>15-7</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>6-5</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>9-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>11.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2077&id_sezon=107" class="main">Paris Saint-Germain FC</a></td>
+<td>8</td>
+<td><b>14</b></td>
+<td>4</td>
+<td>2</td>
+<td>2</td>
+<td>21-11</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>11-6</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>10-5</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>12.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2155&id_sezon=107" class="main">Newcastle United FC</a></td>
+<td>8</td>
+<td><b>14</b></td>
+<td>4</td>
+<td>2</td>
+<td>2</td>
+<td>17-7</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>9-2</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>8-5</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>13.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2021&id_sezon=107" class="main">Juventus FC</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>3</td>
+<td>4</td>
+<td>1</td>
+<td>14-10</td>
+<td>2</td>
+<td>2</td>
+<td>0</td>
+<td>9-5</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>5-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>14.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=474&id_sezon=107" class="main">Club Atlético de Madrid</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>3</td>
+<td>17-15</td>
+<td>3</td>
+<td>0</td>
+<td>1</td>
+<td>11-5</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>6-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>15.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=5758&id_sezon=107" class="main">Atalanta BC</a></td>
+<td>8</td>
+<td><b>13</b></td>
+<td>4</td>
+<td>1</td>
+<td>3</td>
+<td>10-10</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>6-5</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>4-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>16.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2004&id_sezon=107" class="main">TSV Bayer 04 Leverkusen</a></td>
+<td>8</td>
+<td><b>12</b></td>
+<td>3</td>
+<td>3</td>
+<td>2</td>
+<td>13-14</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>8-10</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>5-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>17.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2006&id_sezon=107" class="main">BV Borussia 1909 (Dortmund)</a></td>
+<td>8</td>
+<td><b>11</b></td>
+<td>3</td>
+<td>2</td>
+<td>3</td>
+<td>19-17</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>10-5</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>9-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>18.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2023&id_sezon=107" class="main">Olympiakós SFP (Pireus)</a></td>
+<td>8</td>
+<td><b>11</b></td>
+<td>3</td>
+<td>2</td>
+<td>3</td>
+<td>10-14</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>6-5</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>4-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>19.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=505&id_sezon=107" class="main">Club Brugge KV</a></td>
+<td>8</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>4</td>
+<td>15-17</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>10-7</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>5-10</td>
+<td>1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>20.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=552&id_sezon=107" class="main">Galatasaray SK</a></td>
+<td>8</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>4</td>
+<td>9-11</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>5-3</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>4-8</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>21.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2238&id_sezon=107" class="main">AS Monaco FC</a></td>
+<td>8</td>
+<td><b>10</b></td>
+<td>2</td>
+<td>4</td>
+<td>2</td>
+<td>8-14</td>
+<td>1</td>
+<td>3</td>
+<td>0</td>
+<td>3-2</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>5-12</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>22.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2336&id_sezon=107" class="main">Qaraba&#287; A&#287;dam</a></td>
+<td>8</td>
+<td><b>10</b></td>
+<td>3</td>
+<td>1</td>
+<td>4</td>
+<td>13-21</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>9-8</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>4-13</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>23.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2313&id_sezon=107" class="main">FK Bod&#248;/Glimt</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>2</td>
+<td>3</td>
+<td>3</td>
+<td>14-15</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>7-7</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>7-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>24.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2279&id_sezon=107" class="main">SL e Benfica</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>5</td>
+<td>10-12</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>8-6</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>2-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>25.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2297&id_sezon=107" class="main">Olympique de Marseille</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>5</td>
+<td>11-14</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>6-5</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>5-9</td>
+<td>1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>3-2</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>26.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=20632&id_sezon=107" class="main">Páfos FC</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>2</td>
+<td>3</td>
+<td>3</td>
+<td>8-11</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>8-8</td>
+<td>0</td>
+<td>2</td>
+<td>2</td>
+<td>0-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>27.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=6293&id_sezon=107" class="main">Royale Union Saint-Gilloise</a></td>
+<td>8</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>5</td>
+<td>8-17</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>3-11</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>5-6</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>28.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=664&id_sezon=107" class="main">PSV Eindhoven</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>16-16</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>10-10</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>6-6</td>
+<td>1</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>6-2</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>29.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2328&id_sezon=107" class="main">Athletic Club de Bilbao</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>9-14</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>5-6</td>
+<td>1</td>
+<td>1</td>
+<td>2</td>
+<td>4-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>30.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4940&id_sezon=107" class="main">SSC Napoli</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>9-15</td>
+<td>2</td>
+<td>1</td>
+<td>1</td>
+<td>6-4</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>3-11</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>3-7</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>31.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=1996&id_sezon=107" class="main">FC K&#248;benhavn</a></td>
+<td>8</td>
+<td><b>8</b></td>
+<td>2</td>
+<td>2</td>
+<td>4</td>
+<td>12-21</td>
+<td>1</td>
+<td>2</td>
+<td>1</td>
+<td>8-9</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>4-12</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>32.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=455&id_sezon=107" class="main">AFC Ajax</a></td>
+<td>8</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>6</td>
+<td>8-21</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>1-9</td>
+<td>2</td>
+<td>0</td>
+<td>2</td>
+<td>7-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>33.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=522&id_sezon=107" class="main">Eintracht Frankfurt</a></td>
+<td>8</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>6</td>
+<td>10-21</td>
+<td>1</td>
+<td>0</td>
+<td>3</td>
+<td>6-11</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>4-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>34.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2010&id_sezon=107" class="main">SK Slavia Praga</a></td>
+<td>8</td>
+<td><b>3</b></td>
+<td>0</td>
+<td>3</td>
+<td>5</td>
+<td>5-19</td>
+<td>0</td>
+<td>2</td>
+<td>2</td>
+<td>4-9</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>1-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>35.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2498&id_sezon=107" class="main">Villarreal CF</a></td>
+<td>8</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>7</td>
+<td>5-18</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>5-9</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>0-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>36.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=2625&id_sezon=107" class="main">Kajrat Ałmaty</a></td>
+<td>8</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>7</td>
+<td>7-22</td>
+<td>0</td>
+<td>1</td>
+<td>3</td>
+<td>1-10</td>
+<td>0</td>
+<td>0</td>
+<td>4</td>
+<td>6-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/16 finału - 17-18 lutego, 24-25 lutego</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 30 stycznia 2026, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112090" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 lutego, 21:00 (<nobr>66 387</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Vinícius Júnior 50</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112092" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lutego, 21:00 (7845)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sondre Brunstad Fet 20, Jens Petter Hauge 61, Kasper H&#248;gh 64 - Francesco Pio Esposito 30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112094" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 lutego, 21:00 (<nobr>10 287</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Folarin Balogun 1, 18 - Désiré Doué 29, 67, Achraf Hakimi 41</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112096" class="main"><b>1-6</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lutego, 18:45 (<nobr>28 861</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Elvin C&#601;f&#601;rquliyev 54 - Anthony Gordon 3, 32 (k), 33, 45 (k), Malick Thiaw 8, Jacob Murphy 72</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112098" class="main"><b>5-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 lutego, 18:45 (<nobr>49 977</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gabriel Sara 15, Noa Lang 49, 75, Dávinson Sánchez 60, Sacha Boey 86 - Teun Koopmeiners 16, 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112100" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lutego, 21:00 (<nobr>25 235</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Raphael Onyedika 52, Nicol&#242; Tresoldi 60, Chrístos Tzólis 89 - Julián Álvarez 8 (k), Ademola Lookman 45, Joel Ordó&#241;ez 79 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112102" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 lutego, 21:15 (<nobr>76 900</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Serhou Guirassy 3, Maximilian Beier 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>mecz pierwotnie zaplanowany na 21:00 rozpoczął się z 15-minutowym opóźnieniem z powodu spóźnienia gości</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112104" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 lutego, 21:00 (<nobr>32 300</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Patrik Schick 60, 63</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112091" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lutego, 21:00 (<nobr>76 745</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aurélien Tchouaméni 16, Vinícius Júnior 80 - Rafa Silva 14</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Internazionale Milano  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112093" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Bod&#248;/Glimt  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 lutego, 21:00 (<nobr>70 441</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alessandro Bastoni 76 - Jens Petter Hauge 58, H&#229;kon Evjen 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112095" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  AS Monaco FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lutego, 21:00 (<nobr>47 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marquinhos 60, Chwicza Kwaracchelia 66 - Maghnes Akliouche 45, Jordan Teze 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Newcastle United FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112097" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Qaraba&#287; A&#287;dam  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 lutego, 21:00 (<nobr>50 068</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sandro Tonali 4, Joelinton 6, Sven Botman 52 - Camilo Durán 51, Elvin C&#601;f&#601;rquliyev 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Juventus FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112099" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Galatasaray SK  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lutego, 21:00 (<nobr>41 421</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=2112099" class="main"><b>pd. </b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Manuel Locatelli 37 (k), Federico Gatti 70, Weston McKennie 82 - Victor Osimhen 105, Bar&#305;ş Alper Y&#305;lmaz 119</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Atlético de Madrid  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112101" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Brugge KV  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 lutego, 18:45 (<nobr>66 756</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Alexander S&#248;rloth 23, 76, 87, Johnny Cardoso 48 - Joel Ordó&#241;ez 36</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Atalanta BC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112103" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  BV Borussia 1909 (Dortmund)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 lutego, 18:45 (<nobr>21 234</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gianluca Scamacca 5, Davide Zappacosta 45, Mario Pašalić 57, Lazar Samardžić 90 (k) - Karim Adeyemi 75</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>w 90. minucie czerwonymi kartkami zostali ukarani rezerwowy zawodnik gospodarzy - Giorgio Scalvini oraz rezerwowy zawodnik gości - Nico Schlotterbeck</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  TSV Bayer 04 Leverkusen  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112105" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Olympiakós SFP (Pireus)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 lutego, 21:00 (<nobr>30 210</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/8 finału - 10-11 marca, 17-18 marca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 27 lutego 2026, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112106" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 marca, 18:45 (<nobr>30 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Robert Andrich 46 - Kai Havertz 89 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112108" class="main"><b>1-6</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 marca, 21:00 (<nobr>22 557</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mario Pašalić 90 - Josip Stanišić 12, Michael Olise 22, 64, Serge Gnabry 25, Nicolas Jackson 52, Jamal Musiala 67</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112110" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 marca, 18:45 (<nobr>51 373</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Mario Lemina 7</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112112" class="main"><b>5-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 marca, 21:00 (<nobr>64 168</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Marcos Llorente 6, Antoine Griezmann 14, Julián Álvarez 15, 55, Robin Le Normand 22 - Pedro Porro 26, Dom Solanke 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112114" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 marca, 21:00 (<nobr>52 103</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harvey Barnes 86 - Lamine Yamal Nasraoui 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112116" class="main"><b>5-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 marca, 21:00 (<nobr>47 566</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bradley Barcola 10, Ousmane Dembélé 40, Vitinha 74, Chwicza Kwaracchelia 86, 90 - Malo Gusto 28, Enzo Fernández 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112118" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 marca, 21:00 (7971)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Sondre Brunstad Fet 32 (k), Ole Didrik Blomberg 45, Kasper H&#248;gh 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112120" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">11 marca, 21:00 (<nobr>76 066</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Federico Valverde 20, 27, 42</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Arsenal FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112107" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  TSV Bayer 04 Leverkusen  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 marca, 21:00 (<nobr>57 537</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Eberechi Eze 36, Declan Rice 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Bayern München  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112109" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Atalanta BC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 marca, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 25 (k), 54, Lennart Karl 56, Luis Díaz 70 - Lazar Samardžić 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Liverpool FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112111" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Galatasaray SK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 marca, 21:00 (<nobr>56 714</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Dominik Szoboszlai 25, Hugo Ekitiké 51, Ryan Gravenberch 53, Mohamed Salah 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tottenham Hotspur FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112113" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Atlético de Madrid  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 marca, 21:00 (<nobr>49 568</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Randal Kolo Muani 30, Xavi Simons 52, 90 (k) - Julián Álvarez 47, Dávid Hancko 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Barcelona  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112115" class="main"><b>7-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Newcastle United FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">18 marca, 18:45 (<nobr>56 662</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Raphinha 6, 72, Marc Bernal 18, Lamine Yamal Nasraoui 45 (k), Fermín López 51, Robert Lewandowski 56, 61 - Anthony Elanga 15, 28</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Chelsea FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112117" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 marca, 21:00 (<nobr>35 811</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chwicza Kwaracchelia 6, Bradley Barcola 15, Senny Mayulu 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sporting Clube de Portugal (Lizbona)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112119" class="main"><b>5-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FK Bod&#248;/Glimt  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 marca, 18:45 (<nobr>49 155</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=2112119" class="main"><b>pd. </b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Gonçalo Inácio 34, Pedro Gonçalves 61, Luis Suárez 78 (k), Maxi Araújo 92, Rafael Nel 120</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Manchester City FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112121" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Real Madrid CF  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">17 marca, 21:00 (<nobr>51 103</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Erling H&#229;land 41 - Vinícius Júnior 22 (k), 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/4 finału - 7-8 kwietnia, 14-15 kwietnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 27 lutego 2026, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112573" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 kwietnia, 21:00 (<nobr>47 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Désiré Doué 11, Chwicza Kwaracchelia 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112575" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 kwietnia, 21:00 (<nobr>77 106</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kylian Mbappé 74 - Luis Díaz 41, Harry Kane 46</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112577" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 kwietnia, 21:00 (<nobr>59 522</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julián Álvarez 45, Alexander S&#248;rloth 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112579" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">7 kwietnia, 21:00 (<nobr>50 804</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Kai Havertz 90</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Liverpool FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112574" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 kwietnia, 21:00 (<nobr>59 627</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ousmane Dembélé 72, 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  FC Bayern München  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112576" class="main"><b>4-3</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Real Madrid CF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 kwietnia, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Aleksandar Pavlović 6, Harry Kane 38, Luis Díaz 89, Michael Olise 90 - Arda Güler 1, 29, Kylian Mbappé 42</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>po meczu czerwoną kartką został ukarany zawodnik gości - Arda Güler</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Club Atlético de Madrid  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112578" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Barcelona  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">14 kwietnia, 21:00 (<nobr>69 268</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ademola Lookman 31 - Lamine Yamal Nasraoui 4, Ferran Torres 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Arsenal FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112580" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">15 kwietnia, 21:00 (<nobr>58 249</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału - 28-29 kwietnia, 5-6 maja</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 27 lutego 2026, 12:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Paris Saint-Germain FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112826" class="main"><b>5-4</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 kwietnia, 21:00 (<nobr>47 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Chwicza Kwaracchelia 24, 56, Jo&#227;o Neves 33, Ousmane Dembélé 45 (k), 58 - Harry Kane 17 (k), Michael Olise 41, Dayot Upamecano 65, Luis Díaz 68</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112828" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 kwietnia, 21:00 (<nobr>68 421</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Julián Álvarez 56 (k) - Viktor Gyökeres 44 (k)</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bayern München  </b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112827" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 maja, 21:00 (<nobr>75 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Harry Kane 90 - Ousmane Dembélé 3</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Arsenal FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2112829" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Club Atlético de Madrid  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 maja, 21:00 (<nobr>58 874</nobr>)</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Bukayo Saka 45</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>żółtą kartką ukarany został także rezerwowy zawodnik gospodarzy - Kepa Arrizabalaga</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał - 30 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Paris Saint-Germain FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><a href="/mecz.php?id_mecz=2113144" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="165"><b>  Arsenal FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 maja, 18:00 (<nobr>61 035</nobr>)</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><a href="/mecz.php?id_mecz=2113144" class="main"><b>pd. k. 4-3</b></a>
+</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4">Ousmane Dembélé 65 (k) - Kai Havertz 6</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Budapeszt, Puskás Aréna</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+</table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Paweł Mogielnicki
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_14152.html
+++ b/internal/site/testdata/fixtures/league_14152.html
@@ -1,0 +1,4899 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Liga Mistrzów Futsalu 2025/2026</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=14072"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=14073"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez25-26.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14072" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14073" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=14074" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14072" class="menulnk" title="Sparingi - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14073" class="menulnk" title="Sparingi - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=14074" class="menulnk" title="Sparingi - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=107&runda=2&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14072&runda=2" class="menulnk" title="Przygotowania - Ekstraklasa - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14073&runda=2" class="menulnk" title="Przygotowania - I liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=14074&runda=2" class="menulnk" title="Przygotowania - II liga - zima 2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=107&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=107" class="menulnk" title="Baraże 2026" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14072.html" class="menulnk" title="Ekstraklasa 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14073.html" class="menulnk" title="I liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14074.html" class="menulnk" title="II liga 2025/2026 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=107" class="menulnk" title="III Liga 2025/2026 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14154.html" class="menulnk" title="III Liga 2025/2026 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14155.html" class="menulnk" title="III Liga 2025/2026 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14156.html" class="menulnk" title="III Liga 2025/2026 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14157.html" class="menulnk" title="III Liga 2025/2026 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2025/2026 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14384.html" class="menulnk" title="Centralna Liga Juniorów 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14385.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14386.html" class="menulnk" title="Centralna Liga Juniorów U-17 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14076.html" class="menulnk" title="Puchar Polski 2025/2026 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14075.html" class="menulnk" title="Superpuchar 2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=107" class="menulnk" title="Rozgrywki pucharowe w Polsce 2025/2026 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2025/2026 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14077.html" class="menulnk" title="Liga Mistrzów 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14078.html" class="menulnk" title="Liga Europy 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14079.html" class="menulnk" title="Liga Konferencji 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14634.html" class="menulnk" title="Liga Młodzieżowa 2025/2026 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=107" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=107" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=107" class="menulnk" title="Reprezentacja Polski 2025/2026 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14042.html" class="menulnk" title="Eliminacje mistrzostw świata - USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14645.html" class="menulnk" title="Mistrzostwa świata - Kanada/Meksyk/USA 2026 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2026</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga14658.html" class="menulnk" title="Liga Narodów 2026/2027 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 26/27</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=107" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=107" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=107" class="menulnk" title="Archiwum wyników z sezonu 2025/2026" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2025 / 2026</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/eurcups2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/1/liga14152.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=14152" class="main">Strzelcy</a> | <a href="/stats.php?id=14152" class="main">Statystyki</a> :.
+</p>
+<p>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Liga Mistrzów Futsalu 2025/2026</b>
+</td>
+</tr>
+</table>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<!-- <div align="center"><a target="_blank" href="https://bilety.laczynaspilka.pl/"><img src="/banery/ban-pzpn-2025-10-20-468x60.jpg" border="0" vspace="3"></a></div> --><div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<!-- cmp_UEFA_neutral -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>I faza grupowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FA Erewan  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-3</b></td>
+<td nowrap valign="top" width="165"><b>  SS Murata  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Encamp Dicoansa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Encamp Dicoansa  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  FA Erewan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b>  SS Murata  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/smr.jpg" title="San Marino" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SS Murata  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC Encamp Dicoansa  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/and.jpg" title="Andora" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  FA Erewan  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/arm.jpg" title="Armenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Kumanovo</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26570&id_sezon=107" class="main">FC Forca (Kumanovo)</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>10-0</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>6-0</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=21498&id_sezon=107" class="main">SS Murata</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>9-4</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>6-2</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24984&id_sezon=107" class="main">FA Erewan</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>4-10</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>3-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4451&id_sezon=107" class="main">FC Encamp Dicoansa</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-13</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>2-7</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>12-2</b></td>
+<td nowrap valign="top" width="165"><b>  Ísbjörninn (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KMF Bajo Pivljanin (Plužine)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-2</b></td>
+<td nowrap valign="top" width="165"><b>  Vllaznia Shkodër  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Vllaznia Shkodër  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Ísbjörninn (Kópavogur)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KMF Bajo Pivljanin (Plužine)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isl.jpg" title="Islandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Ísbjörninn (Kópavogur)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-10</b></td>
+<td nowrap valign="top" width="165"><b>  KMF Bajo Pivljanin (Plužine)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mne.jpg" title="Czarnogóra" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/alb.jpg" title="Albania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Vllaznia Shkodër  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-6</b></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Tirana</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26561&id_sezon=107" class="main">Tigers Roermond</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>23-4</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>12-2</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>11-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=15320&id_sezon=107" class="main">KMF Bajo Pivljanin (Plužine)</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>14-14</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>4-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>10-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27502&id_sezon=107" class="main">Vllaznia Shkodër</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>8-10</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>6-6</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24978&id_sezon=107" class="main">Ísbjörninn (Kópavogur)</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>9-26</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>7-10</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>2-16</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa C</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>25-6</b></td>
+<td nowrap valign="top" width="165"><b>  Vangölü SF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bunker Partner Tallin  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Bor&#229;s AIK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Bunker Partner Tallin  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bor&#229;s AIK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>30-6</b></td>
+<td nowrap valign="top" width="165"><b>  Vangölü SF  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/tur.jpg" title="Turcja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Vangölü SF  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-29</b></td>
+<td nowrap valign="top" width="165"><b>  FC Bunker Partner Tallin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/est.jpg" title="Estonia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/swe.jpg" title="Szwecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bor&#229;s AIK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-5</b></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Bor&#229;s</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa C</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27509&id_sezon=107" class="main">FK Siliko (Vrhnika)</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>35-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>25-6</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>10-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27504&id_sezon=107" class="main">Bor&#229;s AIK</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>33-13</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>31-11</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27507&id_sezon=107" class="main">FC Bunker Partner Tallin</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>31-14</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>2-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>29-7</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27506&id_sezon=107" class="main">Vangölü SF</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>19-84</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>7-29</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>12-55</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa D</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Natanja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 14:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEL (Limassol)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-11</b></td>
+<td nowrap valign="top" width="165"><b>  Clic Media Chi&#537;inău  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEL (Limassol)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-5</b></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 14:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Clic Media Chi&#537;inău  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Natanja  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/isr.jpg" title="Izrael" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Maccabi Natanja  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-4</b></td>
+<td nowrap valign="top" width="165"><b>  AEL (Limassol)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cyp.jpg" title="Cypr" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 14:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mda.jpg" title="Mołdawia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Clic Media Chi&#537;inău  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-6</b></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ciorescu</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa D</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26568&id_sezon=107" class="main">Hj&#248;rring FK</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>16-5</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>5-1</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>11-4</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26569&id_sezon=107" class="main">Clic Media Chi&#537;inău</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>15-8</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>4-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>11-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=25665&id_sezon=107" class="main">AEL (Limassol)</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>7-18</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-16</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26567&id_sezon=107" class="main">Maccabi Natanja</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-11</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-4</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>2-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa E</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  WitEn Orsza  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>10-1</b></td>
+<td nowrap valign="top" width="165"><b>  Europa FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 15:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-1</b></td>
+<td nowrap valign="top" width="165"><b>  Lewski Sofia-Zapad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b>  WitEn Orsza  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 15:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Lewski Sofia-Zapad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-2</b></td>
+<td nowrap valign="top" width="165"><b>  Europa FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gib.jpg" title="Gibraltar" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Europa FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-15</b></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 15:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bul.jpg" title="Bułgaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Lewski Sofia-Zapad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-14</b></td>
+<td nowrap valign="top" width="165"><b>  WitEn Orsza  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/blr.jpg" title="Białoruś" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Sofia</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa E</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22290&id_sezon=107" class="main">TSV Weilimdorf 1948</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>25-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>10-4</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>15-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=13047&id_sezon=107" class="main">WitEn Orsza</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>27-8</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>10-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>17-7</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=14232&id_sezon=107" class="main">Lewski Sofia-Zapad</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>10-23</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>9-16</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-7</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24117&id_sezon=107" class="main">Europa FC</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>3-30</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-15</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-15</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa F</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-1</b></td>
+<td nowrap valign="top" width="165"><b>  Sparta Belfast  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Perth Saltires  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-5</b></td>
+<td nowrap valign="top" width="165"><b>  FC Ljuti Krajišnici  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Perth Saltires  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-7</b></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Ljuti Krajišnici  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-2</b></td>
+<td nowrap valign="top" width="165"><b>  Sparta Belfast  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nir.jpg" title="Irlandia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sparta Belfast  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Perth Saltires  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sco.jpg" title="Szkocja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aut.jpg" title="Austria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Ljuti Krajišnici  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-12</b></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Linz</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa F</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=10119&id_sezon=107" class="main">Araz Naxç&#305;van</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>28-6</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>9-1</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>19-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27503&id_sezon=107" class="main">FC Ljuti Krajišnici</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>11-15</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>6-14</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>5-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22285&id_sezon=107" class="main">Sparta Belfast</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>8-13</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>5-1</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=14230&id_sezon=107" class="main">Perth Saltires</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-17</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-12</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-5</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa G</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Blue Magic Dublin  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-0</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Club Cardiff  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KSU Tbilisi  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 21:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KSU Tbilisi  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Blue Magic Dublin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>11-4</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Club Cardiff  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">28 sierpnia, 21:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/wal.jpg" title="Walia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Futsal Club Cardiff  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-7</b></td>
+<td nowrap valign="top" width="165"><b>  KSU Tbilisi  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/geo.jpg" title="Gruzja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-2</b></td>
+<td nowrap valign="top" width="165"><b>  Blue Magic Dublin  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/irl.jpg" title="Irlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 sierpnia, 21:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Cazin</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa G</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27501&id_sezon=107" class="main">MNK Bubamara (Cazin)</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>21-7</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>17-6</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24116&id_sezon=107" class="main">KSU Tbilisi</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>12-5</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-5</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>7-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=18933&id_sezon=107" class="main">Blue Magic Dublin</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>7-10</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-0</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-10</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24980&id_sezon=107" class="main">Futsal Club Cardiff</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-22</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-7</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>4-15</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa H</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Futsal Veszprém  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-0</b></td>
+<td nowrap valign="top" width="165"><b>  Bolton Futsal Club  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sjarmtrollan IL  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-8</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">26 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sjarmtrollan IL  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-5</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Veszprém  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-0</b></td>
+<td nowrap valign="top" width="165"><b>  Bolton Futsal Club  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">27 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 26-31 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/eng.jpg" title="Anglia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Bolton Futsal Club  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-4</b></td>
+<td nowrap valign="top" width="165"><b>  Sjarmtrollan IL  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/nor.jpg" title="Norwegia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 17:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-4</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Veszprém  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/hun.jpg" title="Węgry" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 sierpnia, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Ateny</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa H</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22283&id_sezon=107" class="main">AEK (Ateny)</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>23-5</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>15-4</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>8-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27508&id_sezon=107" class="main">Futsal Veszprém</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>16-8</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>7-0</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>9-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=20738&id_sezon=107" class="main">Sjarmtrollan IL</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>7-17</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>3-13</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27505&id_sezon=107" class="main">Bolton Futsal Club</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>4-20</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>0-16</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>II faza grupowa</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A1</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-0</b></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Kowno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RSC Anderlecht Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Piast Gliwice </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RSC Anderlecht Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Piast Gliwice </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Kowno  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">31 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ltu.jpg" title="Litwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Žalgiris Kowno  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  RSC Anderlecht Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 listopada, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Piast Gliwice </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-0</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">2 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gliwice</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A1</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26572&id_sezon=107" class="main">Futsal Cartagena</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>9-0</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>5-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>4-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=19852&id_sezon=107" class="main">Piast Gliwice</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>5-2</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>3-1</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>0-0</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24986&id_sezon=107" class="main">RSC Anderlecht Futsal</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>5-6</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>1-6</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24110&id_sezon=107" class="main">Žalgiris Kowno</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>1-12</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-4</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>1-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A2</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-5</b></td>
+<td nowrap valign="top" width="165"><b>  FK Era-Pack Chrudim  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-3</b></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-1</b></td>
+<td nowrap valign="top" width="165"><b>  FK Era-Pack Chrudim  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cze.jpg" title="Czechy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Era-Pack Chrudim  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-6</b></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-4</b></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 19:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Palma de Mallorca</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A2</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24988&id_sezon=107" class="main">Palma Futsal</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>12-6</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>10-5</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=25671&id_sezon=107" class="main">Étoile Lavalloise Mayenne FC</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>11-6</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-5</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>6-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26571&id_sezon=107" class="main">FK Semej</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>16-16</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>9-5</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>7-11</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=9601&id_sezon=107" class="main">FK Era-Pack Chrudim</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>7-18</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-6</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>6-12</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A3</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-0</b></td>
+<td nowrap valign="top" width="165"><b>  KMF Loznica-Grad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-1</b></td>
+<td nowrap valign="top" width="165"><b>  Luxol St. Andrews FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-6</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luxol St. Andrews FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-4</b></td>
+<td nowrap valign="top" width="165"><b>  KMF Loznica-Grad  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/srb.jpg" title="Serbia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  KMF Loznica-Grad  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-2</b></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 16:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luxol St. Andrews FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-6</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A3</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=7783&id_sezon=107" class="main">SL e Benfica</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>21-2</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>9-0</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>12-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=25666&id_sezon=107" class="main">Riga FC</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>7-7</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>2-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=18927&id_sezon=107" class="main">Luxol St. Andrews FC</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>6-14</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>5-10</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=24973&id_sezon=107" class="main">KMF Loznica-Grad</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>4-15</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-2</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>4-13</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>4-4</td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa A4</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>19-1</b></td>
+<td nowrap valign="top" width="165"><b>  FC Prishtina 01  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-2</b></td>
+<td nowrap valign="top" width="165"><b>  MNK Novo Vrijeme (Makarska)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-7</b></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Novo Vrijeme (Makarska)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-7</b></td>
+<td nowrap valign="top" width="165"><b>  FC Prishtina 01  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Prishtina 01  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/cro.jpg" title="Chorwacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Novo Vrijeme (Makarska)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Makarska</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa A4</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=4450&id_sezon=107" class="main">Sporting Clube de Portugal (Lizbona)</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>30-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>19-1</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>11-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=9599&id_sezon=107" class="main">Kajrat Ałmaty</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>9-10</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-9</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=25668&id_sezon=107" class="main">FC Prishtina 01</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>9-29</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-4</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>8-25</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=21507&id_sezon=107" class="main">MNK Novo Vrijeme (Makarska)</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>8-14</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>6-11</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-3</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B5</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Akaa Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-6</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-6</b></td>
+<td nowrap valign="top" width="165"><b>  Meta Catania Calcio a 5  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Akaa Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Meta Catania Calcio a 5  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-2</b></td>
+<td nowrap valign="top" width="165"><b>  TSV Weilimdorf 1948  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ger.jpg" title="Niemcy" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ita.jpg" title="Włochy" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Meta Catania Calcio a 5  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>9-3</b></td>
+<td nowrap valign="top" width="165"><b>  Akaa Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fin.jpg" title="Finlandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 20:30</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Katania</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B5</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26560&id_sezon=107" class="main">Meta Catania Calcio a 5</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>18-7</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>12-6</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>6-1</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b></b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22283&id_sezon=107" class="main">AEK (Ateny)</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>18-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>9-2</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>9-5</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>3-3</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=23636&id_sezon=107" class="main">Akaa Futsal</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>9-15</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-6</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>7-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=22290&id_sezon=107" class="main">TSV Weilimdorf 1948</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>3-19</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>1-10</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-9</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B6</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Futsal Minerva  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-5</b></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-4</b></td>
+<td nowrap valign="top" width="165"><b>  Mimel Lučenec  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-1</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Minerva  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mimel Lučenec  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-4</b></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-12</b></td>
+<td nowrap valign="top" width="165"><b>  MNK Bubamara (Cazin)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bih.jpg" title="Bośnia i Hercegowina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svk.jpg" title="Słowacja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Mimel Lučenec  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-4</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Minerva  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/sui.jpg" title="Szwajcaria" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lučenec</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B6</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26568&id_sezon=107" class="main">Hj&#248;rring FK</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>13-18</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>4-12</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>9-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27501&id_sezon=107" class="main">MNK Bubamara (Cazin)</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>13-9</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>1-5</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>12-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=15960&id_sezon=107" class="main">Futsal Minerva</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>9-9</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>4-5</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>5-4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>1-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=21506&id_sezon=107" class="main">Mimel Lučenec</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>9-8</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>5-8</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>4-0</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B7</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Differdange 03  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-8</b></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-1</b></td>
+<td nowrap valign="top" width="165"><b>  CS United Gala&#539;i  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC Differdange 03  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  CS United Gala&#539;i  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ned.jpg" title="Holandia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Tigers Roermond  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 15:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/rou.jpg" title="Rumunia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  CS United Gala&#539;i  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-5</b></td>
+<td nowrap valign="top" width="165"><b>  FC Differdange 03  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lux.jpg" title="Luksemburg" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gałacz</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B7</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=10119&id_sezon=107" class="main">Araz Naxç&#305;van</a></td>
+<td>3</td>
+<td><b>7</b></td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>7-5</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>4-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>3-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26561&id_sezon=107" class="main">Tigers Roermond</a></td>
+<td>3</td>
+<td><b>6</b></td>
+<td>2</td>
+<td>0</td>
+<td>1</td>
+<td>14-9</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>2-3</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>12-6</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=23643&id_sezon=107" class="main">CS United Gala&#539;i</a></td>
+<td>3</td>
+<td><b>3</b></td>
+<td>1</td>
+<td>0</td>
+<td>2</td>
+<td>8-11</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>7-9</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>1-2</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=18929&id_sezon=107" class="main">FC Differdange 03</a></td>
+<td>3</td>
+<td><b>1</b></td>
+<td>0</td>
+<td>1</td>
+<td>2</td>
+<td>12-16</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>5-8</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>7-8</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="4">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b><u>Grupa B8</u></b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 3 lipca 2025, 14:00 - Nyon)</td></tr>
+<tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Z grup A do następnej rundy awansują po trzy drużyny, z grup B po jednej</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ChIT Kijów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>10-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Awrora Kijów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">29 października, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Awrora Kijów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-5</b></td>
+<td nowrap valign="top" width="165"><b>  ChIT Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-2</b></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">30 października, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 28 października-2 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mkd.jpg" title="Macedonia Północna" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Forca (Kumanovo)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-10</b></td>
+<td nowrap valign="top" width="165"><b>  Awrora Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 16:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/svn.jpg" title="Słowenia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Siliko (Vrhnika)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  ChIT Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Lublana</i></td>
+</tr>
+</table>
+<p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Grupa B8</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_UEFA_neutral -->
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=25672&id_sezon=107" class="main">ChIT Kijów</a></td>
+<td>3</td>
+<td><b>9</b></td>
+<td>3</td>
+<td>0</td>
+<td>0</td>
+<td>17-3</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>10-2</td>
+<td>2</td>
+<td>0</td>
+<td>0</td>
+<td>7-1</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27510&id_sezon=107" class="main">Awrora Kijów</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>12-7</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>2-7</td>
+<td>1</td>
+<td>0</td>
+<td>0</td>
+<td>10-0</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=27509&id_sezon=107" class="main">FK Siliko (Vrhnika)</a></td>
+<td>3</td>
+<td><b>4</b></td>
+<td>1</td>
+<td>1</td>
+<td>1</td>
+<td>7-6</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-4</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>0</td>
+<td>2-2</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=26570&id_sezon=107" class="main">FC Forca (Kumanovo)</a></td>
+<td>3</td>
+<td><b>0</b></td>
+<td>0</td>
+<td>0</td>
+<td>3</td>
+<td>4-24</td>
+<td>0</td>
+<td>0</td>
+<td>1</td>
+<td>0-10</td>
+<td>0</td>
+<td>0</td>
+<td>2</td>
+<td>4-14</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+</table>
+<!-- KONIEC TABELI -->
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/8 finału - 24 listopada, 5 grudnia</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 6 listopada 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-4</b></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Piast Gliwice </font> </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 16:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  ChIT Kijów  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-2</b></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">25 listopada, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Berettyóújfalu</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FC Prishtina 01  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 20:15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-9</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 17:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Baku</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>0-11</b></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 20:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  RSC Anderlecht Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-7</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 20:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Roosdaal</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Luxol St. Andrews FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-9</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">24 listopada, 19:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Gżira</i></td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Étoile Lavalloise Mayenne FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-4</b></td>
+<td nowrap valign="top" width="165"><b>  Hj&#248;rring FK  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/den.jpg" title="Dania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">1 grudnia, 20:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/pol.jpg" title="Polska" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b> <font color="blue"> Piast Gliwice </font> </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-5</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  FK Semej  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 19:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Palma Futsal  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-2</b></td>
+<td nowrap valign="top" width="165"><b>  ChIT Kijów  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/ukr.jpg" title="Ukraina" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 19:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Riga FC  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>8-1</b></td>
+<td nowrap valign="top" width="165"><b>  FC Prishtina 01  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kos.jpg" title="Kosowo" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 18:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  SL e Benfica  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-2</b></td>
+<td nowrap valign="top" width="165"><b>  Araz Naxç&#305;van  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/aze.jpg" title="Azerbejdżan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 18:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sporting Clube de Portugal (Lizbona)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>8-3</b></td>
+<td nowrap valign="top" width="165"><b>  AEK (Ateny)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/gre.jpg" title="Grecja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">4 grudnia, 21:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Kajrat Ałmaty  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-3</b></td>
+<td nowrap valign="top" width="165"><b>  RSC Anderlecht Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/bel.jpg" title="Belgia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 16:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Futsal Cartagena  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-1</b></td>
+<td nowrap valign="top" width="165"><b>  Luxol St. Andrews FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/mlt.jpg" title="Malta" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">5 grudnia, 20:30</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/4 finału - 23 lutego, 6 marca</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 6 listopada 2025, 14:00 - Nyon)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>5-4</b></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 lutego, 20:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-4</b></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">22 lutego, 18:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>4-3</b></td>
+<td nowrap valign="top" width="165"><b>  Sporting Clube de Portugal (Lizbona)  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 lutego, 21:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-2</b></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">23 lutego, 16:00</td>
+</tr>
+<tr>
+<td colspan="5"><hr size="1" width="450"></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  FK Semej  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Étoile Lavalloise Mayenne FC  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 16:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/lva.jpg" title="Łotwa" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Riga FC  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>1-0</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Palma Futsal  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 18:30</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sporting Clube de Portugal (Lizbona)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-4</b></td>
+<td nowrap valign="top" width="165"><b>  SL e Benfica  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 21:00</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Futsal Cartagena  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>7-4</b></td>
+<td nowrap valign="top" width="165"><b>  Kajrat Ałmaty  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/kaz.jpg" title="Kazachstan" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">6 marca, 20:30</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>1/2 finału - 8 maja</u></b>
+</td>
+</tr>
+<tr><td colspan="3"><tr><td colspan="3"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+(Losowanie - 17 marca 2026, 12:00 - Pesaro)</td></tr></td></tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b>  Futsal Cartagena  </b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sporting Clube de Portugal (Lizbona)  </u>
+</b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 maja, 17:30</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 5-6</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pesaro</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Palma Futsal  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>6-6</b></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">8 maja, 20:30</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>pd. k. 5-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pesaro</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Mecz o 3. miejsce - 10 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Futsal Cartagena  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>3-3</b></td>
+<td nowrap valign="top" width="165"><b>  Étoile Lavalloise Mayenne FC  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/fra.jpg" title="Francja" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 maja, 15:00</td>
+</tr>
+<tr>
+<td align="center" colspan="5"><b>k. 5-4</b></td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pesaro</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Finał - 10 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/por.jpg" title="Portugalia" border="1" align="absmiddle" vspace="1"></td>
+<td nowrap valign="top" width="165"><b><u>
+  Sporting Clube de Portugal (Lizbona)  </u>
+</b></td>
+<td nowrap valign="top" align="center" width="40"><b>2-0</b></td>
+<td nowrap valign="top" width="165"><b>  Palma Futsal  </b></td>
+<td nowrap valign="top" width="40" align="center"><img src="http://img.90minut.pl/logo/flagmini/esp.jpg" title="Hiszpania" border="1" align="absmiddle" vspace="1"></td>
+<td valign="top" nowrap align="left" width="150">10 maja, 18:00</td>
+</tr>
+<tr align="left">
+<td></td>
+<td colspan="4"><i>Pesaro</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+</table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Maciej Kusina
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/fixtures/league_8694.html
+++ b/internal/site/testdata/fixtures/league_8694.html
@@ -1,0 +1,4478 @@
+
+
+
+
+
+
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-2">
+<meta http-equiv="Content-Language" content="pl">
+<meta http-equiv="Pragma" content="no-cache">
+<title>Lotto Ekstraklasa 2016/2017</title>
+<meta name="keywords" content="futbol, piłka, piłka nożna, Polska, polski, historia, wyniki, statystyki, archiwum, football, soccer, liga, puchar, mistrzostwa">
+<META NAME="Author" CONTENT="Maciej Kusina">
+<meta property="og:image" content="http://img.90minut.pl/img/reklama90/logo_fb.gif"/>
+<link rel="stylesheet" href="http://img.90minut.pl/style.css" type="text/css">
+<link rel="shortcut icon" HREF="http://img.90minut.pl/temp/favicon.ico">
+<!-- Google AdSense - 21.06.2022 -->
+<script data-ad-client="ca-pub-4014248980018133" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- (C)2003 Gemius SA - gemiusAudience  / 90minut.pl / podstrony -->
+<script language="javascript" type="text/javascript">
+<!--
+var pp_gemius_identifier = new String('d7NL_YesGEcSjw8IlA2t7dVr.IMN_fBgA_RfR_6rzqr.L7');
+//-->
+</script>
+<script language="javascript" type="text/javascript" src="http://idm.hit.gemius.pl/pp_gemius.js"></script>
+<script language="javascript" type="text/javascript">
+if (window!= top) top.location.href = location.href;
+</script>
+		
+<base href="http://www.90minut.pl">
+
+<!-- 25.11.2023 Blockthrough -->
+<script src="https://btloader.com/tag?o=5194763873026048&upapi=true" async></script>
+<!-- 07.12.2023 inmobi -->
+<!-- InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+<script type="text/javascript" async=true>
+(function() {
+  var host = window.location.hostname;
+  var element = document.createElement('script');
+  var firstScript = document.getElementsByTagName('script')[0];
+  var url = 'https://cmp.inmobi.com'
+    .concat('/choice/', 't_XST3kwtPra_', '/', host, '/choice.js?tag_version=V3');
+  var uspTries = 0;
+  var uspTriesLimit = 3;
+  element.async = true;
+  element.type = 'text/javascript';
+  element.src = url;
+
+  firstScript.parentNode.insertBefore(element, firstScript);
+
+  function makeStub() {
+    var TCF_LOCATOR_NAME = '__tcfapiLocator';
+    var queue = [];
+    var win = window;
+    var cmpFrame;
+
+    function addFrame() {
+      var doc = win.document;
+      var otherCMP = !!(win.frames[TCF_LOCATOR_NAME]);
+
+      if (!otherCMP) {
+        if (doc.body) {
+          var iframe = doc.createElement('iframe');
+
+          iframe.style.cssText = 'display:none';
+          iframe.name = TCF_LOCATOR_NAME;
+          doc.body.appendChild(iframe);
+        } else {
+          setTimeout(addFrame, 5);
+        }
+      }
+      return !otherCMP;
+    }
+
+    function tcfAPIHandler() {
+      var gdprApplies;
+      var args = arguments;
+
+      if (!args.length) {
+        return queue;
+      } else if (args[0] === 'setGdprApplies') {
+        if (
+          args.length > 3 &&
+          args[2] === 2 &&
+          typeof args[3] === 'boolean'
+        ) {
+          gdprApplies = args[3];
+          if (typeof args[2] === 'function') {
+            args[2]('set', true);
+          }
+        }
+      } else if (args[0] === 'ping') {
+        var retr = {
+          gdprApplies: gdprApplies,
+          cmpLoaded: false,
+          cmpStatus: 'stub'
+        };
+
+        if (typeof args[2] === 'function') {
+          args[2](retr);
+        }
+      } else {
+        if(args[0] === 'init' && typeof args[3] === 'object') {
+          args[3] = Object.assign(args[3], { tag_version: 'V3' });
+        }
+        queue.push(args);
+      }
+    }
+
+    function postMessageEventHandler(event) {
+      var msgIsString = typeof event.data === 'string';
+      var json = {};
+
+      try {
+        if (msgIsString) {
+          json = JSON.parse(event.data);
+        } else {
+          json = event.data;
+        }
+      } catch (ignore) {}
+
+      var payload = json.__tcfapiCall;
+
+      if (payload) {
+        window.__tcfapi(
+          payload.command,
+          payload.version,
+          function(retValue, success) {
+            var returnMsg = {
+              __tcfapiReturn: {
+                returnValue: retValue,
+                success: success,
+                callId: payload.callId
+              }
+            };
+            if (msgIsString) {
+              returnMsg = JSON.stringify(returnMsg);
+            }
+            if (event && event.source && event.source.postMessage) {
+              event.source.postMessage(returnMsg, '*');
+            }
+          },
+          payload.parameter
+        );
+      }
+    }
+
+    while (win) {
+      try {
+        if (win.frames[TCF_LOCATOR_NAME]) {
+          cmpFrame = win;
+          break;
+        }
+      } catch (ignore) {}
+
+      if (win === window.top) {
+        break;
+      }
+      win = win.parent;
+    }
+    if (!cmpFrame) {
+      addFrame();
+      win.__tcfapi = tcfAPIHandler;
+      win.addEventListener('message', postMessageEventHandler, false);
+    }
+  };
+
+  makeStub();
+
+  var uspStubFunction = function() {
+    var arg = arguments;
+    if (typeof window.__uspapi !== uspStubFunction) {
+      setTimeout(function() {
+        if (typeof window.__uspapi !== 'undefined') {
+          window.__uspapi.apply(window.__uspapi, arg);
+        }
+      }, 500);
+    }
+  };
+
+  var checkIfUspIsReady = function() {
+    uspTries++;
+    if (window.__uspapi === uspStubFunction && uspTries < uspTriesLimit) {
+      console.warn('USP is not accessible');
+    } else {
+      clearInterval(uspInterval);
+    }
+  };
+
+  if (typeof window.__uspapi === 'undefined') {
+    window.__uspapi = uspStubFunction;
+    var uspInterval = setInterval(checkIfUspIsReady, 6000);
+  }
+})();
+</script>
+<!-- End InMobi Choice. Consent Manager Tag v3.0 (for TCF 2.2) -->
+</head>
+<!-- 04.05.2023 -->
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-SPY9LYSF30"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-SPY9LYSF30');
+</script>
+<!-- 04.05.2023 -->
+<body>
+<script language="javascript" type="text/javascript" src="http://www.90minut.pl/js/cmp-body-2020-08-13.js"></script>
+<!-- Google Analytics -->
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5TT74W" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-5TT74W');</script>
+<!-- End Google Tag Manager --><div align="center">
+</div>
+
+<div align="center" valign="bottom"><a href="/" class="main"><img src="http://img.90minut.pl/img/title.jpg" width="760" height="109" alt="[ Strona główna ]" border="0"></a></div>
+
+
+</body>
+<body background="http://img.90minut.pl/img/tlo.gif?d=2015-12-21">
+<div align="center">
+<br>
+<!-- /76859581/90minut_tabelawyniki_bill_top -->
+<div id='90minut_tabelawyniki_bill_top'>
+</div>
+<br>
+</div>
+<table width="1090" border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr class="main" bgcolor="#FFFFFF"> 
+    <td align="center"><img src="http://img.90minut.pl/belki/pol.gif" width="130" height="15"><a href="/skarb.php?id_rozgrywki=13482"><img src="http://img.90minut.pl/belki/pol_skarb.gif" width="126" height="15" border="0" alt="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów"></a><a href="/skarb.php?id_rozgrywki=13483"><img src="http://img.90minut.pl/belki/pol_2liga.gif" width="124" height="15" border="0" alt="Skarb I ligi - statystyki, kariery graczy, historie i osiągnięcia klubów"></a><a href="/ligireg.html"><img src="http://img.90minut.pl/belki/pol_ligireg.gif" width="124" height="15" border="0" alt="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !"></a><a href="/szukaj.php"><img src="http://img.90minut.pl/belki/pol_search.gif" width="124" height="15" border="0" alt="Wyszukiwarka klubów, zawodników i sędziów w serwisie 90 Minut"></a><a href="/kontakt.html"><img src="http://img.90minut.pl/belki/pol_kontakt.gif" width="126" height="15" border="0" alt="Jeśli chcesz skontaktować się z redakcją - najpierw to przeczytaj!"></a></td>
+  </tr>
+  <tr class="main" bgcolor="#FFFFFF">
+    <td><div align="center">
+    </div></td>
+  </tr>
+</table>
+<table width="1090" border="0" align="center" cellspacing="0" cellpadding="0">
+<tr> 
+<td bgcolor="#FFFFFF" width="160" valign="top"> 
+<table width="160" border="0" align="center" name="menu" cellspacing="0">
+<script language="JavaScript">
+function selecturl(s) {
+	var gourl = s.options[s.selectedIndex].value;   window.top.location.href = gourl;
+}
+</script>
+<tr><td class="main" bgcolor="#ffffff"><div align="center"><a href="http://www.90minut.pl" class="main"><img src="http://img.90minut.pl/img/reklama90/logo_zlote.gif" border="0" alt="90minut.pl"></a>
+</div></td></tr><tr><td class="main" bgcolor="#ffffff"></td></tr><tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/sez24-25.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/" class="menulnk" title="Strona główna" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Strona główna</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13482" class="menulnk" title="Jedyny w swoim rodzaju Skarb Ekstraklasy - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb Ekstraklasy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13483" class="menulnk" title="Jedyny w swoim rodzaju Skarb I ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb I ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/skarb.php?id_rozgrywki=13484" class="menulnk" title="Jedyny w swoim rodzaju Skarb II ligi - statystyki, sylwetki, kariery graczy, historie, osiągnięcia klubów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Skarb II ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13482" class="menulnk" title="Sparingi - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - Ekstr.</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13483" class="menulnk" title="Sparingi - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - I liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/sparing.php?id_rozgrywki=13484" class="menulnk" title="Sparingi - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Sparingi - II liga</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1" class="menulnk" title="Informacje o transferach w polskiej Ekstraklasie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - Ekstr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=2" class="menulnk" title="Informacje o transferach w polskiej I lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=3" class="menulnk" title="Informacje o transferach w polskiej II lidze" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/transfery.php?id_sezon=105&runda=1&poziom=-1" class="menulnk" title="Informacje o transferach zagranicznych z udziałem polskich zawodników" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Transfery - zagr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13482&runda=1" class="menulnk" title="Przygotowania - Ekstraklasa - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania E</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13483&runda=1" class="menulnk" title="Przygotowania - I liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/przygotowania.php?id_rozgrywki=13484&runda=1" class="menulnk" title="Przygotowania - II liga - lato 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Przygotowania II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=0" class="menulnk" title="Polacy za granicą" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Polacy za granicą</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/stranieri.php?id_sezon=105&runda=1&typ=1" class="menulnk" title="Zagraniczni piłkarze, którzy kiedyś występowali w polskich klubach" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Obcokrajowcy</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?baraze=1&id_sezon=103" class="menulnk" title="Baraże 2024" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Baraże 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13482.html" class="menulnk" title="Ekstraklasa 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ekstraklasa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13483.html" class="menulnk" title="I liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>I liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13484.html" class="menulnk" title="II liga 2024/2025 - wyniki, tabele, statystyki drużyn i zawodników" style="BORDER-TOP: #666666 0px solid; FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>II liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?poziom=4&id_sezon=105" class="menulnk" title="III Liga 2024/2025 - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>III liga</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13556.html" class="menulnk" title="III Liga 2024/2025 - grupa I - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. I</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13557.html" class="menulnk" title="III Liga 2024/2025 - grupa II - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. II</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13558.html" class="menulnk" title="III Liga 2024/2025 - grupa III - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. III</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13559.html" class="menulnk" title="III Liga 2024/2025 - grupa IV - wyniki, tabela, strzelcy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">III liga, gr. IV</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/mecze_okreg.php" class="menulnk" title="Mecze według dat" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Dziś grają</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.html" class="menulnk" title="Rozgrywki regionalne 2024/2025 - od IV ligi do Klasy C !!!" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Niższe ligi</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligireg.php?nowe=1" class="menulnk" title="Najnowsze rozgrywki 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Najnowsze rozgr.</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13870.html" class="menulnk" title="Centralna Liga Juniorów 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13871.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (zachodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13872.html" class="menulnk" title="Centralna Liga Juniorów U-17 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>CLJ U-17 (wschodnia)</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13486.html" class="menulnk" title="Puchar Polski 2024/2025 - Puchar Polski na szczeblu centralnym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puchar Polski</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13485.html" class="menulnk" title="Superpuchar 2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Superpuchar</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/polcups.php?id_sezon=105" class="menulnk" title="Rozgrywki pucharowe w Polsce 2024/2025 - Puchar Polski na szczeblu okręgowym" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Puch. okręgowe</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=eurcups" class="menulnk" title="Europejskie Puchary 2024/2025 - Liga Mistrzów, Puchar UEFA, UEFA Intertoto, Puchar Europy Kobiet i jeszcze kilka innych, a także Rankingi europejskie i statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Europuchary</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13487.html" class="menulnk" title="Liga Mistrzów 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Mistrzów</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13488.html" class="menulnk" title="Liga Europy 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Europy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13489.html" class="menulnk" title="Liga Konferencji 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Konferencji</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13552.html" class="menulnk" title="Liga Młodzieżowa 2024/2025 - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Młodzieżowa</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_reprezentacji_uefa.php?rok=2017" class="menulnk" title="Ranking reprezentacyjny UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprez. UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?id_sezon=105" class="menulnk" title="Ranking krajowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Krajowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ranking_uefa.php?i=1&id_sezon=105" class="menulnk" title="Ranking klubowy UEFA" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Klubowy UEFA</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/rep_mecze.php?id_sezon=105" class="menulnk" title="Reprezentacja Polski 2024/2025 - turnieje, wyniki, statystyki, sylwetki reprezentantów" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reprezentacja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga11718.html" class="menulnk" title="Eliminacje mistrzostw świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eMŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12322.html" class="menulnk" title="Mistrzostwa świata - Katar 2022 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>MŚ 2022</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13467.html" class="menulnk" title="Liga Narodów 2024/2025 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Liga Narodów 24/25</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga12873.html" class="menulnk" title="Eliminacje mistrzostw Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>eME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/liga/1/liga13459.html" class="menulnk" title="Mistrzostwa Europy 2024 - terminarz, wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>ME 2024</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/kobiety.php?id_sezon=105" class="menulnk" title="Futbol Pań - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Kobiety</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/futsal.php?id_sezon=105" class="menulnk" title="Piłka Nożna Pięcioosobowa - Ligi polskie, puchary, rozgrywki międzynarodowe - wyniki, strzelcy, statystyki" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Futsal</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=kalendarz" class="menulnk" title="Kalendarz piłkarski - szczegółowe kalendarium rozgrywek i wydarzeń futbolowych w Polsce i na świecie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kalendarz</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/archiwum.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/szukaj.php" class="menulnk" title="Wyszukiwarka klubów, zawodników i sędziów w bazie piłkarskiej serwisu 90 Minut !" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Wyszukiwarka</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=105" class="menulnk" title="Archiwum wyników z sezonu 2024/2025" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2024 / 2025</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=103" class="menulnk" title="Archiwum wyników z sezonu 2023/2024" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2023 / 2024</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=101" class="menulnk" title="Archiwum wyników z sezonu 2022/2023" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2022 / 2023</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=99" class="menulnk" title="Archiwum wyników z sezonu 2021/2022" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2021 / 2022</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=97" class="menulnk" title="Archiwum wyników z sezonu 2020/2021" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2020 / 2021</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=95" class="menulnk" title="Archiwum wyników z sezonu 2019/2020" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2019 / 2020</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=93" class="menulnk" title="Archiwum wyników z sezonu 2018/2019" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2018 / 2019</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=91" class="menulnk" title="Archiwum wyników z sezonu 2017/2018" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2017 / 2018</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=89" class="menulnk" title="Archiwum wyników z sezonu 2016/2017" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2016 / 2017</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=87" class="menulnk" title="Archiwum wyników z sezonu 2015/2016" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2015 / 2016</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=85" class="menulnk" title="Archiwum wyników z sezonu 2014/2015" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2014 / 2015</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=83" class="menulnk" title="Archiwum wyników z sezonu 2013/2014" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2013 / 2014</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=81" class="menulnk" title="Archiwum wyników z sezonu 2012/2013" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2012 / 2013</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=79" class="menulnk" title="Archiwum wyników z sezonu 2011/2012" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2011 / 2012</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=77" class="menulnk" title="Archiwum wyników z sezonu 2010/2011" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2010 / 2011</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=75" class="menulnk" title="Archiwum wyników z sezonu 2009/2010" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2009 / 2010</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=73" class="menulnk" title="Archiwum wyników z sezonu 2008/2009" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2008 / 2009</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=71" class="menulnk" title="Archiwum wyników z sezonu 2007/2008" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2007 / 2008</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=69" class="menulnk" title="Archiwum wyników z sezonu 2006/2007" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2006 / 2007</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=67" class="menulnk" title="Archiwum wyników z sezonu 2005/2006" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2005 / 2006</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=65" class="menulnk" title="Archiwum wyników z sezonu 2004/2005" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2004 / 2005</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=63" class="menulnk" title="Archiwum wyników z sezonu 2003/2004" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2003 / 2004</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=61" class="menulnk" title="Archiwum wyników z sezonu 2002/2003" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2002 / 2003</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=59" class="menulnk" title="Archiwum wyników z sezonu 2001/2002" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2001 / 2002</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=57" class="menulnk" title="Archiwum wyników z sezonu 2000/2001" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">2000 / 2001</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=55" class="menulnk" title="Archiwum wyników z sezonu 1999/2000" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1999 / 2000</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=53" class="menulnk" title="Archiwum wyników z sezonu 1998/1999" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1998 / 1999</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=51" class="menulnk" title="Archiwum wyników z sezonu 1997/1998" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1997 / 1998</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=49" class="menulnk" title="Archiwum wyników z sezonu 1996/1997" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1996 / 1997</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=47" class="menulnk" title="Archiwum wyników z sezonu 1995/1996" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1995 / 1996</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/archsezon.php?id_sezon=45" class="menulnk" title="Archiwum wyników z sezonu 1994/1995" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">1994 / 1995</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=archiwum_sezony" class="menulnk" title="Archiwum wyników z sezonów 1927 - 1993/1994" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>1927 - 1993 / 1994</b></a></div>
+</td></tr>
+<tr><td>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_1 -->
+<div id='90minut_tabelawyniki_sky_lewy_1'>
+</div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/rozgrywki.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=pzpn" class="menulnk" title="Wszystko o Polskim Związku Piłki Nożnej - adresy, struktura, historia, ludzie" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">PZPN</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_mp" class="menulnk" title="Mistrzostwa Polski (1920 - 2020) - Kompletna dokumentacja rywalizacji o najcenniejszy laur w Polsce na wszystkich szczeblach - wyniki, tabele, statystyki, podsumowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Mistrzostwa Polski</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=rozgrywki_polcups" class="menulnk" title="Rozgrywki o krajowe trofea (1926 - 2020) - Puchar Polski, Puchar Ligi, Superpuchar" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Puchary w Polsce</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/reprezentanci.php" class="menulnk" title="Reprezentanci Polski (1921 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Reprezentanci</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/ligowcy.php" class="menulnk" title="Ligowcy (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Ligowcy</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/rywalizacje.php" class="menulnk" title="Rywalizacje ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Rywalizacje</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/serie.php" class="menulnk" title="Serie ligowe (1927 - 2020)" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Serie</b></a></div>
+</td></tr>
+<tr><td bgcolor="#FFFFFF" class="main"><img src="http://img.90minut.pl/belki/wyp.gif" width="20" height="15"><img src="http://img.90minut.pl/belki/serwis.gif" width="110" height="15"></td></tr>
+<tr><td class="main">
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=o_stronie" class="menulnk" title="Podstawowe informacje o tej witrynie - historia, założenia, podziękowania" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">O stronie</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/nabor.html" class="menulnk" title="Chcesz dołączyć do nas? Wypełnij ten formularz" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Nabór</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/redakcja.php" class="menulnk" title="Redakcja, czyli kim jesteśmy" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Redakcja</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz_zielony.gif" width="10" align="absmiddle">&nbsp;<a href="/kontakt.html" class="menulnk" title="Kontakt z redakcją" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'"><b>Kontakt</b></a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=banery" class="menulnk" title="Materiały reklamowe 90minut.pl" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Reklamy 90minut.pl</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=bibliografia" class="menulnk" title="Materiały, które okazały się pomocne przy tworzeniu tej strony" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Bibliografia</a></div>
+<div align="left">
+<img src="http://img.90minut.pl/img/rasz.gif" width="10" align="absmiddle">&nbsp;<a href="/strona.php?id=cookies" class="menulnk" title="Polityka serwisu dotycząca plików cookies" style=" FONT-SIZE: 11px; BACKGROUND: #FFFFFF; WIDTH: 100%; CURSOR: hand; COLOR: black; BORDER-BOTTOM: #666666 0px solid" onmouseover="this.style.background='#f5f5f5';this.style.color='#0066FF'" onmouseout="this.style.background='#FFFFFF';this.style.color='#000000'">Pliki cookies</a></div>
+</td></tr>
+<tr><td valign="center" align="middle">
+<div align="center"><a href="http://www.rsssf.com" target="_blank" class="main"><img src="http://img.90minut.pl/banery/but-rsssf.gif" border="0" alt="RSSSF"></a>
+<!-- /76859581/90minut_tabelawyniki_sky_lewy_2 -->
+<div id='90minut_tabelawyniki_sky_lewy_2'>
+</div>
+<!-- (C) 2004 stat.pl --><!-- <a href="http://www.stat.pl" target="_blank"><img src="http://www.stat.pl/logo/logoWhite.gif" width="90" height="26" style="border:0px" alt="statystyki www stat.pl"></a> 02.08.2011 -->
+</div><div align="center"><br>
+</div></td></tr>
+</table>
+</td>
+<td width="6" bgcolor="#FFFFFF" background="http://img.90minut.pl/img/bg-dots2.gif">&nbsp;</td>
+<td bgcolor="#FFFFFF" valign="top" class="main" align="center" width="628">
+&nbsp;<br>
+&nbsp;&nbsp;&nbsp;<img src="http://img.90minut.pl/belki/liga2.gif" width="450" height="15">
+<p align="center">
+.: <a href="/liga/0/liga8694.html" class="main">Wyniki</a> | <a href="/strzelcy.php?id=8694" class="main">Strzelcy</a> | <a href="/stats.php?id=8694" class="main">Statystyki</a> | <a href="/liga/0/liga8694.html#last" class="main">Ostatnia kolejka</a> :.
+</p>
+<!-- /76859581/90minut_tabelawyniki_belka_gora -->
+<div id='90minut_tabelawyniki_belka_gora'>
+</div>
+<!-- kreski --><p>
+<p>
+<!-- POCZĄTEK TABELI -->
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr>
+<td colspan="14" class="main">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<b>Lotto Ekstraklasa 2016/2017</b>
+</td>
+</tr>
+<tr><td>&nbsp;</td></tr>
+<tr align="center">
+<td colspan="4"></td>
+<td colspan="4"><b>RAZEM</b></td>
+<td colspan="4"><b>DOM</b></td>
+<td colspan="4"><b>WYJAZD</b></td>
+<td colspan="6"><b>MECZE BEZPOŚREDNIE</b></td>
+</tr>
+
+<tr align="center" bgcolor="#B81B1B">
+<td></td>
+<td align="left" width="170"><b><font color="#FFFFFF">Nazwa</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+<td><b><font color="#FFFFFF">M.</font></b></td>
+<td><b><font color="#FFFFFF">Pkt.</font></b></td>
+<td><b><font color="#FFFFFF">Z.</font></b></td>
+<td><b><font color="#FFFFFF">R.</font></b></td>
+<td><b><font color="#FFFFFF">P.</font></b></td>
+<td><b><font color="#FFFFFF">Bramki</font></b></td>
+</tr>
+<!-- cmp_ESA13 -->
+<tr align="center" bgcolor="#50E983">
+<td><b>1.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=171&id_sezon=89" class="main">Legia Warszawa</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>44</b> (58)</nobr>&nbsp;</td>
+<td>21</td>
+<td>10</td>
+<td>6</td>
+<td>70-31</td>
+<td>8</td>
+<td>8</td>
+<td>3</td>
+<td>32-15</td>
+<td>13</td>
+<td>2</td>
+<td>3</td>
+<td>38-16</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#FFFF99">
+<td><b>2.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=132&id_sezon=89" class="main">Jagiellonia Białystok</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>42</b> (59)</nobr>&nbsp;</td>
+<td>21</td>
+<td>8</td>
+<td>8</td>
+<td>64-39</td>
+<td>11</td>
+<td>4</td>
+<td>4</td>
+<td>36-17</td>
+<td>10</td>
+<td>4</td>
+<td>4</td>
+<td>28-22</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#E9E983">
+<td><b>3.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=169&id_sezon=89" class="main">Lech Poznań</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>42</b> (55)</nobr>&nbsp;</td>
+<td>20</td>
+<td>9</td>
+<td>8</td>
+<td>62-29</td>
+<td>12</td>
+<td>4</td>
+<td>3</td>
+<td>29-12</td>
+<td>8</td>
+<td>5</td>
+<td>5</td>
+<td>33-17</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>4.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=165&id_sezon=89" class="main">Lechia Gdańsk</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>42</b> (53)</nobr>&nbsp;</td>
+<td>20</td>
+<td>8</td>
+<td>9</td>
+<td>57-37</td>
+<td>15</td>
+<td>2</td>
+<td>2</td>
+<td>44-16</td>
+<td>5</td>
+<td>6</td>
+<td>7</td>
+<td>13-21</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>5.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=146&id_sezon=89" class="main">Korona Kielce</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>28</b> (39)</nobr>&nbsp;</td>
+<td>14</td>
+<td>5</td>
+<td>18</td>
+<td>47-65</td>
+<td>11</td>
+<td>2</td>
+<td>5</td>
+<td>33-20</td>
+<td>3</td>
+<td>3</td>
+<td>13</td>
+<td>14-45</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>6.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=423&id_sezon=89" class="main">Wisła Kraków</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>26</b> (44)</nobr>&nbsp;</td>
+<td>14</td>
+<td>6</td>
+<td>17</td>
+<td>54-57</td>
+<td>11</td>
+<td>3</td>
+<td>4</td>
+<td>33-18</td>
+<td>3</td>
+<td>3</td>
+<td>13</td>
+<td>21-39</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>7.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=297&id_sezon=89" class="main">Pogoń Szczecin</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>25</b> (42)</nobr>&nbsp;</td>
+<td>11</td>
+<td>13</td>
+<td>13</td>
+<td>51-54</td>
+<td>8</td>
+<td>7</td>
+<td>3</td>
+<td>35-21</td>
+<td>3</td>
+<td>6</td>
+<td>10</td>
+<td>16-33</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>5-2</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>8.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=19729&id_sezon=89" class="main">Bruk-Bet Termalica Nieciecza</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>25</b> (42)</nobr>&nbsp;</td>
+<td>13</td>
+<td>7</td>
+<td>17</td>
+<td>35-55</td>
+<td>6</td>
+<td>5</td>
+<td>7</td>
+<td>18-21</td>
+<td>7</td>
+<td>2</td>
+<td>10</td>
+<td>17-34</td>
+<td>2</td>
+<td>3</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>2-5</td>
+</tr>
+<tr><td colspan="22"><hr></td></tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>9.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=439&id_sezon=89" class="main">Zagłębie Lubin</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>34</b> (39)</nobr>&nbsp;</td>
+<td>14</td>
+<td>11</td>
+<td>12</td>
+<td>51-45</td>
+<td>6</td>
+<td>6</td>
+<td>7</td>
+<td>28-27</td>
+<td>8</td>
+<td>5</td>
+<td>5</td>
+<td>23-18</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>10.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=273&id_sezon=89" class="main">Piast Gliwice</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>31</b> (30)</nobr>&nbsp;</td>
+<td>12</td>
+<td>10</td>
+<td>15</td>
+<td>45-54</td>
+<td>8</td>
+<td>5</td>
+<td>5</td>
+<td>27-26</td>
+<td>4</td>
+<td>5</td>
+<td>10</td>
+<td>18-28</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>11.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=390&id_sezon=89" class="main">Śląsk Wrocław</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>29</b> (34)</nobr>&nbsp;</td>
+<td>12</td>
+<td>10</td>
+<td>15</td>
+<td>49-52</td>
+<td>6</td>
+<td>6</td>
+<td>7</td>
+<td>28-27</td>
+<td>6</td>
+<td>4</td>
+<td>8</td>
+<td>21-25</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>12.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=424&id_sezon=89" class="main">Wisła Płock</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>28</b> (39)</nobr>&nbsp;</td>
+<td>12</td>
+<td>11</td>
+<td>14</td>
+<td>49-57</td>
+<td>7</td>
+<td>5</td>
+<td>7</td>
+<td>26-27</td>
+<td>5</td>
+<td>6</td>
+<td>7</td>
+<td>23-30</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#DFDFDF">
+<td><b>13.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=7&id_sezon=89" class="main">Arka Gdynia</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>24</b> (31)</nobr>&nbsp;</td>
+<td>10</td>
+<td>9</td>
+<td>18</td>
+<td>44-60</td>
+<td>6</td>
+<td>5</td>
+<td>8</td>
+<td>26-27</td>
+<td>4</td>
+<td>4</td>
+<td>10</td>
+<td>18-33</td>
+<td>2</td>
+<td>4</td>
+<td>1</td>
+<td>1</td>
+<td>0</td>
+<td>2-1</td>
+</tr>
+<tr align="center" bgcolor="#F5F5F5">
+<td><b>14.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=51&id_sezon=89" class="main">Cracovia</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>24</b> (31)</nobr>&nbsp;</td>
+<td>8</td>
+<td>15</td>
+<td>14</td>
+<td>45-52</td>
+<td>7</td>
+<td>6</td>
+<td>5</td>
+<td>28-18</td>
+<td>1</td>
+<td>9</td>
+<td>9</td>
+<td>17-34</td>
+<td>2</td>
+<td>1</td>
+<td>0</td>
+<td>1</td>
+<td>1</td>
+<td>1-2</td>
+</tr>
+<tr align="center" bgcolor="#E98350">
+<td><b>15.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=93&id_sezon=89" class="main">Górnik Łęczna</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>22</b> (30)</nobr>&nbsp;</td>
+<td>9</td>
+<td>10</td>
+<td>18</td>
+<td>47-63</td>
+<td>6</td>
+<td>3</td>
+<td>9</td>
+<td>24-26</td>
+<td>3</td>
+<td>7</td>
+<td>9</td>
+<td>23-37</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr align="center" bgcolor="#FF9966">
+<td><b>16.</b></td>
+<td align="left">&nbsp;<a href="/skarb.php?id_klub=340&id_sezon=89" class="main">Ruch Chorzów</a></td>
+<td>37</td>
+<td>&nbsp;<nobr><b>19</b> (30)</nobr>&nbsp;</td>
+<td>10</td>
+<td>8</td>
+<td>19</td>
+<td>42-62</td>
+<td>5</td>
+<td>4</td>
+<td>9</td>
+<td>20-27</td>
+<td>5</td>
+<td>4</td>
+<td>10</td>
+<td>22-35</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+</tr>
+<tr><td colspan="22"><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Ruch Chorzów został ukarany odjęciem czterech punktów za zaległości finansowe.</td></tr></table>
+<!-- KONIEC TABELI -->
+<p>
+<table align="center" width="600" border="0" cellspacing="0" cellpadding="0" class="main2">
+<tr bgcolor="#7777BB" align="center" valign="middle"><td></td><td></td><td><font color="white">&nbsp;1&nbsp;</font></td><td><font color="white">&nbsp;2&nbsp;</font></td><td><font color="white">&nbsp;3&nbsp;</font></td><td><font color="white">&nbsp;4&nbsp;</font></td><td><font color="white">&nbsp;5&nbsp;</font></td><td><font color="white">&nbsp;6&nbsp;</font></td><td><font color="white">&nbsp;7&nbsp;</font></td><td><font color="white">&nbsp;8&nbsp;</font></td><td><font color="white">&nbsp;9&nbsp;</font></td><td><font color="white">&nbsp;10&nbsp;</font></td><td><font color="white">&nbsp;11&nbsp;</font></td><td><font color="white">&nbsp;12&nbsp;</font></td><td><font color="white">&nbsp;13&nbsp;</font></td><td><font color="white">&nbsp;14&nbsp;</font></td><td><font color="white">&nbsp;15&nbsp;</font></td><td><font color="white">&nbsp;16&nbsp;</font></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;1&nbsp;</font></td><td align="left" valign="middle">Legia Warszawa</td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229275" class="main" title="Legia Warszawa 1-1 Jagiellonia Białystok">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229376" class="main" title="Legia Warszawa 2-1 Lech Poznań">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316067" class="main" title="Legia Warszawa 2-0 Lech Poznań">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229360" class="main" title="Legia Warszawa 3-0 Lechia Gdańsk">3-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316092" class="main" title="Legia Warszawa 0-0 Lechia Gdańsk">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229505" class="main" title="Legia Warszawa 0-0 Korona Kielce">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229473" class="main" title="Legia Warszawa 1-0 Wisła Kraków">1-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316043" class="main" title="Legia Warszawa 1-1 Wisła Kraków">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229489" class="main" title="Legia Warszawa 2-0 Pogoń Szczecin">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229457" class="main" title="Legia Warszawa 1-1 Bruk-Bet Termalica Nieciecza">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316060" class="main" title="Legia Warszawa 6-0 Bruk-Bet Termalica Nieciecza">6-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229340" class="main" title="Legia Warszawa 2-3 Zagłębie Lubin">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229305" class="main" title="Legia Warszawa 0-0 Piast Gliwice">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229284" class="main" title="Legia Warszawa 0-0 Śląsk Wrocław">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229417" class="main" title="Legia Warszawa 2-2 Wisła Płock">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229319" class="main" title="Legia Warszawa 1-3 Arka Gdynia">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229392" class="main" title="Legia Warszawa 2-0 Cracovia">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229433" class="main" title="Legia Warszawa 5-0 Górnik Łęczna">5-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229449" class="main" title="Legia Warszawa 1-3 Ruch Chorzów">1-3</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;2&nbsp;</font></td><td align="left" valign="middle">Jagiellonia Białystok</td><td><nobr><a href="/mecz.php?id_mecz=1229401" class="main" title="Jagiellonia Białystok 1-4 Legia Warszawa">1-4</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316074" class="main" title="Jagiellonia Białystok 0-0 Legia Warszawa">0-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229416" class="main" title="Jagiellonia Białystok 2-1 Lech Poznań">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316090" class="main" title="Jagiellonia Białystok 2-2 Lech Poznań">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229318" class="main" title="Jagiellonia Białystok 0-1 Lechia Gdańsk">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229472" class="main" title="Jagiellonia Białystok 4-1 Korona Kielce">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229336" class="main" title="Jagiellonia Białystok 2-1 Wisła Kraków">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316058" class="main" title="Jagiellonia Białystok 2-0 Wisła Kraków">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229358" class="main" title="Jagiellonia Białystok 0-0 Pogoń Szczecin">0-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316042" class="main" title="Jagiellonia Białystok 1-0 Pogoń Szczecin">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229486" class="main" title="Jagiellonia Białystok 1-0 Bruk-Bet Termalica Nieciecza">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229372" class="main" title="Jagiellonia Białystok 1-2 Zagłębie Lubin">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229393" class="main" title="Jagiellonia Białystok 2-0 Piast Gliwice">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229464" class="main" title="Jagiellonia Białystok 4-1 Śląsk Wrocław">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229432" class="main" title="Jagiellonia Białystok 1-2 Wisła Płock">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229302" class="main" title="Jagiellonia Białystok 4-1 Arka Gdynia">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229502" class="main" title="Jagiellonia Białystok 0-0 Cracovia">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229446" class="main" title="Jagiellonia Białystok 5-0 Górnik Łęczna">5-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229288" class="main" title="Jagiellonia Białystok 4-1 Ruch Chorzów">4-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;3&nbsp;</font></td><td align="left" valign="middle">Lech Poznań</td><td><nobr><a href="/mecz.php?id_mecz=1229497" class="main" title="Lech Poznań 1-2 Legia Warszawa">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229292" class="main" title="Lech Poznań 0-2 Jagiellonia Białystok">0-2</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229462" class="main" title="Lech Poznań 1-0 Lechia Gdańsk">1-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316075" class="main" title="Lech Poznań 0-0 Lechia Gdańsk">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229421" class="main" title="Lech Poznań 1-0 Korona Kielce">1-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316044" class="main" title="Lech Poznań 3-2 Korona Kielce">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229367" class="main" title="Lech Poznań 1-1 Wisła Kraków">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316083" class="main" title="Lech Poznań 2-1 Wisła Kraków">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229330" class="main" title="Lech Poznań 3-1 Pogoń Szczecin">3-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316061" class="main" title="Lech Poznań 2-0 Pogoń Szczecin">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229439" class="main" title="Lech Poznań 3-0 Bruk-Bet Termalica Nieciecza">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229282" class="main" title="Lech Poznań 0-2 Zagłębie Lubin">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229323" class="main" title="Lech Poznań 2-0 Piast Gliwice">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229399" class="main" title="Lech Poznań 3-0 Śląsk Wrocław">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229381" class="main" title="Lech Poznań 2-0 Wisła Płock">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229352" class="main" title="Lech Poznań 0-0 Arka Gdynia">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229310" class="main" title="Lech Poznań 2-1 Cracovia">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229480" class="main" title="Lech Poznań 0-0 Górnik Łęczna">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229507" class="main" title="Lech Poznań 3-0 Ruch Chorzów">3-0</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;4&nbsp;</font></td><td align="left" valign="middle">Lechia Gdańsk</td><td><nobr><a href="/mecz.php?id_mecz=1229481" class="main" title="Lechia Gdańsk 1-2 Legia Warszawa">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229441" class="main" title="Lechia Gdańsk 3-0 Jagiellonia Białystok">3-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316066" class="main" title="Lechia Gdańsk 4-0 Jagiellonia Białystok">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229344" class="main" title="Lechia Gdańsk 2-1 Lech Poznań">2-1</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229306" class="main" title="Lechia Gdańsk 3-2 Korona Kielce">3-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316059" class="main" title="Lechia Gdańsk 0-0 Korona Kielce">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229291" class="main" title="Lechia Gdańsk 3-1 Wisła Kraków">3-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229391" class="main" title="Lechia Gdańsk 1-1 Pogoń Szczecin">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316085" class="main" title="Lechia Gdańsk 4-0 Pogoń Szczecin">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229328" class="main" title="Lechia Gdańsk 1-2 Bruk-Bet Termalica Nieciecza">1-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316045" class="main" title="Lechia Gdańsk 2-0 Bruk-Bet Termalica Nieciecza">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229487" class="main" title="Lechia Gdańsk 1-0 Zagłębie Lubin">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229377" class="main" title="Lechia Gdańsk 3-2 Piast Gliwice">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229422" class="main" title="Lechia Gdańsk 3-0 Śląsk Wrocław">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229400" class="main" title="Lechia Gdańsk 2-1 Wisła Płock">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229503" class="main" title="Lechia Gdańsk 2-1 Arka Gdynia">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229456" class="main" title="Lechia Gdańsk 4-2 Cracovia">4-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229406" class="main" title="Lechia Gdańsk 3-0 Górnik Łęczna">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229350" class="main" title="Lechia Gdańsk 2-1 Ruch Chorzów">2-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;5&nbsp;</font></td><td align="left" valign="middle">Korona Kielce</td><td><nobr><a href="/mecz.php?id_mecz=1229383" class="main" title="Korona Kielce 2-4 Legia Warszawa">2-4</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316084" class="main" title="Korona Kielce 0-1 Legia Warszawa">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229351" class="main" title="Korona Kielce 1-2 Jagiellonia Białystok">1-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316050" class="main" title="Korona Kielce 1-1 Jagiellonia Białystok">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229298" class="main" title="Korona Kielce 4-1 Lech Poznań">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229431" class="main" title="Korona Kielce 2-0 Lechia Gdańsk">2-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229317" class="main" title="Korona Kielce 1-0 Wisła Kraków">1-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316069" class="main" title="Korona Kielce 3-2 Wisła Kraków">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229405" class="main" title="Korona Kielce 4-1 Pogoń Szczecin">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229509" class="main" title="Korona Kielce 0-1 Bruk-Bet Termalica Nieciecza">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229398" class="main" title="Korona Kielce 2-1 Zagłębie Lubin">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229296" class="main" title="Korona Kielce 1-1 Piast Gliwice">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229363" class="main" title="Korona Kielce 1-2 Śląsk Wrocław">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229447" class="main" title="Korona Kielce 4-2 Wisła Płock">4-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229332" class="main" title="Korona Kielce 1-0 Arka Gdynia">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229479" class="main" title="Korona Kielce 3-0 Cracovia">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229461" class="main" title="Korona Kielce 2-1 Górnik Łęczna">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229491" class="main" title="Korona Kielce 1-0 Ruch Chorzów">1-0</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;6&nbsp;</font></td><td align="left" valign="middle">Wisła Kraków</td><td><nobr><a href="/mecz.php?id_mecz=1229353" class="main" title="Wisła Kraków 0-0 Legia Warszawa">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229451" class="main" title="Wisła Kraków 3-1 Jagiellonia Białystok">3-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229484" class="main" title="Wisła Kraków 0-0 Lech Poznań">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229413" class="main" title="Wisła Kraków 3-0 Lechia Gdańsk">3-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316051" class="main" title="Wisła Kraków 0-1 Lechia Gdańsk">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229435" class="main" title="Wisła Kraków 2-0 Korona Kielce">2-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229274" class="main" title="Wisła Kraków 2-1 Pogoń Szczecin">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316076" class="main" title="Wisła Kraków 4-0 Pogoń Szczecin">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229374" class="main" title="Wisła Kraków 2-0 Bruk-Bet Termalica Nieciecza">2-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316091" class="main" title="Wisła Kraków 1-2 Bruk-Bet Termalica Nieciecza">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229499" class="main" title="Wisła Kraków 1-0 Zagłębie Lubin">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229345" class="main" title="Wisła Kraków 1-0 Piast Gliwice">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229327" class="main" title="Wisła Kraków 1-5 Śląsk Wrocław">1-5</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229477" class="main" title="Wisła Kraków 3-2 Wisła Płock">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229403" class="main" title="Wisła Kraków 5-1 Arka Gdynia">5-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229418" class="main" title="Wisła Kraków 1-1 Cracovia">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229388" class="main" title="Wisła Kraków 3-2 Górnik Łęczna">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229313" class="main" title="Wisła Kraków 1-2 Ruch Chorzów">1-2</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;7&nbsp;</font></td><td align="left" valign="middle">Pogoń Szczecin</td><td><nobr><a href="/mecz.php?id_mecz=1229365" class="main" title="Pogoń Szczecin 3-2 Legia Warszawa">3-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316052" class="main" title="Pogoń Szczecin 0-2 Legia Warszawa">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229478" class="main" title="Pogoń Szczecin 0-0 Jagiellonia Białystok">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229455" class="main" title="Pogoń Szczecin 0-3 Lech Poznań">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229513" class="main" title="Pogoń Szczecin 3-1 Lechia Gdańsk">3-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229283" class="main" title="Pogoń Szczecin 1-1 Korona Kielce">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316093" class="main" title="Pogoń Szczecin 3-0 Korona Kielce">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229397" class="main" title="Pogoń Szczecin 6-2 Wisła Kraków">6-2</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229312" class="main" title="Pogoń Szczecin 5-0 Bruk-Bet Termalica Nieciecza">5-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316068" class="main" title="Pogoń Szczecin 1-1 Bruk-Bet Termalica Nieciecza">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229420" class="main" title="Pogoń Szczecin 1-1 Zagłębie Lubin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229434" class="main" title="Pogoń Szczecin 2-1 Piast Gliwice">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229290" class="main" title="Pogoń Szczecin 0-2 Śląsk Wrocław">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229460" class="main" title="Pogoń Szczecin 1-1 Wisła Płock">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229495" class="main" title="Pogoń Szczecin 5-1 Arka Gdynia">5-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229324" class="main" title="Pogoń Szczecin 1-1 Cracovia">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229349" class="main" title="Pogoń Szczecin 1-1 Górnik Łęczna">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229379" class="main" title="Pogoń Szczecin 2-1 Ruch Chorzów">2-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;8&nbsp;</font></td><td align="left" valign="middle">Bruk-Bet Termalica Nieciecza</td><td><nobr><a href="/mecz.php?id_mecz=1229335" class="main" title="Bruk-Bet Termalica Nieciecza 2-1 Legia Warszawa">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229369" class="main" title="Bruk-Bet Termalica Nieciecza 0-0 Jagiellonia Białystok">0-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316082" class="main" title="Bruk-Bet Termalica Nieciecza 1-2 Jagiellonia Białystok">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229314" class="main" title="Bruk-Bet Termalica Nieciecza 0-0 Lech Poznań">0-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316053" class="main" title="Bruk-Bet Termalica Nieciecza 0-3 Lech Poznań">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229443" class="main" title="Bruk-Bet Termalica Nieciecza 1-1 Lechia Gdańsk">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229386" class="main" title="Bruk-Bet Termalica Nieciecza 1-3 Korona Kielce">1-3</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316077" class="main" title="Bruk-Bet Termalica Nieciecza 0-2 Korona Kielce">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229492" class="main" title="Bruk-Bet Termalica Nieciecza 2-3 Wisła Kraków">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229428" class="main" title="Bruk-Bet Termalica Nieciecza 2-0 Pogoń Szczecin">2-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229412" class="main" title="Bruk-Bet Termalica Nieciecza 0-1 Zagłębie Lubin">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229504" class="main" title="Bruk-Bet Termalica Nieciecza 1-0 Piast Gliwice">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229476" class="main" title="Bruk-Bet Termalica Nieciecza 1-2 Śląsk Wrocław">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229347" class="main" title="Bruk-Bet Termalica Nieciecza 0-0 Wisła Płock">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229278" class="main" title="Bruk-Bet Termalica Nieciecza 2-0 Arka Gdynia">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229287" class="main" title="Bruk-Bet Termalica Nieciecza 3-2 Cracovia">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229299" class="main" title="Bruk-Bet Termalica Nieciecza 2-1 Górnik Łęczna">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229465" class="main" title="Bruk-Bet Termalica Nieciecza 0-0 Ruch Chorzów">0-0</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;9&nbsp;</font></td><td align="left" valign="middle">Zagłębie Lubin</td><td><nobr><a href="/mecz.php?id_mecz=1229463" class="main" title="Zagłębie Lubin 1-3 Legia Warszawa">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229490" class="main" title="Zagłębie Lubin 3-4 Jagiellonia Białystok">3-4</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229402" class="main" title="Zagłębie Lubin 0-3 Lech Poznań">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229364" class="main" title="Zagłębie Lubin 1-2 Lechia Gdańsk">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229280" class="main" title="Zagłębie Lubin 4-0 Korona Kielce">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229382" class="main" title="Zagłębie Lubin 2-2 Wisła Kraków">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229301" class="main" title="Zagłębie Lubin 1-1 Pogoń Szczecin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229297" class="main" title="Zagłębie Lubin 2-0 Bruk-Bet Termalica Nieciecza">2-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229426" class="main" title="Zagłębie Lubin 2-1 Piast Gliwice">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316064" class="main" title="Zagłębie Lubin 3-1 Piast Gliwice">3-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229506" class="main" title="Zagłębie Lubin 1-1 Śląsk Wrocław">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316071" class="main" title="Zagłębie Lubin 2-0 Śląsk Wrocław">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229331" class="main" title="Zagłębie Lubin 1-2 Wisła Płock">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229442" class="main" title="Zagłębie Lubin 1-0 Arka Gdynia">1-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316096" class="main" title="Zagłębie Lubin 1-3 Arka Gdynia">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229348" class="main" title="Zagłębie Lubin 1-1 Cracovia">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316047" class="main" title="Zagłębie Lubin 2-2 Cracovia">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229315" class="main" title="Zagłębie Lubin 0-0 Górnik Łęczna">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229475" class="main" title="Zagłębie Lubin 0-1 Ruch Chorzów">0-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;10&nbsp;</font></td><td align="left" valign="middle">Piast Gliwice</td><td><nobr><a href="/mecz.php?id_mecz=1229425" class="main" title="Piast Gliwice 1-5 Legia Warszawa">1-5</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229510" class="main" title="Piast Gliwice 0-1 Jagiellonia Białystok">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229448" class="main" title="Piast Gliwice 0-3 Lech Poznań">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229496" class="main" title="Piast Gliwice 1-1 Lechia Gdańsk">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229410" class="main" title="Piast Gliwice 1-0 Korona Kielce">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229458" class="main" title="Piast Gliwice 1-2 Wisła Kraków">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229321" class="main" title="Piast Gliwice 0-2 Pogoń Szczecin">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229378" class="main" title="Piast Gliwice 2-1 Bruk-Bet Termalica Nieciecza">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229309" class="main" title="Piast Gliwice 0-0 Zagłębie Lubin">0-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229346" class="main" title="Piast Gliwice 1-1 Śląsk Wrocław">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316057" class="main" title="Piast Gliwice 2-0 Śląsk Wrocław">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229285" class="main" title="Piast Gliwice 2-1 Wisła Płock">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316086" class="main" title="Piast Gliwice 4-0 Wisła Płock">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229474" class="main" title="Piast Gliwice 3-2 Arka Gdynia">3-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229396" class="main" title="Piast Gliwice 2-2 Cracovia">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229333" class="main" title="Piast Gliwice 3-3 Górnik Łęczna">3-3</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316081" class="main" title="Piast Gliwice 2-1 Górnik Łęczna">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229362" class="main" title="Piast Gliwice 2-1 Ruch Chorzów">2-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;11&nbsp;</font></td><td align="left" valign="middle">Śląsk Wrocław</td><td><nobr><a href="/mecz.php?id_mecz=1229408" class="main" title="Śląsk Wrocław 0-4 Legia Warszawa">0-4</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229342" class="main" title="Śląsk Wrocław 0-4 Jagiellonia Białystok">0-4</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229277" class="main" title="Śląsk Wrocław 0-0 Lech Poznań">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229304" class="main" title="Śląsk Wrocław 0-0 Lechia Gdańsk">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229485" class="main" title="Śląsk Wrocław 3-0 Korona Kielce">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229444" class="main" title="Śląsk Wrocław 1-0 Wisła Kraków">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229414" class="main" title="Śląsk Wrocław 1-1 Pogoń Szczecin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229356" class="main" title="Śląsk Wrocław 1-2 Bruk-Bet Termalica Nieciecza">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229387" class="main" title="Śląsk Wrocław 2-1 Zagłębie Lubin">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229466" class="main" title="Śląsk Wrocław 3-4 Piast Gliwice">3-4</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229316" class="main" title="Śląsk Wrocław 0-0 Wisła Płock">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229429" class="main" title="Śląsk Wrocław 0-2 Arka Gdynia">0-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316079" class="main" title="Śląsk Wrocław 4-1 Arka Gdynia">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229373" class="main" title="Śląsk Wrocław 2-2 Cracovia">2-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316087" class="main" title="Śląsk Wrocław 2-0 Cracovia">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229501" class="main" title="Śląsk Wrocław 2-2 Górnik Łęczna">2-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316048" class="main" title="Śląsk Wrocław 0-2 Górnik Łęczna">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229337" class="main" title="Śląsk Wrocław 1-2 Ruch Chorzów">1-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316065" class="main" title="Śląsk Wrocław 6-0 Ruch Chorzów">6-0</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;12&nbsp;</font></td><td align="left" valign="middle">Wisła Płock</td><td><nobr><a href="/mecz.php?id_mecz=1229295" class="main" title="Wisła Płock 2-3 Legia Warszawa">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229308" class="main" title="Wisła Płock 1-0 Jagiellonia Białystok">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229500" class="main" title="Wisła Płock 0-3 Lech Poznań">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229279" class="main" title="Wisła Płock 2-1 Lechia Gdańsk">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229322" class="main" title="Wisła Płock 1-2 Korona Kielce">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229357" class="main" title="Wisła Płock 2-3 Wisła Kraków">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229339" class="main" title="Wisła Płock 2-0 Pogoń Szczecin">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229467" class="main" title="Wisła Płock 1-0 Bruk-Bet Termalica Nieciecza">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229452" class="main" title="Wisła Płock 2-1 Zagłębie Lubin">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316078" class="main" title="Wisła Płock 1-2 Zagłębie Lubin">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229407" class="main" title="Wisła Płock 0-0 Piast Gliwice">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229436" class="main" title="Wisła Płock 1-1 Śląsk Wrocław">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316094" class="main" title="Wisła Płock 0-3 Śląsk Wrocław">0-3</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229389" class="main" title="Wisła Płock 0-0 Arka Gdynia">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229488" class="main" title="Wisła Płock 4-1 Cracovia">4-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316062" class="main" title="Wisła Płock 1-1 Cracovia">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229370" class="main" title="Wisła Płock 1-2 Górnik Łęczna">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229423" class="main" title="Wisła Płock 4-3 Ruch Chorzów">4-3</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316046" class="main" title="Wisła Płock 1-1 Ruch Chorzów">1-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;13&nbsp;</font></td><td align="left" valign="middle">Arka Gdynia</td><td><nobr><a href="/mecz.php?id_mecz=1229440" class="main" title="Arka Gdynia 0-1 Legia Warszawa">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229424" class="main" title="Arka Gdynia 2-3 Jagiellonia Białystok">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229469" class="main" title="Arka Gdynia 1-4 Lech Poznań">1-4</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229384" class="main" title="Arka Gdynia 1-1 Lechia Gdańsk">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229453" class="main" title="Arka Gdynia 4-1 Korona Kielce">4-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229289" class="main" title="Arka Gdynia 3-0 Wisła Kraków">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229371" class="main" title="Arka Gdynia 0-3 Pogoń Szczecin">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229394" class="main" title="Arka Gdynia 1-3 Bruk-Bet Termalica Nieciecza">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229326" class="main" title="Arka Gdynia 1-1 Zagłębie Lubin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229361" class="main" title="Arka Gdynia 1-2 Piast Gliwice">1-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316049" class="main" title="Arka Gdynia 1-1 Piast Gliwice">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229307" class="main" title="Arka Gdynia 2-0 Śląsk Wrocław">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229511" class="main" title="Arka Gdynia 1-1 Wisła Płock">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316070" class="main" title="Arka Gdynia 0-1 Wisła Płock">0-1</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229341" class="main" title="Arka Gdynia 1-0 Cracovia">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229483" class="main" title="Arka Gdynia 2-4 Górnik Łęczna">2-4</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316063" class="main" title="Arka Gdynia 1-0 Górnik Łęczna">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229293" class="main" title="Arka Gdynia 3-0 Ruch Chorzów">3-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316089" class="main" title="Arka Gdynia 1-1 Ruch Chorzów">1-1</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;14&nbsp;</font></td><td align="left" valign="middle">Cracovia</td><td><nobr><a href="/mecz.php?id_mecz=1229512" class="main" title="Cracovia 1-2 Legia Warszawa">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229385" class="main" title="Cracovia 1-3 Jagiellonia Białystok">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229430" class="main" title="Cracovia 1-1 Lech Poznań">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229334" class="main" title="Cracovia 0-1 Lechia Gdańsk">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229355" class="main" title="Cracovia 6-0 Korona Kielce">6-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229303" class="main" title="Cracovia 2-1 Wisła Kraków">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229445" class="main" title="Cracovia 1-1 Pogoń Szczecin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229404" class="main" title="Cracovia 1-3 Bruk-Bet Termalica Nieciecza">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229470" class="main" title="Cracovia 1-1 Zagłębie Lubin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229281" class="main" title="Cracovia 5-1 Piast Gliwice">5-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316095" class="main" title="Cracovia 0-1 Piast Gliwice">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229493" class="main" title="Cracovia 1-0 Śląsk Wrocław">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229368" class="main" title="Cracovia 1-0 Wisła Płock">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229459" class="main" title="Cracovia 1-1 Arka Gdynia">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316055" class="main" title="Cracovia 2-0 Arka Gdynia">2-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229415" class="main" title="Cracovia 1-1 Górnik Łęczna">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229320" class="main" title="Cracovia 1-1 Ruch Chorzów">1-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316080" class="main" title="Cracovia 2-0 Ruch Chorzów">2-0</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#F5F5F5" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;15&nbsp;</font></td><td align="left" valign="middle">Górnik Łęczna</td><td><nobr><a href="/mecz.php?id_mecz=1229311" class="main" title="Górnik Łęczna 1-0 Legia Warszawa">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229325" class="main" title="Górnik Łęczna 0-2 Jagiellonia Białystok">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229354" class="main" title="Górnik Łęczna 1-2 Lech Poznań">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229286" class="main" title="Górnik Łęczna 1-2 Lechia Gdańsk">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229338" class="main" title="Górnik Łęczna 4-0 Korona Kielce">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229508" class="main" title="Górnik Łęczna 3-1 Wisła Kraków">3-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229471" class="main" title="Górnik Łęczna 2-2 Pogoń Szczecin">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229419" class="main" title="Górnik Łęczna 3-0 Bruk-Bet Termalica Nieciecza">3-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229437" class="main" title="Górnik Łęczna 0-1 Zagłębie Lubin">0-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316088" class="main" title="Górnik Łęczna 1-3 Zagłębie Lubin">1-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229450" class="main" title="Górnik Łęczna 1-0 Piast Gliwice">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229380" class="main" title="Górnik Łęczna 0-3 Śląsk Wrocław">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229494" class="main" title="Górnik Łęczna 2-3 Wisła Płock">2-3</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316054" class="main" title="Górnik Łęczna 2-3 Wisła Płock">2-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229366" class="main" title="Górnik Łęczna 0-0 Arka Gdynia">0-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229294" class="main" title="Górnik Łęczna 0-0 Cracovia">0-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316073" class="main" title="Górnik Łęczna 3-0 Cracovia">3-0</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td><td><nobr><a href="/mecz.php?id_mecz=1229395" class="main" title="Górnik Łęczna 0-4 Ruch Chorzów">0-4</a>&nbsp;</nobr></td></tr>
+<tr bgcolor="#DFDFDF" align="center" valign="top"><td valign="middle" bgcolor="#7777BB"><font color="white">&nbsp;16&nbsp;</font></td><td align="left" valign="middle">Ruch Chorzów</td><td><nobr><a href="/mecz.php?id_mecz=1229329" class="main" title="Ruch Chorzów 0-2 Legia Warszawa">0-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229409" class="main" title="Ruch Chorzów 1-2 Jagiellonia Białystok">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229390" class="main" title="Ruch Chorzów 0-5 Lech Poznań">0-5</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229468" class="main" title="Ruch Chorzów 2-1 Lechia Gdańsk">2-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229375" class="main" title="Ruch Chorzów 4-0 Korona Kielce">4-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229427" class="main" title="Ruch Chorzów 1-0 Wisła Kraków">1-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229498" class="main" title="Ruch Chorzów 1-2 Pogoń Szczecin">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229343" class="main" title="Ruch Chorzów 0-1 Bruk-Bet Termalica Nieciecza">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229359" class="main" title="Ruch Chorzów 1-2 Zagłębie Lubin">1-2</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316056" class="main" title="Ruch Chorzów 1-1 Zagłębie Lubin">1-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229482" class="main" title="Ruch Chorzów 0-0 Piast Gliwice">0-0</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316072" class="main" title="Ruch Chorzów 0-3 Piast Gliwice">0-3</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229454" class="main" title="Ruch Chorzów 2-0 Śląsk Wrocław">2-0</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229300" class="main" title="Ruch Chorzów 2-2 Wisła Płock">2-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229411" class="main" title="Ruch Chorzów 1-2 Arka Gdynia">1-2</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229438" class="main" title="Ruch Chorzów 0-1 Cracovia">0-1</a>&nbsp;</nobr></td><td><nobr><a href="/mecz.php?id_mecz=1229276" class="main" title="Ruch Chorzów 2-1 Górnik Łęczna">2-1</a>&nbsp;</nobr><br><nobr><a href="/mecz.php?id_mecz=1316097" class="main" title="Ruch Chorzów 2-2 Górnik Łęczna">2-2</a>&nbsp;</nobr></td><td bgcolor="#7777BB">&nbsp;&nbsp;&nbsp;&nbsp;</td></tr>
+</table>
+<div align="center"><a href="http://www.90minut.pl/news/229/news2296955-Wyslij-SMS-a-z-wynikiem.html" target="_blank"><img src="http://img.90minut.pl/banery/90min_wynikisms2_new.gif" border="0"></a></div><!-- /76859581/90minut_tabelawyniki_belka_srodek_1 -->
+<div id='90minut_tabelawyniki_belka_srodek_1'>
+</div>
+<div align="center">
+</div>
+<!-- cmp_ESA13 -->
+<!-- 0 --><p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 1 - 16-17 lipca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229274" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">16 lipca, 18:00 (9779)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Brożek 3, Rafał Pietrzak 82 - Jarosław Fojut 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229275" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">16 lipca, 20:30 (<nobr>13 654</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michaił Aleksandrow 45 - Fedor Černych 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229276" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">16 lipca, 15:30 (5401)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jakub Arak 64, Mariusz Stępiński 90 - Wojciech Skaba 88 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229277" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">15 lipca, 20:30 (<nobr>12 402</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229278" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">18 lipca, 18:00 (3338)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vladislavs Gutkovskis 9, Samuel Štefánik 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229279" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">15 lipca, 18:00 (8531)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Szymiński 23, Dominik Furman 77 (k) - <i>Marco Paix&#227;o</i> 15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229280" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">17 lipca, 15:30 (5073)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Piątek 1, Krzysztof Janus 16 (k), Maciej Dąbrowski 24, Krzysztof Piątek 31</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229281" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">17 lipca, 18:00 (7659)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Čovilo 4, 70, Mateusz Szczepaniak 44, <i>Deleu</i> 62, Marcin Budziński 87 - Bartosz Szeliga 76</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 2 - 23-24 lipca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229282" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">24 lipca, 18:00 (<nobr>16 354</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michal Papadopulos 33, Filip Starzyński 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229283" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">22 lipca, 18:00 (6234)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kort 20 - Serhij Pyłypczuk 43</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229284" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">23 lipca, 20:30 (<nobr>12 179</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229285" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">24 lipca, 15:30 (4581)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Saša Živec 18, Patrik Mráz 55 - Arkadiusz Reca 7</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229286" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">25 lipca, 18:00 (3574)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vanja Milinković-Savić 54 (s) - Miloš Krasić 28, Grzegorz Kuświk 56</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229287" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">24 lipca, 15:30 (4595)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vladislavs Gutkovskis 13, Mateusz Kupczak 21, Róbert Litauszki 36 (s) - Erik Jendrišek 26, Damian Dąbrowski 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229288" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">23 lipca, 18:00 (<nobr>13 240</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Grzyb 2, Maciej Górski 17, Konstantin Vassiljev 50, Karol Świderski 79 - Patryk Lipski 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229289" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">22 lipca, 20:30 (<nobr>10 203</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Yannick Kakoko 8, Dariusz Zjawiński 21, <i>Marcus Vinícius</i> 81 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 3 - 30-31 lipca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229290" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">1 sierpnia, 18:00 (6120)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Kokoszka 3, <i>Filipe Gonçalves</i> 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229291" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">30 lipca, 18:00 (<nobr>15 740</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Flávio Paix&#227;o</i> 30, 68, <i>Marco Paix&#227;o</i> 89 - Rafał Boguski 57</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229292" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">29 lipca, 20:30 (<nobr>10 396</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Konstantin Vassiljev 61, 72 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229293" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">29 lipca, 18:00 (<nobr>10 099</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dariusz Zjawiński 23, Miroslav Božok 68, Rafał Siemaszko 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229294" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">31 lipca, 15:30 (4015)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin / mecz przerwany w 47. minucie na sześć minut z powodu ulewy</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229295" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">30 lipca, 20:30 (9679)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Tomislav Božić 2, Przemysław Szymiński 10 - Aleksandar Prijović 17, Michał Kucharczyk 41, Igor Lewczuk 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229296" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">31 lipca, 18:00 (5062)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Sekulski 72 - Bartosz Szeliga 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229297" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">31 lipca, 15:30 (6193)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Krzysztof Janus 8, Filip Starzyński 45</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 4 - 6-7 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229298" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">6 sierpnia, 20:30 (5989)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Sekulski 21 (k), 50, Miguel Palanca 70, Rafał Grzelak 79 - Marcin Robak 16</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229299" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">6 sierpnia, 15:30 (3017)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vlastimir Jovanović 38 (k), Martin Juhar 51 - Maciej Szmatiuk 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229300" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">8 sierpnia, 18:00 (6176)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mariusz Stępiński 45, Rafał Grodzicki 90 (k) - José Kanté 45, Giorgi Merebaszwili 80</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229301" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">7 sierpnia, 15:30 (6298)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Janoszka 84 - Kamil Drygas 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229302" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">5 sierpnia, 18:00 (<nobr>16 471</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Konstantin Vassiljev 4, 59 (k), Fedor Černych 44, 51 - Dawid Sołdecki 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229303" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">5 sierpnia, 20:30 (<nobr>14 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Budziński 2, Mateusz Szczepaniak 43 - Patryk Małecki 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229304" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">6 sierpnia, 18:00 (<nobr>13 166</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229305" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">7 sierpnia, 18:00 (<nobr>18 382</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 5 - 13-14 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229306" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">12 sierpnia, 18:00 (<nobr>15 386</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Grzegorz Kuświk 19, 86, Rafał Wolski 37 - Mateusz Możdżeń 40, Elhadji Pape Diaw 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229307" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">13 sierpnia, 15:30 (9507)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marcus Vinícius</i> 14 (k), Rafał Siemaszko 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229308" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">15 sierpnia, 18:00 (7138)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dimityr Ilijew 40</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229309" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">14 sierpnia, 15:30 (4779)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229310" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">12 sierpnia, 20:30 (<nobr>10 724</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jan Bednarek 64, Marcin Robak 78 - Miroslav Čovilo 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229311" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">13 sierpnia, 18:00 (9248)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vojo Ubiparip 80</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 68. minucie Grzegorz Bonin (Górnik Łęczna) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229312" class="main"><b>5-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">13 sierpnia, 20:30 (4292)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Matras 19, Rafał Murawski 46, 90, <i>Ricardo Nunes</i> 71, Kamil Drygas 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229313" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">14 sierpnia, 18:00 (<nobr>12 703</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Zachara 5 - Mariusz Stępiński 25, Paweł Oleksy 55</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 6 - 20-21 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229314" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">19 sierpnia, 20:30 (4595)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229315" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">21 sierpnia, 15:30 (5212)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229316" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">19 sierpnia, 18:00 (6679)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229317" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">22 sierpnia, 18:00 (6754)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jacek Kiełb 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229318" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">21 sierpnia, 18:00 (<nobr>17 100</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Aleksandar Kovačević 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229319" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">20 sierpnia, 20:30 (<nobr>16 529</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kasper Hämäläinen 62 - <i>Marcus Vinícius</i> 6, Adam Marciniak 19, 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229320" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">20 sierpnia, 15:30</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Čovilo 85 - Jakub Arak 45</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229321" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">20 sierpnia, 18:00 (4296)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Seiya Kitano 26, Kamil Drygas 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 7 - 27-28 sierpnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229322" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">26 sierpnia, 18:00 (6912)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dimityr Ilijew 74 - Łukasz Sekulski 60, Radek Dejmek 82</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229323" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">28 sierpnia, 15:30 (<nobr>11 254</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dariusz Formella 73, Maciej Gajos 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229324" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">27 sierpnia, 15:30 (8125)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kort 89 - Mateusz Szczepaniak 9</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229325" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">27 sierpnia, 18:00 (2817)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Fedor Černych 24, Taras Romanczuk 29</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229326" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">27 sierpnia, 20:30 (<nobr>10 002</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Božok 50 - Filip Starzyński 24</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229327" class="main"><b>1-5</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">26 sierpnia, 20:30 (<nobr>13 607</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Mójta 60 (k) - Kamil Biliński 45, Ry&#333;ta Morioka 69, 81, <i>Filipe Gonçalves</i> 71, Ostoja Stjepanović 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229328" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">28 sierpnia, 18:00 (<nobr>17 140</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Flávio Paix&#227;o</i> 88 - Vladislavs Gutkovskis 33, 82</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229329" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">28 sierpnia, 18:00 (9010)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Nemanja Nikolić 39, Rafał Grodzicki 76 (s)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 8 - 10-11 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229330" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">11 września, 15:30 (<nobr>17 247</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Robak 10, 27 (k), Abdul Aziz Tetteh 89 - Łukasz Zwoliński 7</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 63. minucie Łukasz Zwoliński (Pogoń Szczecin) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229331" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">9 września, 20:30 (5194)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ľubomír Guldan 71 - Giorgi Merebaszwili 26, Dominik Kun 29</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 26. minucie Dominik Furman (Wisła Płock) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229332" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">10 września, 18:00 (7356)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Sekulski 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229333" class="main"><b>3-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">10 września, 15:30 (4528)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Pietrowski 2, Radosław Murawski 9 (k), Maciej Jankowski 25 - Grzegorz Piesio 32, Javi Hernández 90, 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229334" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">9 września, 18:00 (8413)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 18</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229335" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">10 września, 20:30 (4555)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vlastimir Jovanović 20 (k), Wojciech Kędziora 84 (k) - Nemanja Nikolić 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229336" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">11 września, 18:00 (<nobr>18 646</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dmytro Chomczenowśkyj 12, Konstantin Vassiljev 73 - Patryk Małecki 85</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 90. minucie Piotr Tomasik (Jagiellonia Białystok) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229337" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">12 września, 18:00 (8384)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ry&#333;ta Morioka 75 (k) - Piotr Ćwielong 38, 52</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 9 - 17-18 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229338" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">17 września, 15:30 (2401)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Grzegorz Bonin 28, 34, Bartosz Śpiączka 55, Slaven Juriša 82</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229339" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">17 września, 18:00 (5620)</td>
+</tr>
+<tr align="left">
+<td colspan="4">José Kanté 78, 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229340" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">18 września, 18:00 (<nobr>14 216</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jakub Czerwiński 49, Steeven Langil 57 - Jarosław Jach 17, Krzysztof Janus 35 (k), Michał Pazdan 71 (s)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 86. minucie Nemanja Nikolić (Legia Warszawa) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229341" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">19 września, 18:00 (9436)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marcus Vinícius</i> 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229342" class="main"><b>0-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">16 września, 20:30 (<nobr>10 715</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Frankowski 9, 18, Konstantin Vassiljev 50, Taras Romanczuk 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229343" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">16 września, 18:00</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vladislavs Gutkovskis 23</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>bez udziału publiczności</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229344" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">18 września, 15:30 (<nobr>26 054</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 38, Maciej Wilusz 87 (s) - Marcin Robak 35</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229345" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">17 września, 20:30 (8483)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Małecki 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 10 - 24-25 września</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229346" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">26 września, 18:00 (4252)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Hebert</i> 90 - Kamil Biliński 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229347" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">23 września, 18:00 (3851)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229348" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">24 września, 20:30 (6134)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Janoszka 24 - Marcin Budziński 31</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229349" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">24 września, 15:30 (4354)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Murawski 50 - Bartosz Śpiączka 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229350" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">24 września, 18:00 (<nobr>15 433</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Sławomir Peszko 5, <i>Flávio Paix&#227;o</i> 13 - Rafał Grodzicki 34 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229351" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">25 września, 15:30 (6979)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miguel Palanca 16 - Przemysław Frankowski 68, Ivan Runje 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229352" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">25 września, 18:00 (<nobr>39 539</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229353" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">23 września, 20:30 (<nobr>19 477</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 83. minucie Denis Popovič (Wisła Kraków) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 11 - 1-2 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229354" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">30 września, 20:30 (7078)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Grzelczak 13 - Maciej Gajos 71, Maciej Makuszewski 90</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229355" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">2 października, 15:30 (8867)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Szczepaniak 15, Krzysztof Piątek 23, 64, Marcin Budziński 34, Miroslav Čovilo 47, Mateusz Wdowiak 87</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229356" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">2 października, 15:30 (7907)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Fryc 23 (s) - Wojciech Kędziora 40 (k), Kornel Osyra 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229357" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">1 października, 18:00 (7558)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dominik Furman 49 (k), Giorgi Merebaszwili 69 - Mateusz Zachara 12, Richárd Guzmics 34, Patryk Małecki 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229358" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">2 października, 18:00 (<nobr>16 850</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229359" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">30 września, 18:00 (5781)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jarosław Niezgoda 8 - Łukasz Janoszka 3, Krzysztof Janus 63 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229360" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">1 października, 20:30 (<nobr>18 941</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Guilherme</i> 49, 58, Nemanja Nikolić 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229361" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">1 października, 15:30 (7658)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marcus Vinícius</i> 53 (k) - Gerard Badía 18, <i>Hebert</i> 88</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 12 - 15-16 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229362" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">15 października, 18:00 (7662)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Tomasz Mokwa 41, Aleksandar Sedlar 86 - Jarosław Niezgoda 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229363" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">17 października, 18:00 (4505)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dani Abalo 83 - Kamil Dankowski 69, Adam Kokoszka 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229364" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">15 października, 20:30 (8317)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Martin Nešpor 49 - Rafał Janicki 5, Grzegorz Kuświk 31</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229365" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">14 października, 20:30 (9328)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Frączczak 7, 40 (k), Rafał Murawski 72 - Miroslav Radović 24, 74</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229366" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">15 października, 15:30 (2558)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229367" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">16 października, 18:00 (<nobr>20 158</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Darko Jevtić 69 - Paweł Brożek 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229368" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">14 października, 18:00 (7443)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jakub Wójcicki 55</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 31. minucie Dominik Furman (Wisła Płock) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229369" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">16 października, 15:30 (4378)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 13 - 22-23 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229370" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">22 października, 15:30 (3529)</td>
+</tr>
+<tr align="left">
+<td colspan="4">José Kanté 88 - Grzegorz Piesio 85, Szymon Drewniak 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229371" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">21 października, 18:00 (6895)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Frączczak 35, 39, Mateusz Matras 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229372" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">23 października, 18:00 (<nobr>10 006</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jacek Góralski 35 - Martin Nešpor 49, Arkadiusz Woźniak 52</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229373" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">22 października, 18:00 (6482)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Peter Grajciar 7, 57 - Miroslav Čovilo 64, Damian Dąbrowski 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229374" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">21 października, 20:30 (<nobr>11 347</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Zdeněk Ondrášek 26, 69 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229375" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">24 października, 18:00 (5365)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jarosław Niezgoda 16, Łukasz Moneta 61, Piotr Ćwielong 77, Paweł Oleksy 85</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229376" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">22 października, 20:30 (<nobr>28 842</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Nemanja Nikolić 64, Kasper Hämäläinen 90 - Marcin Robak 90 (k)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w 90. minucie czerwoną kartką został ukarany rezerwowy zawodnik gości - Jasmin Burić</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229377" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">23 października, 15:30 (<nobr>17 206</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Sławomir Peszko 9, <i>Flávio Paix&#227;o</i> 79 (k), 86 - Uroš Korun 28, Saša Živec 64</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 14 - 29-30 października</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229378" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">28 października, 18:00 (4726)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michał Masłowski 45, Josip Barišić 55 - Patrik Mišák 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229379" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">29 października, 18:00 (8397)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Spas Delew 21, 61 - Jarosław Niezgoda 18</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229380" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">29 października, 15:30 (2606)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ry&#333;ta Morioka 15, Kamil Biliński 21, Peter Grajciar 29</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229381" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">29 października, 20:30 (9591)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kownacki 9, Marcin Robak 88 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229382" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">31 października, 18:00 (6281)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Woźniak 45, 49 - Petar Brlek 14, Jakub Bartosz 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229383" class="main"><b>2-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">28 października, 20:30 (8477)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miguel Palanca 8 (k), Rafał Grzelak 12 - <i>Guilherme</i> 29, Nemanja Nikolić 57, Bartosz Rymaniak 61 (s), Aleksandar Prijović 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229384" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">30 października, 18:00 (<nobr>14 029</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adrian Błąd 65 - <i>Marco Paix&#227;o</i> 32</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229385" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">30 października, 15:30 (7755)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Cetnarski 50 (k) - Konstantin Vassiljev 41 (k), Fedor Černych 73, Przemysław Frankowski 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 15 - 5-6 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229386" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">5 listopada, 15:30 (3972)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vlastimir Jovanović 41 - Radek Dejmek 22, Serhij Pyłypczuk 68, Nabil Aankour 75</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 53. minucie Miguel Palanca (Korona Kielce) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229387" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">6 listopada, 15:30 (<nobr>10 778</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Lasza Dwali 71, <i>Alvarinho</i> 88 - Kamil Dankowski 6 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229388" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">6 listopada, 15:30 (<nobr>10 362</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Boguski 8, 33, 62 - Krzysztof Danielewicz 39, Szymon Drewniak 59 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229389" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">4 listopada, 18:00 (3357)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229390" class="main"><b>0-5</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">4 listopada, 20:30 (7296)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Darko Jevtić 37, Dawid Kownacki 41, Radosław Majewski 59, Marcin Robak 67 (k), Szymon Pawłowski 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229391" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">5 listopada, 20:30 (<nobr>14 461</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Wolski 9 - Adam Frączczak 45 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229392" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">6 listopada, 18:00 (<nobr>24 342</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Nemanja Nikolić 43, Miroslav Radović 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229393" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">5 listopada, 18:00 (8260)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Taras Romanczuk 33, Przemysław Frankowski 89</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 16 - 19-20 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229394" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">20 listopada, 15:30 (1915)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marcus Vinícius</i> 2 (k) - Bartłomiej Babiarz 22, Vladislavs Gutkovskis 29, Dávid Guba 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229395" class="main"><b>0-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">19 listopada, 15:30 (1896)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Ćwielong 10, Adam Pazio 18, Jarosław Niezgoda 61, Jakub Arak 79</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229396" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">18 listopada, 18:00 (4532)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Gerard Badía 79, Sandro Gotal 90 (k) - Miroslav Čovilo 29, Marcin Budziński 90</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został także ukarany rezerwowy zawodnik gości - Mateusz Cetnarski</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229397" class="main"><b>6-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">19 listopada, 18:00 (6935)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ádám Gyurcsó 15, 20, 25, 51, Mateusz Matras 34, <i>Ricardo Nunes</i> 48 - Jakub Bartosz 37, Adam Mójta 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229398" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">21 listopada, 18:00 (4774)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miguel Palanca 25, 40 - Łukasz Piątek 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229399" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">20 listopada, 18:00 (<nobr>15 943</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Darko Jevtić 16, Marcin Robak 66, 74 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229400" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">19 listopada, 20:30 (<nobr>12 921</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Grzegorz Kuświk 59, 81 - Giorgi Merebaszwili 28</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 59. minucie Grzegorz Kuświk (Lechia Gdańsk) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229401" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">18 listopada, 20:30 (<nobr>18 765</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Taras Romanczuk 90 - <i>Guilherme</i> 39, Vadis Odjidja-Ofoe 62, Aleksandar Prijović 90, Michał Kucharczyk 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 17 - 26-27 listopada</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229402" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">25 listopada, 20:30 (8819)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paulus Arajuuri 5, Darko Jevtić 22, Dawid Kownacki 32</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 79. minucie Krzysztof Janus (Zagłębie Lubin) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229403" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">26 listopada, 20:30 (9132)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Boguski 18, 29, 63, Petar Brlek 38, Paweł Brożek 71 - Marcin Warcholak 5</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229404" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">25 listopada, 18:00 (7164)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Szczepaniak 68 - Patrik Mišák 10, 70, Kornel Osyra 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229405" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">26 listopada, 15:30 (5260)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vanja Marković 5, 53, Nabil Aankour 45, 78 - Mateusz Matras 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229406" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">28 listopada, 18:00 (<nobr>11 075</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 25, Rafał Wolski 69, Lukáš Haraslín 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229407" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">27 listopada, 15:30 (3145)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229408" class="main"><b>0-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">27 listopada, 18:00 (<nobr>22 004</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Radović 1, <i>Filipe Gonçalves</i> 5 (s), Aleksandar Prijović 7, 44</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229409" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">26 listopada, 18:00 (6587)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Ćwielong 90 (k) - Fedor Černych 35, Konstantin Vassiljev 44</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 18 - 3-4 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229410" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">3 grudnia, 15:30 (4002)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Gerard Badía 56</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229411" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">5 grudnia, 18:00 (5029)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Lipski 48 - Michał Marcjanik 3, <i>Marcus Vinícius</i> 20 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229412" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">2 grudnia, 18:00 (3011)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Buksa 5</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229413" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">3 grudnia, 20:30 (9607)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Głowacki 5, Rafał Boguski 26, Mateusz Zachara 88</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 64. minucie Marco Paix&#227;o (Lechia Gdańsk) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229414" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">3 grudnia, 18:00 (4001)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Celeban 14 - Adam Frączczak 42 (k)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 36. minucie Kamil Biliński (Śląsk Wrocław) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229415" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">4 grudnia, 15:30 (5432)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Krzysztof Piątek 65 - Miroslav Čovilo 72 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229416" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">4 grudnia, 18:00 (<nobr>10 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Karol Świderski 16, Fedor Černych 64 - Paulus Arajuuri 45</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229417" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">2 grudnia, 20:30 (<nobr>21 821</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Nemanja Nikolić 10, Kasper Hämäläinen 56 - Dominik Furman 63, Kamil Sylwestrzak 78</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 19 - 10-11 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229418" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">10 grudnia, 20:30 (<nobr>28 907</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Petar Brlek 3 - Krzysztof Piątek 71</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229419" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">10 grudnia, 15:30 (1505)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Sasin 52, Szymon Drewniak 63 (k), Piotr Grzelczak 90</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229420" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">9 grudnia, 18:00 (4494)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Frączczak 64 - Adam Buksa 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229421" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">11 grudnia, 15:30 (<nobr>12 025</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kownacki 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229422" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">9 grudnia, 20:30 (<nobr>13 574</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Flávio Paix&#227;o</i> 30, 90, Grzegorz Kuświk 58</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229423" class="main"><b>4-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">10 grudnia, 18:00 (2914)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Wlazło 17, 70 (k), 78, Arkadiusz Reca 36 - Jarosław Niezgoda 24, Patryk Lipski 45, 48</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229424" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">12 grudnia, 18:00 (4058)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Antoni Łukasiewicz 25, Rafał Siemaszko 37 - Fedor Černych 29, <i>Guti</i> 64, Konstantin Vassiljev 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229425" class="main"><b>1-5</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">11 grudnia, 18:00 (8219)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Igor Sapała 90 - Miroslav Radović 32, 73, Nemanja Nikolić 45, 79, Vadis Odjidja-Ofoe 81</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 20 - 17-18 grudnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229426" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">19 grudnia, 18:00 (4121)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Woźniak 44, 56 - Maciej Jankowski 23</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229427" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">16 grudnia, 20:30 (7137)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jarosław Niezgoda 80</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229428" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">16 grudnia, 18:00 (2084)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patrik Mišák 3, Samuel Štefánik 55</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229429" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">18 grudnia, 15:30 (7314)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Siemaszko 57, Michał Marcjanik 60</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229430" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">17 grudnia, 20:30 (8117)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Budziński 44 - Lasse Nielsen 77</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229431" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">17 grudnia, 15:30 (4354)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jacek Kiełb 61, 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229432" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">17 grudnia, 18:00 (8127)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Fedor Černych 58 - Piotr Wlazło 49, Kamil Sylwestrzak 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229433" class="main"><b>5-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">18 grudnia, 18:00 (<nobr>21 901</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Nemanja Nikolić 5, 58, 76, Miroslav Radović 20, Kasper Hämäläinen 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 21 - 11-12 lutego</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229434" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">13 lutego, 18:00 (3882)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Murawski 71, Ádám Gyurcsó 89 (k) - Michal Papadopulos 28</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został ukarany także rezerwowy zawodnik drużyny gospodarzy - Dawid Kort</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229435" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">11 lutego, 18:00 (<nobr>10 511</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Małecki 12, Paweł Brożek 79</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 79. minucie Paweł Brożek (Wisła Kraków) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229436" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">12 lutego, 15:30 (2117)</td>
+</tr>
+<tr align="left">
+<td colspan="4">José Kanté 90 - Róbert Pich 82</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229437" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">7 marca, 18:00 (2443)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Filip Starzyński 6</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin / w pierwotnym terminie (11 lutego, 15:30) odwołany z powodu złego stanu boiska</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229438" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">10 lutego, 18:00 (6179)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Krzysztof Piątek 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229439" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">10 lutego, 20:30 (<nobr>10 453</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kownacki 33 (k), Marcin Robak 89 (k), Darko Jevtić 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229440" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">11 lutego, 20:30 (9154)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Tomasz Jodłowiec 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229441" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">12 lutego, 18:00 (<nobr>15 573</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 11, 70, <i>Flávio Paix&#227;o</i> 84 (k)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 22 - 18-19 lutego</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229442" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">20 lutego, 18:00 (5125)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Filip Starzyński 55 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229443" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">17 lutego, 20:30 (3121)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vladislavs Gutkovskis 90 (k) - Sławomir Peszko 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229444" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">18 lutego, 18:00 (9967)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Joan Román 76</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229445" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">19 lutego, 15:30 (7824)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Krzysztof Piątek 46 - Adam Frączczak 51</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229446" class="main"><b>5-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">17 lutego, 18:00 (5531)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dmytro Chomczenowśkyj 20, Konstantin Vassiljev 29 (k), 55, Taras Romanczuk 52, Fedor Černych 65</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229447" class="main"><b>4-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">18 lutego, 15:30 (5166)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ilijan Micanski 24, Jacek Kiełb 33 (k), 67 (k), Miguel Palanca 50 - Giorgi Merebaszwili 43, José Kanté 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229448" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">18 lutego, 20:30 (3875)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Radosław Majewski 27, 35, Dawid Kownacki 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229449" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">19 lutego, 18:00 (<nobr>17 409</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Radović 84 - Patryk Lipski 14, Maciej Urbańczyk 42, Jarosław Niezgoda 51</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 23 - 25-26 lutego</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229450" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">26 lutego, 15:30 (1401)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Grzelczak 90</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229451" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">25 lutego, 20:30 (<nobr>11 210</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Brożek 21, Patryk Małecki 35, Rafał Boguski 52 - Damian Szymański 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229452" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">25 lutego, 15:30 (3432)</td>
+</tr>
+<tr align="left">
+<td colspan="4">José Kanté 38, Giorgi Merebaszwili 86 - Martin Nešpor 20</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229453" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">24 lutego, 18:00 (5213)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dariusz Formella 36, Mateusz Szwoch 60 (k), Rafał Siemaszko 79, Dominik Hofbauer 90 - Ilijan Micanski 40</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 31. minucie Marcus Vinícius (Arka Gdynia) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229454" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">27 lutego, 18:00 (5557)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miłosz Przybecki 8, Rafał Grodzicki 70 (k)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>od 46. minuty z powodu kontuzji arbitra sędziował Robert Marciniak (Kraków)</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229455" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">24 lutego, 20:30 (8678)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kownacki 3, 36, Marcin Robak 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229456" class="main"><b>4-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">25 lutego, 18:00 (<nobr>13 018</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ariel Borysiuk 45, <i>Flávio Paix&#227;o</i> 47 (k), Grzegorz Kuświk 58, Grzegorz Wojtkowiak 84 - Krzysztof Piątek 15, 70</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został ukarany także rezerwowy zawodnik drużyny gospodarzy - Vanja Milinković-Savić</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229457" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">26 lutego, 18:00 (<nobr>14 163</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Radović 37 - Samuel Štefánik 22</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 24 - 4-5 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229458" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">4 marca, 20:30 (5447)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Gerard Badía 81 - Zdeněk Ondrášek 69, Petar Brlek 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229459" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">4 marca, 15:30 (9255)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jaroslav Mihalík 55 - Przemysław Trytko 42</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229460" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">6 marca, 18:00 (3458)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jarosław Fojut 76 - Przemysław Szymiński 42</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229461" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">3 marca, 18:00 (5475)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jacek Kiełb 88, 90 (k) - Bartosz Śpiączka 50</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229462" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">5 marca, 18:00 (<nobr>31 281</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Radosław Majewski 70</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został ukarany także rezerwowy zawodnik gospodarzy - Lasse Nielsen, a żółtą i w 78. minucie czerwoną kartką rezerwowy zawodnik gości - Vanja Milinković-Savić</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229463" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">3 marca, 20:30 (<nobr>10 892</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Woźniak 56 - Thibault Moulin 36, Maciej Dąbrowski 82, Sebastian Szymański 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229464" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">5 marca, 15:30 (<nobr>10 736</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Frankowski 34, 82, Konstantin Vassiljev 41, Jacek Góralski 59 - Róbert Pich 14</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229465" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">4 marca, 18:00 (3079)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 65. minucie Wojciech Kędziora (Bruk-Bet Termalica Nieciecza) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 25 - 11-12 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229466" class="main"><b>3-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">10 marca, 18:10 (6262)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Aleksandar Kovačević 56, Róbert Pich 58, 86 - Gerard Badía 7, 56, 71, Uroš Korun 47</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>po meczu czerwonymi kartkami zostali ukarani zawodnik gospodarzy - Łukasz Madej i zawodnik gości - Hebert</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229467" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">11 marca, 15:30 (3712)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Szarek 22 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229468" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">11 marca, 18:00 (7002)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Lipski 51, Jarosław Niezgoda 67 - <i>Marco Paix&#227;o</i> 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229469" class="main"><b>1-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">10 marca, 20:30 (<nobr>11 514</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Siemaszko 52 - Maciej Gajos 5, Darko Jevtić 17, Dawid Kownacki 44, Marcin Robak 79</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229470" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">13 marca, 18:00 (6473)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Budziński 68 - Filip Starzyński 12</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229471" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">12 marca, 15:30 (2126)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Grzegorz Bonin 41, Bartosz Śpiączka 53 - Mateusz Matras 32, Spas Delew 44</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229472" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">11 marca, 20:30 (9554)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Frankowski 24, Milan Borjan 34 (s), Fedor Černych 70, 90 - Ilijan Micanski 14</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229473" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">12 marca, 18:00 (<nobr>26 870</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Miroslav Radović 11</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółta kartka Ivána Gonzáleza nie jest wliczana do rejestru kartek jako pokazana niesłusznie</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 26 - 18-19 marca</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229474" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">18 marca, 15:30 (4154)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Martin Bukata 30, Maciej Jankowski 69, Gerard Badía 84 - Mateusz Szwoch 54 (k), Rafał Siemaszko 66</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229475" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">18 marca, 18:00 (5479)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jarosław Niezgoda 67</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229476" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">17 marca, 18:00 (3526)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Artem Putiwcew 18 - Róbert Pich 5, Adam Kokoszka 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229477" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">17 marca, 20:30 (<nobr>12 123</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Petar Brlek 24, Semir Štilić 84, Jakub Bartosz 86 - Siergiej Kriwiec 41, Mateusz Piątkowski 72</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229478" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">18 marca, 20:30 (3486)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229479" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">19 marca, 15:30 (6328)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jakub Żubrowski 33, Maciej Górski 86, Jacek Kiełb 88</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 8. minucie Jacek Kiełb (Korona Kielce) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229480" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">19 marca, 15:30 (<nobr>40 324</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229481" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">19 marca, 18:00 (<nobr>37 220</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mario Maloča 48 - Michał Kucharczyk 58, 87</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 27 - 1-2 kwietnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229482" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">3 kwietnia, 18:00 (7837)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229483" class="main"><b>2-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">1 kwietnia, 15:30 (6621)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dariusz Formella 73, Josip Barišić 88 - Javi Hernández 17, Grzegorz Bonin 36, Bartosz Śpiączka 62, Szymon Drewniak 80</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229484" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">31 marca, 20:30 (<nobr>30 128</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229485" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">31 marca, 18:00 (8229)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Ry&#333;ta Morioka 33 (k), Radek Dejmek 62 (s), Kamil Biliński 80 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229486" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">2 kwietnia, 15:30 (<nobr>14 392</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Cillian Sheridan 79 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229487" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">2 kwietnia, 18:00 (<nobr>16 263</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 27</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229488" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">1 kwietnia, 18:00 (8127)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Siergiej Kriwiec 4, Piotr Wlazło 16 (k), Mateusz Piątkowski 27, 78 - Sebastian Steblecki 11</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229489" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">1 kwietnia, 20:30 (<nobr>22 910</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michał Kucharczyk 63, Vadis Odjidja-Ofoe 77</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 28 - 8-9 kwietnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229490" class="main"><b>3-4</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">7 kwietnia, 20:30 (5182)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Woźniak 15, Łukasz Piątek 61, Łukasz Janoszka 75 - Cillian Sheridan 17, 38 (k), Ivan Runje 78, Arvydas Novikovas 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229491" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">10 kwietnia, 18:00 (7479)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Grodzicki 84 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229492" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">8 kwietnia, 20:30 (4595)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patrik Mišák 14, Artem Putiwcew 51 - Artem Putiwcew 12 (s), Petar Brlek 64, Mateusz Zachara 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229493" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">7 kwietnia, 18:00 (6342)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Polczak 9</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229494" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">8 kwietnia, 15:30 (2614)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Przemysław Pitry 4, Piotr Grzelczak 24 - Paweł Sasin 56 (s), Damian Byrtek 65, Dimityr Ilijew 85</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229495" class="main"><b>5-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">8 kwietnia, 18:00 (4312)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Frączczak 2, 53, Spas Delew 60, Cornel Râpă 63, Michał Marcjanik 90 (s) - Przemysław Trytko 3</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229496" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">9 kwietnia, 15:30 (5974)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Aleksandar Sedlar 10 - Mario Maloča 12</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229497" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">9 kwietnia, 18:00 (<nobr>41 026</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Tomasz Kędziora 82 - Maciej Dąbrowski 88, Kasper Hämäläinen 90</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 29 - 15 kwietnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229498" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">15 kwietnia, 15:30 (6364)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Bartosz Nowak 28 - Dawid Kort 19, Adam Frączczak 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229499" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">17 kwietnia, 18:00 (<nobr>12 411</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Małecki 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229500" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">15 kwietnia, 20:30 (9750)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Robak 25, 35, Radosław Majewski 52</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229501" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">15 kwietnia, 15:30 (7675)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kamil Biliński 16, Róbert Pich 42 - Szymon Drewniak 57, Javi Hernández 81</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229502" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">15 kwietnia, 18:00 (<nobr>10 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółta kartka Ziggy'ego Gordona nie jest wliczana do rejestru kartek jako pokazana niesłusznie</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229503" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">17 kwietnia, 18:00 (<nobr>28 145</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 27, Michał Marcjanik 62 (s) - Dominik Hofbauer 70</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229504" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">17 kwietnia, 15:30 (3012)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Nowak 4</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229505" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">17 kwietnia, 15:30 (<nobr>17 962</nobr>)</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 30 - 22 kwietnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229506" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (8282)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Woźniak 30 - Piotr Celeban 5</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229507" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (<nobr>20 114</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Surma 7 (s), Maciej Gajos 41, Darko Jevtić 62</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229508" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (5903)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Bartosz Śpiączka 22, 90, Grzegorz Bonin 79 - Arkadiusz Głowacki 71</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229509" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (<nobr>11 999</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Nowak 56</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został ukarany także rezerwowy zawodnik drużyny gospodarzy - Bartosz Kwiecień</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229510" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (4439)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Cillian Sheridan 25</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229511" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (5505)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Siemaszko 41 - José Kanté 90 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229512" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (<nobr>12 438</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Damian Dąbrowski 44 (k) - Dominik Nagy 18, Tomáš Necid 49</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1229513" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">22 kwietnia, 18:00 (6961)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Adam Frączczak 11, Dawid Kort 62, 69 - Miloš Krasić 18</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 31 - 29-30 kwietnia</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316042" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">30 kwietnia, 15:30 (<nobr>12 100</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Cillian Sheridan 33</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316043" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">30 kwietnia, 18:00 (<nobr>22 239</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Artur Jędrzejczyk 75 - Petar Brlek 58 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316044" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">28 kwietnia, 20:30 (<nobr>11 192</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Darko Jevtić 17, Marcin Robak 42 (k), 80 (k) - Mateusz Możdżeń 21, Jacek Kiełb 45 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316045" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">29 kwietnia, 20:30 (<nobr>10 095</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Lukáš Haraslín 3, <i>Marco Paix&#227;o</i> 53</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316046" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">29 kwietnia, 15:30 (3414)</td>
+</tr>
+<tr align="left">
+<td colspan="4">José Kanté 50 (k) - Jakub Arak 75</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 77. minucie Giorgi Merebaszwili (Wisła Płock) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316047" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">1 maja, 18:00 (4242)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Martin Nešpor 90, Ľubomír Guldan 90 - Mateusz Szczepaniak 32, Krzysztof Piątek 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316048" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">29 kwietnia, 18:00 (4921)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Bartosz Śpiączka 35, Grzegorz Bonin 59</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316049" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">28 kwietnia, 18:00 (4623)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Szwoch 9 (k) - Maciej Jankowski 88</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>pierwsza żółta kartka Aleksandra Sedlara nie jest wliczana do rejestru kartek jako pokazana niesłusznie</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 32 - 6-7 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316050" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">5 maja, 20:30 (8956)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Serhij Pyłypczuk 47 - Arvydas Novikovas 49</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316051" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">6 maja, 20:30 (<nobr>16 021</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Załuska 58 (s)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316052" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">7 maja, 18:00 (9876)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dominik Nagy 49, Thibault Moulin 68</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 60. minucie Miroslav Radović (Legia Warszawa) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316053" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">7 maja, 15:30 (4595)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mihai Rădu&#539; 15, Vladislavs Gutkovskis 71 (s), Radosław Majewski 73</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316054" class="main"><b>2-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">6 maja, 18:00 (3666)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Grzelczak 6, Vojo Ubiparip 90 - Piotr Wlazło 13 (k), José Kanté 17, Arkadiusz Reca 53</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316055" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">8 maja, 18:00 (6279)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Krzysztof Piątek 44, Damian Dąbrowski 73 (k)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316056" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">5 maja, 18:00 (6319)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Łukasz Moneta 63 - Jakub Tosik 74</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316057" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">6 maja, 15:30 (5118)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Radosław Murawski 38, Saša Živec 58</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 33 - 13-14 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316058" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">13 maja, 15:30 (<nobr>15 117</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Cillian Sheridan 27, Dmytro Chomczenowśkyj 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316059" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">14 maja, 15:30 (<nobr>15 349</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316060" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">14 maja, 18:00 (<nobr>19 765</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kasper Hämäläinen 5, 74, Miroslav Radović 28, Dominik Nagy 52, <i>Guilherme</i> 55 (k), Waleri Kazaiszwili 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316061" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">14 maja, 15:30 (<nobr>15 862</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Marcin Robak 35, Łukasz Trałka 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316062" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">13 maja, 20:30 (4001)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Piotr Wlazło 31 (k) - Sebastian Steblecki 38</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316063" class="main"><b>1-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">12 maja, 20:30 (5623)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Siemaszko 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316064" class="main"><b>3-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">12 maja, 18:00 (3827)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Filip Starzyński 34, Kamil Mazek 55, Arkadiusz Woźniak 90 - Michal Papadopulos 13</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316065" class="main"><b>6-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">13 maja, 18:00 (6685)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kamil Biliński 17, 54, 71, Ry&#333;ta Morioka 50, 82, Piotr Celeban 56</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 34 - 17 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316066" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">17 maja, 18:00 (<nobr>15 025</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 17 (k), 25 (k), 48, Lukáš Haraslín 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316067" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">17 maja, 20:30 (<nobr>28 820</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vadis Odjidja-Ofoe 7, Michał Kucharczyk 83</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316068" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">17 maja, 20:30 (3108)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dawid Kort 76 - Vladislavs Gutkovskis 86</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316069" class="main"><b>3-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">17 maja, 18:30 (9911)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Radek Dejmek 18, Mateusz Możdżeń 54, Jacek Kiełb 58 (k) - Petar Brlek 6, Krzysztof Mączyński 29</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>mecz pierwotnie zaplanowany na 18:00 rozpoczął się z 30-minutowym opóźnieniem z powodu awarii oświetlenia</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316070" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">16 maja, 18:00 (6015)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Arkadiusz Reca 16</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316071" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">16 maja, 20:30 (8109)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Filip Starzyński 15, Łukasz Piątek 54</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316072" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">16 maja, 20:30 (6437)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Paweł Oleksy 72 (s), Gerard Badía 75, <i>Hebert</i> 88</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316073" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">16 maja, 18:00 (4418)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Leândro</i> 50, Adam Dźwigała 77, Bartosz Śpiączka 82</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 35 - 20-21 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316074" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">21 maja, 18:00 (<nobr>22 394</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316075" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">21 maja, 15:30 (<nobr>20 139</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316076" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">20 maja, 20:30 (<nobr>11 588</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Patryk Małecki 18, Paweł Brożek 24, Iván González 32, Rafał Boguski 35</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316077" class="main"><b>0-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">22 maja, 18:00 (3247)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mateusz Możdżeń 11, Bartosz Rymaniak 54</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>druga żółta kartka Rafała Grzelaka nie jest wliczana do rejestru kartek jako pokazana niesłusznie</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316078" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">20 maja, 15:30 (4598)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kamil Sylwestrzak 70 - Jakub Tosik 45, Adam Buksa 61</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316079" class="main"><b>4-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">19 maja, 18:00 (7228)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mariusz Pawelec 34, Róbert Pich 35, Kamil Biliński 41, Mario Engels 60 - Dawid Sołdecki 15</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316080" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">19 maja, 20:30 (8509)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Sebastian Steblecki 2, Krzysztof Piątek 13</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316081" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">20 maja, 18:00 (5007)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Denis Gojko 9, Aleksandar Sedlar 14 - Adam Dźwigała 19</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 36 - 27-28 maja</u></b>
+</td>
+</tr>
+</table>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316082" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td valign="top" nowrap align="left" width="190">28 maja, 18:00 (4017)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Vlastimir Jovanović 71 - Cillian Sheridan 16, 34</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 73. minucie Mateusz Kupczak (Bruk-Bet Termalica Nieciecza) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316083" class="main"><b>2-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td valign="top" nowrap align="left" width="190">28 maja, 18:00 (<nobr>19 373</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Radosław Majewski 9, Maciej Makuszewski 21 - Rafał Boguski 27</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316084" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td valign="top" nowrap align="left" width="190">28 maja, 18:00 (<nobr>15 000</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Dominik Nagy 35</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>żółtą kartką został także ukarany rezerwowy zawodnik gospodarzy - Dani Abalo</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316085" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td valign="top" nowrap align="left" width="190">28 maja, 18:00 (<nobr>20 067</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Marco Paix&#227;o</i> 20, 34, 70 (k), Piotr Wiśniewski 80</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316086" class="main"><b>4-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td valign="top" nowrap align="left" width="190">27 maja, 18:00 (5540)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Saša Živec 49, Maciej Jankowski 65, 80, Martin Bukata 71</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>czerwona kartka José Kanté nie jest wliczana do rejestru kartek jako pokazana niesłusznie</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316087" class="main"><b>2-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td valign="top" nowrap align="left" width="190">27 maja, 18:00 (<nobr>11 867</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Kamil Biliński 13, Ry&#333;ta Morioka 35</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316088" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td valign="top" nowrap align="left" width="190">27 maja, 18:00 (5395)</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>Gérson</i> 16 - Jakub Tosik 40, Wojciech Małecki 88 (s), Jarosław Kubicki 90</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>W 88. minucie Arkadiusz Woźniak (Zagłębie Lubin) nie wykorzystał rzutu karnego.<br>
+</i></td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>w Lublinie; na Arenie Lublin</i></td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316089" class="main"><b>1-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td valign="top" nowrap align="left" width="190">27 maja, 18:00 (9001)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Siemaszko 23 - Łukasz Moneta 4</td>
+</tr>
+</table>
+<a name="last">
+<!-- /76859581/90minut_tabelawyniki_belka_srodek_2 -->
+<div id='90minut_tabelawyniki_belka_srodek_2'>
+</div>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr>
+<td colspan="3">
+<img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+ <b><u>Kolejka 37 - 2-4 czerwca</u></b>
+</td>
+</tr>
+</table>
+</a>
+<p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="1" align="center">
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Jagiellonia Białystok  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316090" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lech Poznań  </b></td>
+<td valign="top" nowrap align="left" width="190">4 czerwca, 18:00 (<nobr>19 084</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Jacek Góralski 77, Arvydas Novikovas 87 - Radosław Majewski 11, Łukasz Trałka 39</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Kraków  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316091" class="main"><b>1-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Bruk-Bet Termalica Nieciecza  </b></td>
+<td valign="top" nowrap align="left" width="190">4 czerwca, 18:00 (<nobr>14 149</nobr>)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Boguski 14 - Wojciech Kędziora 47, Martin Mikovič 90</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Legia Warszawa  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316092" class="main"><b>0-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Lechia Gdańsk  </b></td>
+<td valign="top" nowrap align="left" width="190">4 czerwca, 18:00 (<nobr>28 953</nobr>)</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Pogoń Szczecin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316093" class="main"><b>3-0</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Korona Kielce  </b></td>
+<td valign="top" nowrap align="left" width="190">4 czerwca, 18:00 (2545)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Rafał Murawski 61, 87, Robert Obst 89</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Wisła Płock  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316094" class="main"><b>0-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Śląsk Wrocław  </b></td>
+<td valign="top" nowrap align="left" width="190">2 czerwca, 20:30 (4068)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Mario Engels 9, 58, Kamil Biliński 64</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Cracovia  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316095" class="main"><b>0-1</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Piast Gliwice  </b></td>
+<td valign="top" nowrap align="left" width="190">2 czerwca, 20:30 (7311)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Maciej Jankowski 63</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Zagłębie Lubin  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316096" class="main"><b>1-3</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Arka Gdynia  </b></td>
+<td valign="top" nowrap align="left" width="190">2 czerwca, 20:30 (6921)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Michał Marcjanik 48 (s) - Rafał Siemaszko 19, Dariusz Formella 29, Marcin Warcholak 75</td>
+</tr>
+<tr align="left">
+<td nowrap valign="top" width="180"><b>  Ruch Chorzów  </b></td>
+<td nowrap valign="top" align="center" width="50"><a href="/mecz.php?id_mecz=1316097" class="main"><b>2-2</b></a>
+</td>
+<td nowrap valign="top" width="180"><b>  Górnik Łęczna  </b></td>
+<td valign="top" nowrap align="left" width="190">2 czerwca, 20:30 (5962)</td>
+</tr>
+<tr align="left">
+<td colspan="4">Eduards Viš&#326;akovs 90, Michał Koj 90 - Bartosz Śpiączka 16, Piotr Grzelczak 43</td>
+</tr>
+<tr align="left">
+<td colspan="4"><i>mecz przerwany w 61. minucie na 20 minut z powodu awantur na trybunach</i></td>
+</tr>
+</table>
+
+<div id="wtg-taboola"></div>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+<a class="main" href="/liga/0/liga8695.html">Nice I liga 2016/2017</a>
+</td></tr>
+</table>
+<p align="center"><img src="http://img.90minut.pl/img/line.gif"></p>
+<table class="main" width="600" border="0" cellspacing="0" cellpadding="0" align="center">
+<tr><td><img src="http://img.90minut.pl/img/redarrowl.gif" width="15" height="15" align="absmiddle">
+Autor: Paweł Mogielnicki
+</td></tr>
+</table><br>
+   <p align="center">&nbsp;</p>
+   </td>
+    <td bgcolor="#FFFFFF" width="0" valign="top"></td>
+  </tr>
+  <tr>
+  <td colspan="3" valign="top" width="1090" height="15"><img src="http://img.90minut.pl/belki/footer1090.gif" usemap="#Map_footer" border="0"><map name="Map_footer"><area shape="rect" coords="329,2,411,14" href="/kontakt.html" alt="Napisz do nas"></map></td>
+  </tr>
+</table>
+<script type="text/javascript" src="https://lib.wtg-ads.com/publisher/www.90minut.pl/lib.min.js" async></script>
+</body>
+</html>

--- a/internal/site/testdata/manifest.json
+++ b/internal/site/testdata/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "sha256:cf427f8e4a0a8553cecbad69de680de5bcc35ecec270990c8e53b193171e2f3b",
+  "generated_at": "sha256:74405c99489c4b38bd7d6f1513c14db73b9ff36759e01bdd6f70924b0f1c756b",
   "source": "http://www.90minut.pl/archsezon.php",
   "fixtures": [
     {
@@ -60,6 +60,62 @@
       "season": "2025/26",
       "file": "fixtures/league_14141.html",
       "note": "current women league page without match links; fixtures stay valid with empty MatchURL and MatchID"
+    },
+    {
+      "name": "league_14077",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga14077.html",
+      "season": "2025/26",
+      "file": "fixtures/league_14077.html",
+      "note": "Champions League league-phase format: qualifiers, league phase, knockouts"
+    },
+    {
+      "name": "league_12909",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga12909.html",
+      "season": "2023/24",
+      "file": "fixtures/league_12909.html",
+      "note": "Champions League group-stage format with repeated matchdays per group"
+    },
+    {
+      "name": "league_14152",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga14152.html",
+      "season": "2025/26",
+      "file": "fixtures/league_14152.html",
+      "note": "Futsal Champions League multi-group format with repeated matchdays and source-order group sections"
+    },
+    {
+      "name": "league_13459",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga13459.html",
+      "season": "2023/24",
+      "file": "fixtures/league_13459.html",
+      "note": "Euro tournament groups with fixture-row dates rather than heading dates"
+    },
+    {
+      "name": "league_14042",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga14042.html",
+      "season": "2025/26",
+      "file": "fixtures/league_14042.html",
+      "note": "World Cup qualifying page with unsectioned and grouped matchdays"
+    },
+    {
+      "name": "league_10529",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/1/liga10529.html",
+      "season": "2018/19",
+      "file": "fixtures/league_10529.html",
+      "note": "Futsal cup with underlined fixture/team labels inside knockout rounds; team labels must not become sections"
+    },
+    {
+      "name": "league_8694",
+      "kind": "league",
+      "url": "http://www.90minut.pl/liga/0/liga8694.html",
+      "season": "2016/17",
+      "file": "fixtures/league_8694.html",
+      "note": "Older Ekstraklasa continuous split-season matchdays"
     },
     {
       "name": "league_liga11233",

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -86,12 +86,29 @@ func barLine(left, right string, width int) string {
 }
 
 func topBarRoundMeta(round site.Round, roundIdx, total int, leagueTitle string) string {
-	label := displayRoundLabelWithFixtures(round.Name, roundIdx, round.Fixtures, leagueTitle)
+	label := displayRoundLabelForRound(round, roundIdx, leagueTitle)
 	roundPart, datePart, ok := strings.Cut(label, " - ")
 	if !ok || strings.TrimSpace(datePart) == "" {
 		return fmt.Sprintf("%s / %d", label, total)
 	}
 	return fmt.Sprintf("%s · %s / %d", roundPart, strings.TrimSpace(datePart), total)
+}
+
+func displayRoundLabelForRound(round site.Round, fallback int, leagueTitle string) string {
+	label := displayRoundLabelWithFixtures(round.Name, fallback, round.Fixtures, leagueTitle)
+	section := displayRoundSection(round.Section)
+	if section == "" {
+		return label
+	}
+	return section + " · " + label
+}
+
+func displayRoundSection(section string) string {
+	cleaned := normalizeDisplayText(section)
+	if cleaned == "" {
+		return ""
+	}
+	return translatePolishDateText(cleaned)
 }
 
 func (m Model) statusBarView() string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -160,6 +160,21 @@ func TestTopBarRoundMetaShowsSingleFixtureDate(t *testing.T) {
 	}
 }
 
+func TestTopBarRoundMetaShowsRoundSection(t *testing.T) {
+	round := site.Round{
+		Section: "Grupa A",
+		Name:    "Kolejka 1",
+		Fixtures: []site.Fixture{
+			{Home: "A", Away: "B", WhenInfo: "14 czerwca 2024, 21:00"},
+		},
+	}
+
+	got := topBarRoundMeta(round, 1, 12, "Mistrzostwa Europy - Niemcy 2024")
+	if got != "Grupa A · Round 1 · Jun 14 / 12" {
+		t.Fatalf("unexpected round meta: %q", got)
+	}
+}
+
 func TestTopBarRoundMetaShowsCrossMonthFixtureDateSpan(t *testing.T) {
 	round := site.Round{
 		Name: "3. kolejka - 30 kwietnia",


### PR DESCRIPTION
## Summary
- add stage and section metadata to parsed rounds so grouped/staged competitions keep source semantics
- preserve source order for qualification/group/knockout flows while keeping numeric ordering for plain leagues
- show section context in the top bar for repeated matchdays like Grupa A / Kolejka 1
- add regression fixtures covering Champions League, Euro, World Cup qualifying, futsal, and older Ekstraklasa formats

## Verification
- go test ./...

Closes #60