### PR TITLE
Fix selector season refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ go run ./cmd/90minutui
 - `h/l` previous/next round; in selector, switch season/competition pane
 - `enter` open selected season, competition, league, or match
 - `esc` close match view, back out of submenus, or toggle the selector
-- `tab` switch selector focus
+- `tab` open selector, or switch selector focus when already open
 - `pgup`/`pgdn`, `ctrl+u`/`ctrl+d` scroll match details
 - `r` reload
 - `q` quit

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ go run ./cmd/90minutui
 
 ## Controls
 
-- `j/k` move selection; in match view, previous/next fixture
-- `h/l` previous/next round
+- `j/k` move selection; in season selector, updates competitions for that season
+- `h/l` previous/next round; in selector, switch season/competition pane
 - `enter` open selected season, competition, league, or match
 - `esc` close match view, back out of submenus, or toggle the selector
 - `tab` switch selector focus

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -12,7 +12,7 @@ import (
 
 // cmdTimeout is generous enough for slow archive pages without blocking the TUI indefinitely.
 const cmdTimeout = 20 * time.Second
-const selectorSeasonLoadDelay = 150 * time.Millisecond
+const selectorSeasonLoadDelay = 300 * time.Millisecond
 
 func (m Model) loadArchiveCmd(url string) tea.Cmd {
 	return func() tea.Msg {

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -22,12 +22,13 @@ func (m Model) loadArchiveCmd(url string) tea.Cmd {
 	}
 }
 
-func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string) tea.Cmd {
+// selectorOnly refreshes the selector list without auto-loading a competition or closing the selector.
+func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string, selectorOnly bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
 		_, _, competitions, err := m.service.LoadArchive(ctx, url)
-		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, err: err}
+		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, selectorOnly: selectorOnly, err: err}
 	}
 }
 

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -12,6 +12,7 @@ import (
 
 // cmdTimeout is generous enough for slow archive pages without blocking the TUI indefinitely.
 const cmdTimeout = 20 * time.Second
+const selectorSeasonLoadDelay = 150 * time.Millisecond
 
 func (m Model) loadArchiveCmd(url string) tea.Cmd {
 	return func() tea.Msg {
@@ -30,6 +31,12 @@ func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string, selectorOnly boo
 		_, _, competitions, err := m.service.LoadArchive(ctx, url)
 		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, selectorOnly: selectorOnly, err: err}
 	}
+}
+
+func (m Model) settleSeasonSelectionCmd(url, seasonKey string) tea.Cmd {
+	return tea.Tick(selectorSeasonLoadDelay, func(time.Time) tea.Msg {
+		return seasonSelectionSettledMsg{seasonKey: seasonKey, seasonURL: url}
+	})
 }
 
 func (m Model) loadCompetitionCmd(url, competitionKey string) tea.Cmd {

--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -822,6 +822,30 @@ func TestSelectorLeftRightSwitchesSeasonAndCompetitionFocus(t *testing.T) {
 	}
 }
 
+func TestTabOpensSelectorFromFixturesAndMatchViews(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyTab))
+	if cmd != nil {
+		t.Fatalf("expected tab to open selector without command")
+	}
+	if !m.selectorVisible || m.focus != focusCompetitions {
+		t.Fatalf("expected tab to open selector from fixtures, focus=%v selector=%v", m.focus, m.selectorVisible)
+	}
+
+	m.closeSelector()
+	m.matchView = true
+	m.match = loader.match
+	m, cmd = updateModelWithMsg(t, m, testKey(tea.KeyTab))
+	if cmd != nil {
+		t.Fatalf("expected tab to open selector from match view without command")
+	}
+	if !m.selectorVisible || m.focus != focusCompetitions || !m.matchView {
+		t.Fatalf("expected tab to overlay selector on match view, focus=%v selector=%v match=%v", m.focus, m.selectorVisible, m.matchView)
+	}
+}
+
 func TestSelectorSeasonMoveRefreshesCompetitionsInPlace(t *testing.T) {
 	loader := newRecordingLoader()
 	season2024 := site.Season{Label: "2024/2025", URL: "http://www.90minut.pl/archsezon.php?id_sezon=105", SeasonID: "105"}
@@ -838,10 +862,18 @@ func TestSelectorSeasonMoveRefreshesCompetitionsInPlace(t *testing.T) {
 
 	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyDown))
 	if cmd == nil {
-		t.Fatalf("expected season cursor move to load competitions")
+		t.Fatalf("expected season cursor move to schedule delayed competition load")
 	}
