### PR TITLE
Fix selector modal wrapping

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -197,13 +197,13 @@ func selectorPopupWidth(total int, seasonLines []string, rightHeading string, co
 func selectorContentWidths(seasonLines []string, rightHeading string, competitionLines []string) (int, int) {
 	seasonWidth := lipgloss.Width("SEASON")
 	for _, line := range seasonLines {
-		seasonWidth = max(seasonWidth, lipgloss.Width(line))
+		seasonWidth = max(seasonWidth, lipgloss.Width(normalizeDisplayText(line)))
 	}
 	leftWidth := clamp(seasonWidth+4, 18, 18)
 
-	rightWidth := lipgloss.Width(rightHeading)
+	rightWidth := lipgloss.Width(normalizeDisplayText(rightHeading))
 	for _, line := range competitionLines {
-		rightWidth = max(rightWidth, lipgloss.Width(line))
+		rightWidth = max(rightWidth, lipgloss.Width(normalizeDisplayText(line)))
 	}
 	rightWidth = max(16, rightWidth+1)
 

--- a/internal/ui/view_selector.go
+++ b/internal/ui/view_selector.go
@@ -48,10 +48,7 @@ func (m Model) selectorSketchView() string {
 
 func (m Model) selectorOverlayView(body string) string {
 	seasonLines := renderSeasonsWindow(m.seasons, m.seasonCursor)
-	rightHeading := "Leagues"
-	if strings.TrimSpace(m.competitionTitle) != "" {
-		rightHeading = m.competitionTitle
-	}
+	rightHeading := selectorRightHeading(m.competitionTitle)
 	competitionLines := selectorCompetitionWidthLines(m.competitions)
 	popup := m.selectorPopupView(selectorPopupWidth(m.width, seasonLines, rightHeading, competitionLines))
 	bodyLines := strings.Split(body, "\n")
@@ -120,7 +117,8 @@ func (m Model) selectorPopupView(width int) string {
 	}
 
 	panel := lipgloss.NewStyle().
-		Width(innerWidth).
+		// Tiny terminals already use the full-screen overlay path; keep a minimum useful modal width.
+		Width(max(26, width)).
 		Border(lipgloss.NormalBorder()).
 		BorderForeground(colorBorderStrong).
 		Background(colorBgModal)

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1417,10 +1417,11 @@ func TestSelectorPopupNormalizesNewlinesInLeagueNames(t *testing.T) {
 	m.seasons = []site.Season{{Label: "2025 /\n2026"}}
 	m.competitionTitle = "Women\r\nLeagues"
 	m.competitions = []site.Competition{{
-		Name: "V liga kobiet 2025/2026\ngrupa: małopolska",
+		Name: "V liga kobiet 2025/2026\ngrupa: małopolska, bardzo długa nazwa rozgrywek",
 	}}
 
-	plain := ansi.Strip(m.selectorPopupView(80))
+	popupWidth := 44
+	plain := ansi.Strip(m.selectorPopupView(popupWidth))
 	if strings.Contains(plain, "2025/2026\ngrupa") || strings.Contains(plain, "2025 /\n2026") || strings.Contains(plain, "Women\r\nLeagues") {
 		t.Fatalf("expected embedded newline to be normalized\n%s", plain)
 	}
@@ -1430,11 +1431,62 @@ func TestSelectorPopupNormalizesNewlinesInLeagueNames(t *testing.T) {
 	if !strings.Contains(plain, "WOMEN LEAGUES") {
 		t.Fatalf("expected normalized selector heading in one row\n%s", plain)
 	}
-	if !strings.Contains(plain, "V liga kobiet 2025/2026 grupa") {
-		t.Fatalf("expected normalized league name in one row\n%s", plain)
+	if !strings.Contains(plain, "V liga kobiet 2025/2") {
+		t.Fatalf("expected normalized truncated league name in one row\n%s", plain)
 	}
-	if got := selectorCompetitionWidthLines(m.competitions); len(got) != 1 || got[0] != "V liga kobiet 2025/2026 grupa: małopolska" {
+	if strings.Contains(plain, "2025/2…\n") {
+		t.Fatalf("expected truncated league name not to wrap\n%s", plain)
+	}
+	for _, line := range strings.Split(plain, "\n") {
+		if width := ansi.StringWidth(line); width > popupWidth {
+			t.Fatalf("expected selector line within popup width %d, got %d: %q\n%s", popupWidth, width, line, plain)
+		}
+	}
+	if got := selectorCompetitionWidthLines(m.competitions); len(got) != 1 || got[0] != "V liga kobiet 2025/2026 grupa: małopolska, bardzo długa nazwa rozgrywek" {
 		t.Fatalf("expected width lines to normalize league names, got %+v", got)
+	}
+	if got := selectorPopupWidth(popupWidth, []string{"2025 /\n2026"}, "Women\r\nLeagues", []string{m.competitions[0].Name}); got != popupWidth-2 {
+		t.Fatalf("expected popup width to clamp to terminal body, got %d", got)
+	}
+}
+
+func TestSelectorPopupWidthNormalizesUnclampedInputs(t *testing.T) {
+	raw := selectorPopupWidth(
+		160,
+		[]string{"2025 /\n2026"},
+		"Women\r\nLeagues",
+		[]string{"V liga kobiet 2025/2026\ngrupa: małopolska"},
+	)
+	normalized := selectorPopupWidth(
+		160,
+		[]string{"2025 / 2026"},
+		"Women Leagues",
+		[]string{"V liga kobiet 2025/2026 grupa: małopolska"},
+	)
+	if raw != normalized {
+		t.Fatalf("expected raw and normalized selector widths to match, got raw=%d normalized=%d", raw, normalized)
+	}
+}
+
+func TestSelectorOverlayKeepsLongNewlineLeagueNameWithinTerminalWidth(t *testing.T) {
+	m := sketchModel()
+	m.width = 44
+	m.height = 12
+	m.selectorVisible = true
+	m.focus = focusCompetitions
+	m.competitionTitle = "Women\nLeagues"
+	m.competitions = []site.Competition{{
+		Name: "V liga kobiet 2025/2026\ngrupa: małopolska, bardzo długa nazwa rozgrywek",
+	}}
+
+	plain := ansi.Strip(m.viewContent())
+	for _, line := range strings.Split(plain, "\n") {
+		if width := ansi.StringWidth(line); width > m.width {
+			t.Fatalf("expected rendered line within terminal width %d, got %d: %q\n%s", m.width, width, line, plain)
+		}
+	}
+	if strings.Contains(plain, "2025/2026\ngrupa") || strings.Contains(plain, "Women\nLeagues") {
+		t.Fatalf("expected selector overlay to normalize embedded newlines\n%s", plain)
 	}
 }
 


### PR DESCRIPTION
## Summary
- render selector modal with the requested outer width so borders do not force row wrapping
- normalize selector width inputs defensively before measuring
- add regressions for long/newline league names in direct popup and production overlay paths

## Verification
- go test ./...
- git diff --check