-	if !m.loading || m.focus != focusSeasons || !m.selectorVisible {
-		t.Fatalf("expected in-place selector loading state, loading=%v focus=%v selector=%v", m.loading, m.focus, m.selectorVisible)
+	if m.loading || m.focus != focusSeasons || !m.selectorVisible || len(m.competitions) != 1 {
+		t.Fatalf("expected delayed selector refresh without immediate load, loading=%v focus=%v selector=%v competitions=%+v", m.loading, m.focus, m.selectorVisible, m.competitions)
+	}
+
+	m, cmd = updateModelWithMsg(t, m, seasonSelectionSettledMsg{seasonKey: seasonRequestKey(season2025), seasonURL: season2025.URL})
+	if cmd == nil {
+		t.Fatalf("expected settled season to load competitions")
+	}
+	if !m.loading || len(m.competitions) != 0 {
+		t.Fatalf("expected settled season to enter loading state and clear stale competitions, loading=%v competitions=%+v", m.loading, m.competitions)
 	}
 
 	m, cmd = updateModelWithMsg(t, m, cmd())
@@ -871,11 +903,22 @@ func TestStaleSeasonCompetitionResultsDoNotOverwriteCurrentSelectorLoad(t *testi
 
 	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyDown))
 	if cmd == nil {
-		t.Fatalf("expected selected season load command")
+		t.Fatalf("expected selected season settle command")
+	}
+	m, staleCmd := updateModelWithMsg(t, m, seasonSelectionSettledMsg{seasonKey: seasonRequestKey(season2024), seasonURL: season2024.URL})
+	if staleCmd != nil {
+		t.Fatalf("expected stale settle message to be ignored without command")
+	}
+	if m.loading || len(m.competitions) != 1 {
+		t.Fatalf("stale settle changed selector before current load: loading=%v competitions=%+v", m.loading, m.competitions)
+	}
+	m, cmd = updateModelWithMsg(t, m, seasonSelectionSettledMsg{seasonKey: seasonRequestKey(season2025), seasonURL: season2025.URL})
+	if cmd == nil {
+		t.Fatalf("expected current settle message to start load")
 	}
 
 	staleKey := seasonRequestKey(season2024)
-	m, staleCmd := updateModelWithMsg(t, m, competitionsLoadedMsg{
+	m, staleCmd = updateModelWithMsg(t, m, competitionsLoadedMsg{
 		seasonKey:    staleKey,
 		competitions: []site.Competition{{Name: "Stale league"}},
 		selectorOnly: true,

--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -29,19 +30,23 @@ type recordingLoader struct {
 	menuCalls    int
 	matchCalls   int
 
-	seasons      []site.Season
-	selectedIdx  int
-	competitions []site.Competition
-	menus        map[string]*site.CompetitionMenu
-	league       *site.LeaguePage
-	match        *site.MatchPage
+	seasons             []site.Season
+	selectedIdx         int
+	competitions        []site.Competition
+	archiveCompetitions map[string][]site.Competition
+	menus               map[string]*site.CompetitionMenu
+	league              *site.LeaguePage
+	match               *site.MatchPage
 
 	// compErr, when non-nil, is returned by LoadCompetition instead of the league.
 	compErr error
 }
 
-func (l *recordingLoader) LoadArchive(context.Context, string) ([]site.Season, int, []site.Competition, error) {
+func (l *recordingLoader) LoadArchive(_ context.Context, rawURL string) ([]site.Season, int, []site.Competition, error) {
 	l.archiveCalls++
+	if competitions, ok := l.archiveCompetitions[strings.TrimSpace(rawURL)]; ok {
+		return l.seasons, l.selectedIdx, competitions, nil
+	}
 	return l.seasons, l.selectedIdx, l.competitions, nil
 }
 
@@ -792,6 +797,135 @@ func TestToggleFocusCyclesBetweenSeasonsAndCompetitions(t *testing.T) {
 	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyTab))
 	if m.focus != focusCompetitions {
 		t.Fatalf("expected competitions focus after second tab, got %v", m.focus)
+	}
+}
+
+func TestSelectorLeftRightSwitchesSeasonAndCompetitionFocus(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+	if cmd != nil {
+		t.Fatalf("expected focus switch without command")
+	}
+	if m.focus != focusSeasons {
+		t.Fatalf("expected left to focus seasons, got %v", m.focus)
+	}
+
+	m, cmd = updateModelWithMsg(t, m, testKey(tea.KeyRight))
+	if cmd != nil {
+		t.Fatalf("expected focus switch without command")
+	}
+	if m.focus != focusCompetitions {
+		t.Fatalf("expected right to focus competitions, got %v", m.focus)
+	}
+}
+
+func TestSelectorSeasonMoveRefreshesCompetitionsInPlace(t *testing.T) {
+	loader := newRecordingLoader()
+	season2024 := site.Season{Label: "2024/2025", URL: "http://www.90minut.pl/archsezon.php?id_sezon=105", SeasonID: "105"}
+	season2025 := site.Season{Label: "2025/2026", URL: "http://www.90minut.pl/archsezon.php?id_sezon=107", SeasonID: "107", Current: true}
+	loader.seasons = []site.Season{season2024, season2025}
+	loader.selectedIdx = 0
+	loader.competitions = []site.Competition{{Name: "Ekstraklasa 2024/2025", URL: "http://www.90minut.pl/liga/1/liga13482.html", LeagueKey: "liga13482"}}
+	loader.archiveCompetitions = map[string][]site.Competition{
+		season2025.URL: []site.Competition{{Name: "Ekstraklasa 2025/2026", URL: "http://www.90minut.pl/liga/1/liga14072.html", LeagueKey: "liga14072"}},
+	}
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyDown))
+	if cmd == nil {
+		t.Fatalf("expected season cursor move to load competitions")
+	}
+	if !m.loading || m.focus != focusSeasons || !m.selectorVisible {
+		t.Fatalf("expected in-place selector loading state, loading=%v focus=%v selector=%v", m.loading, m.focus, m.selectorVisible)
+	}
+
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd != nil {
+		t.Fatalf("expected selector-only competition load to settle without league load")
+	}
+	if !m.selectorVisible || m.focus != focusSeasons {
+		t.Fatalf("expected selector to stay on seasons, focus=%v selector=%v", m.focus, m.selectorVisible)
+	}
+	if len(m.competitions) != 1 || m.competitions[0].Name != "Ekstraklasa 2025/2026" {
+		t.Fatalf("expected competitions from selected season, got %+v", m.competitions)
+	}
+	if loader.leagueCalls != 1 {
+		t.Fatalf("season cursor refresh should not auto-load a league, got %d league calls", loader.leagueCalls)
+	}
+}
+
+func TestStaleSeasonCompetitionResultsDoNotOverwriteCurrentSelectorLoad(t *testing.T) {
+	loader := newRecordingLoader()
+	season2024 := site.Season{Label: "2024/2025", URL: "http://www.90minut.pl/archsezon.php?id_sezon=105", SeasonID: "105"}
+	season2025 := site.Season{Label: "2025/2026", URL: "http://www.90minut.pl/archsezon.php?id_sezon=107", SeasonID: "107", Current: true}
+	loader.seasons = []site.Season{season2024, season2025}
+	loader.selectedIdx = 0
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyDown))
+	if cmd == nil {
+		t.Fatalf("expected selected season load command")
+	}
+
+	staleKey := seasonRequestKey(season2024)
+	m, staleCmd := updateModelWithMsg(t, m, competitionsLoadedMsg{
+		seasonKey:    staleKey,
+		competitions: []site.Competition{{Name: "Stale league"}},
+		selectorOnly: true,
+	})
+	if staleCmd != nil {
+		t.Fatalf("expected stale success to be ignored without command")
+	}
+	m, staleCmd = updateModelWithMsg(t, m, competitionsLoadedMsg{
+		seasonKey:    staleKey,
+		selectorOnly: true,
+		err:          errors.New("stale season failed"),
+	})
+	if staleCmd != nil {
+		t.Fatalf("expected stale error to be ignored without command")
+	}
+	if !m.loading || m.err != "" || len(m.competitions) != 0 {
+		t.Fatalf("stale result changed active selector load: loading=%v err=%q competitions=%+v", m.loading, m.err, m.competitions)
+	}
+}
+
+func TestSelectorSeasonEnterLoadsFirstCompetition(t *testing.T) {
+	loader := newRecordingLoader()
+	season2024 := site.Season{Label: "2024/2025", URL: "http://www.90minut.pl/archsezon.php?id_sezon=105", SeasonID: "105"}
+	season2025 := site.Season{Label: "2025/2026", URL: "http://www.90minut.pl/archsezon.php?id_sezon=107", SeasonID: "107", Current: true}
+	loader.seasons = []site.Season{season2024, season2025}
+	loader.selectedIdx = 1
+	loader.archiveCompetitions = map[string][]site.Competition{
+		season2025.URL: []site.Competition{{Name: "Ekstraklasa 2025/2026", URL: "http://www.90minut.pl/liga/1/liga14072.html", LeagueKey: "liga14072"}},
+	}
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyEnter))
+	if cmd == nil {
+		t.Fatalf("expected season enter to load competitions")
+	}
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd == nil {
+		t.Fatalf("expected season competition load to schedule first competition load")
+	}
+	m, cmd = updateModelWithMsg(t, m, cmd())
+	if cmd != nil {
+		t.Fatalf("expected first competition load to settle")
+	}
+	if m.selectorVisible {
+		t.Fatalf("expected season enter flow to close selector after league load")
+	}
+	if loader.leagueCalls != 2 {
+		t.Fatalf("expected startup plus selected season league load, got %d", loader.leagueCalls)
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -43,6 +43,11 @@ type competitionsLoadedMsg struct {
 	err          error
 }
 
+type seasonSelectionSettledMsg struct {
+	seasonKey string
+	seasonURL string
+}
+
 type competitionMenuLoadedMsg struct {
 	competitionKey string
 	menu           *site.CompetitionMenu

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -39,6 +39,7 @@ type archiveLoadedMsg struct {
 type competitionsLoadedMsg struct {
 	seasonKey    string
 	competitions []site.Competition
+	selectorOnly bool
 	err          error
 }
 

--- a/internal/ui/render_helpers.go
+++ b/internal/ui/render_helpers.go
@@ -58,7 +58,7 @@ func renderSeasonsWindow(seasons []site.Season, cursor int) []string {
 	start, end := windowBounds(len(seasons), cursor, 10)
 	lines := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		lines = append(lines, seasons[i].Label)
+		lines = append(lines, normalizeDisplayText(seasons[i].Label))
 	}
 
 	return lines

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -44,21 +44,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.matchView {
 				return m, m.moveMatchFixture(-1)
 			}
-			m.moveCursor(-1)
-			return m, nil
+			return m, m.moveCursor(-1)
 		case "down", "j":
 			if m.matchView {
 				return m, m.moveMatchFixture(1)
 			}
-			m.moveCursor(1)
-			return m, nil
+			return m, m.moveCursor(1)
 		case "left", "h":
+			if m.selectorActive() {
+				m.focus = focusSeasons
+				return m, nil
+			}
 			if m.matchView {
 				return m, m.moveMatchRound(-1)
 			}
 			m.shiftRound(-1)
 			return m, nil
 		case "right", "l":
+			if m.selectorActive() {
+				m.focus = focusCompetitions
+				return m, nil
+			}
 			if m.matchView {
 				return m, m.moveMatchRound(1)
 			}
@@ -117,16 +123,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
 
 	case competitionsLoadedMsg:
+		season := m.currentSeason()
+		// Drop stale async results after the selected season changes.
+		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
+			return m, nil
+		}
+
 		m.loading = false
 		if msg.err != nil {
 			m.err = msg.err.Error()
 			m.openSelector()
-			return m, nil
-		}
-
-		season := m.currentSeason()
-		// Drop stale async results after the selected season changes.
-		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
 			return m, nil
 		}
 
@@ -136,6 +142,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.matchView = false
 		m.match = nil
 		m.matchScroll = 0
+		if msg.selectorOnly {
+			m.openSelector()
+			return m, nil
+		}
 
 		if len(m.competitions) == 0 {
 			m.openSelector()
@@ -231,22 +241,42 @@ func (m *Model) toggleFocus() {
 	}
 }
 
-func (m *Model) moveCursor(delta int) {
+func (m *Model) moveCursor(delta int) tea.Cmd {
 	if !m.selectorActive() {
 		round := m.currentRound()
 		if round == nil {
-			return
+			return nil
 		}
 		m.fixtureCursor = clamp(m.fixtureCursor+delta, 0, len(round.Fixtures)-1)
-		return
+		return nil
 	}
 
 	switch m.focus {
 	case focusSeasons:
-		m.seasonCursor = clamp(m.seasonCursor+delta, 0, len(m.seasons)-1)
+		if len(m.seasons) == 0 {
+			return nil
+		}
+		next := clamp(m.seasonCursor+delta, 0, len(m.seasons)-1)
+		if next == m.seasonCursor {
+			return nil
+		}
+		m.seasonCursor = next
+		m.loading = true
+		m.err = ""
+		m.competitionTitle = "Competitions"
+		m.competitions = nil
+		m.competitionCursor = 0
+		m.competitionStack = nil
+		season := m.currentSeason()
+		if season == nil {
+			m.loading = false
+			return nil
+		}
+		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), true)
 	case focusCompetitions:
 		m.competitionCursor = clamp(m.competitionCursor+delta, 0, len(m.competitions)-1)
 	}
+	return nil
 }
 
 func (m *Model) shiftRound(delta int) {
@@ -310,7 +340,7 @@ func (m *Model) handleEnter() tea.Cmd {
 				m.loading = false
 				return nil
 			}
-			return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season))
+			return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), false)
 
 		case focusCompetitions:
 			if len(m.competitions) == 0 {
@@ -384,7 +414,7 @@ func (m *Model) handleReload() tea.Cmd {
 			m.loading = false
 			return nil
 		}
-		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season))
+		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), false)
 	}
 
 	competition := m.currentCompetition()
@@ -394,7 +424,7 @@ func (m *Model) handleReload() tea.Cmd {
 			m.loading = false
 			return nil
 		}
-		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season))
+		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), false)
 	}
 
 	m.matchView = false

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -32,6 +32,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "tab":
+			if !m.selectorActive() {
+				m.openSelector()
+				return m, nil
+			}
 			m.toggleFocus()
 			return m, nil
 		case "pgup", "ctrl+u":
@@ -220,6 +224,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.match = msg.match
 		m.matchScroll = 0
 		return m, nil
+
+	case seasonSelectionSettledMsg:
+		season := m.currentSeason()
+		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
+			return m, nil
+		}
+		m.loading = true
+		m.err = ""
+		m.competitionTitle = "Competitions"
+		m.competitions = nil
+		m.competitionCursor = 0
+		m.competitionStack = nil
+		return m, m.loadSeasonCompetitionsCmd(msg.seasonURL, msg.seasonKey, true)
 	}
 
 	return m, nil
@@ -261,18 +278,12 @@ func (m *Model) moveCursor(delta int) tea.Cmd {
 			return nil
 		}
 		m.seasonCursor = next
-		m.loading = true
 		m.err = ""
-		m.competitionTitle = "Competitions"
-		m.competitions = nil
-		m.competitionCursor = 0
-		m.competitionStack = nil
 		season := m.currentSeason()
 		if season == nil {
-			m.loading = false
 			return nil
 		}
-		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), true)
+		return m.settleSeasonSelectionCmd(season.URL, seasonRequestKey(*season))
 	case focusCompetitions:
 		m.competitionCursor = clamp(m.competitionCursor+delta, 0, len(m.competitions)-1)
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -116,7 +116,7 @@ func (m Model) statusBarView() string {
 
 	switch {
 	case m.selectorActive():
-		parts = []statusBarItem{{"j/k", "move"}, {"tab", "focus"}, {"enter", "load"}}
+		parts = []statusBarItem{{"j/k", "move"}, {"h/l", "pane"}, {"enter", "load"}}
 		if len(m.competitionStack) > 0 {
 			parts[2] = statusBarItem{"enter", "open"}
 			parts = append(parts, statusBarItem{"esc", "back"})
@@ -217,7 +217,7 @@ func selectorCompetitionWidthLines(items []site.Competition) []string {
 
 	lines := make([]string, 0, len(items))
 	for _, item := range items {
-		lines = append(lines, item.Name)
+		lines = append(lines, normalizeDisplayText(item.Name))
 	}
 	return lines
 }

--- a/internal/ui/view_selector.go
+++ b/internal/ui/view_selector.go
@@ -129,7 +129,7 @@ func (m Model) selectorPopupView(width int) string {
 }
 
 func selectorRightHeading(title string) string {
-	cleaned := strings.TrimSpace(title)
+	cleaned := normalizeDisplayText(title)
 	if cleaned == "" || strings.EqualFold(cleaned, "Competitions") {
 		return "COMPETITIONS"
 	}
@@ -143,7 +143,7 @@ func selectorSeasonRows(seasons []site.Season, cursor int) []string {
 	start, end := windowBounds(len(seasons), cursor, 10)
 	rows := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		rows = append(rows, seasons[i].Label)
+		rows = append(rows, normalizeDisplayText(seasons[i].Label))
 	}
 	return rows
 }
@@ -155,14 +155,14 @@ func selectorCompetitionRows(items []site.Competition, cursor int) []string {
 	start, end := windowBounds(len(items), cursor, 18)
 	rows := make([]string, 0, end-start)
 	for i := start; i < end; i++ {
-		rows = append(rows, items[i].Name)
+		rows = append(rows, normalizeDisplayText(items[i].Name))
 	}
 	return rows
 }
 
 func selectorModalPane(width int, heading string, rows []string, cursor, visibleRows int, focused bool) string {
 	var b strings.Builder
-	b.WriteString(renderFullLine(" "+truncate(heading, max(1, width-1)), width, colorBgHeader, colorAccent, true))
+	b.WriteString(renderFullLine(" "+truncate(normalizeDisplayText(heading), max(1, width-1)), width, colorBgHeader, colorAccent, true))
 	for i := range visibleRows {
 		b.WriteString("\n")
 		row := ""
@@ -184,7 +184,7 @@ func selectorModalRow(text string, selected, focused bool, width int) string {
 		fg = colorAccent
 		bar = "▌ "
 	}
-	return renderFullLine(bar+truncate(text, max(1, width-2)), width, bg, fg, selected)
+	return renderFullLine(bar+truncate(normalizeDisplayText(text), max(1, width-2)), width, bg, fg, selected)
 }
 
 func selectorModalDivider(height int) string {

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1411,6 +1411,33 @@ func TestSelectorPopupWidthDoesNotDependOnCurrentScrollWindow(t *testing.T) {
 	}
 }
 
+func TestSelectorPopupNormalizesNewlinesInLeagueNames(t *testing.T) {
+	m := sketchModel()
+	m.focus = focusCompetitions
+	m.seasons = []site.Season{{Label: "2025 /\n2026"}}
+	m.competitionTitle = "Women\r\nLeagues"
+	m.competitions = []site.Competition{{
+		Name: "V liga kobiet 2025/2026\ngrupa: małopolska",
+	}}
+
+	plain := ansi.Strip(m.selectorPopupView(80))
+	if strings.Contains(plain, "2025/2026\ngrupa") || strings.Contains(plain, "2025 /\n2026") || strings.Contains(plain, "Women\r\nLeagues") {
+		t.Fatalf("expected embedded newline to be normalized\n%s", plain)
+	}
+	if !strings.Contains(plain, "2025 / 2026") {
+		t.Fatalf("expected normalized season label in one row\n%s", plain)
+	}
+	if !strings.Contains(plain, "WOMEN LEAGUES") {
+		t.Fatalf("expected normalized selector heading in one row\n%s", plain)
+	}
+	if !strings.Contains(plain, "V liga kobiet 2025/2026 grupa") {
+		t.Fatalf("expected normalized league name in one row\n%s", plain)
+	}
+	if got := selectorCompetitionWidthLines(m.competitions); len(got) != 1 || got[0] != "V liga kobiet 2025/2026 grupa: małopolska" {
+		t.Fatalf("expected width lines to normalize league names, got %+v", got)
+	}
+}
+
 func TestOverlayLinePreservesContentOutsidePopup(t *testing.T) {
 	got := overlayLine("left-center-right", "     POPUP", 5)
 	if !strings.HasPrefix(got, "left-") {


### PR DESCRIPTION
## Summary
- make h/l switch selector focus between seasons and competitions
- refresh competitions in-place when moving the season cursor without auto-loading a league
- ignore stale season competition results before mutating loading/error state
- normalize selector labels/headings so long names with embedded newlines do not bleed across panes
- update README controls and regression coverage

## Verification
- go test ./...
- git diff --check