### PR TITLE
Add in-process document cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go run ./cmd/90minutui
 - `esc` close match view, back out of submenus, or toggle the selector
 - `tab` open selector, or switch selector focus when already open
 - `pgup`/`pgdn`, `ctrl+u`/`ctrl+d` scroll match details
-- `r` reload
+- `r` fresh reload current page or match from the network
 - `q` quit
 
 ## What Works

--- a/internal/site/client.go
+++ b/internal/site/client.go
@@ -7,14 +7,32 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 
 	"github.com/PuerkitoBio/goquery"
 	"golang.org/x/net/html/charset"
 )
 
+// documentCacheLimit caps the per-process FIFO HTML response cache.
+const documentCacheLimit = 20 * 1024 * 1024
+
 type Client struct {
 	baseURL *url.URL
 	http    *http.Client
+	cache   *documentCache
+}
+
+type cachedDocument struct {
+	body        []byte
+	contentType string
+}
+
+type documentCache struct {
+	maxBytes int
+	bytes    int
+	entries  map[string]cachedDocument
+	order    []string
+	mu       sync.Mutex
 }
 
 func NewClient() *Client {
@@ -25,6 +43,7 @@ func NewClient() *Client {
 		http: &http.Client{
 			Timeout: HTTPTimeout,
 		},
+		cache: newDocumentCache(documentCacheLimit),
 	}
 }
 
@@ -45,10 +64,37 @@ func (c *Client) Resolve(raw string) string {
 	return c.baseURL.ResolveReference(u).String()
 }
 
+func (c *Client) Cached(rawURL string) bool {
+	if c.cache == nil {
+		return false
+	}
+	_, _, ok := c.cache.get(c.Resolve(rawURL))
+	return ok
+}
+
 // Document resolves rawURL, sends the project User-Agent, decodes legacy HTML charsets,
-// and reports request, transport, status, body-read, and parse failures with URL context.
+// and caches successful responses in-process. Cached responses are reparsed on each call.
+// Request-build, fetch/status, body-read, and parse failures include URL context.
 func (c *Client) Document(ctx context.Context, rawURL string) (*goquery.Document, error) {
+	return c.document(ctx, rawURL, true)
+}
+
+// DocumentFresh bypasses the in-process cache, fetches rawURL, and replaces any cached response.
+func (c *Client) DocumentFresh(ctx context.Context, rawURL string) (*goquery.Document, error) {
+	return c.document(ctx, rawURL, false)
+}
+
+func (c *Client) document(ctx context.Context, rawURL string, useCache bool) (*goquery.Document, error) {
 	absoluteURL := c.Resolve(rawURL)
+	if useCache {
+		if body, contentType, ok := c.cachedDocument(absoluteURL); ok {
+			doc, err := decodeAndParse(body, contentType)
+			if err != nil {
+				return nil, fmt.Errorf("parse cached %q HTML: %w", absoluteURL, err)
+			}
+			return doc, nil
+		}
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, absoluteURL, nil)
 	if err != nil {
@@ -72,12 +118,91 @@ func (c *Client) Document(ctx context.Context, rawURL string) (*goquery.Document
 		return nil, fmt.Errorf("read %q body: %w", absoluteURL, err)
 	}
 
-	doc, err := decodeAndParse(body, resp.Header.Get("Content-Type"))
+	contentType := resp.Header.Get("Content-Type")
+	doc, err := decodeAndParse(body, contentType)
 	if err != nil {
 		return nil, fmt.Errorf("parse %q HTML: %w", absoluteURL, err)
 	}
+	c.storeDocument(absoluteURL, body, contentType)
 
 	return doc, nil
+}
+
+func (c *Client) cachedDocument(url string) ([]byte, string, bool) {
+	if c.cache == nil {
+		return nil, "", false
+	}
+	return c.cache.get(url)
+}
+
+func (c *Client) storeDocument(url string, body []byte, contentType string) {
+	if c.cache == nil {
+		return
+	}
+	c.cache.put(url, body, contentType)
+}
+
+func newDocumentCache(maxBytes int) *documentCache {
+	return &documentCache{
+		maxBytes: maxBytes,
+		entries:  make(map[string]cachedDocument),
+	}
+}
+
+func (c *documentCache) get(url string) ([]byte, string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[url]
+	return entry.body, entry.contentType, ok
+}
+
+func (c *documentCache) put(url string, body []byte, contentType string) {
+	if c.maxBytes <= 0 || len(body) > c.maxBytes {
+		c.delete(url)
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.entries[url]; ok {
+		c.bytes -= len(existing.body)
+	} else {
+		c.order = append(c.order, url)
+	}
+
+	c.entries[url] = cachedDocument{body: bytes.Clone(body), contentType: contentType}
+	c.bytes += len(body)
+
+	for c.bytes > c.maxBytes && len(c.order) > 0 {
+		oldest := c.order[0]
+		c.order = c.order[1:]
+		entry, ok := c.entries[oldest]
+		if !ok {
+			continue
+		}
+		delete(c.entries, oldest)
+		c.bytes -= len(entry.body)
+	}
+}
+
+func (c *documentCache) delete(url string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[url]
+	if !ok {
+		return
+	}
+	delete(c.entries, url)
+	c.bytes -= len(entry.body)
+	for i, cachedURL := range c.order {
+		if cachedURL == url {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			return
+		}
+	}
 }
 
 func decodeAndParse(body []byte, contentType string) (*goquery.Document, error) {

--- a/internal/site/client_test.go
+++ b/internal/site/client_test.go
@@ -120,3 +120,112 @@ func TestClientDocumentSendsUserAgent(t *testing.T) {
 		t.Fatalf("unexpected user agent: %q", userAgent)
 	}
 }
+
+func TestClientDocumentCachesSuccessfulResponses(t *testing.T) {
+	requests := 0
+	body := `<html><body><p>cached</p></body></html>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client(), cache: newDocumentCache(documentCacheLimit)}
+	if client.Cached(server.URL) {
+		t.Fatalf("expected URL to be uncached before first load")
+	}
+
+	for range 2 {
+		if _, err := client.Document(context.Background(), server.URL); err != nil {
+			t.Fatalf("expected document load to succeed, got %v", err)
+		}
+	}
+	if !client.Cached(server.URL) {
+		t.Fatalf("expected URL to be cached after successful load")
+	}
+	if requests != 1 {
+		t.Fatalf("expected second document load to use cache, got %d requests", requests)
+	}
+
+	body = `<html><body><p>fresh</p></body></html>`
+	doc, err := client.DocumentFresh(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected fresh document load to succeed, got %v", err)
+	}
+	if got := strings.TrimSpace(doc.Find("p").Text()); got != "fresh" {
+		t.Fatalf("expected fresh document body, got %q", got)
+	}
+	doc, err = client.Document(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected cached fresh document load to succeed, got %v", err)
+	}
+	if got := strings.TrimSpace(doc.Find("p").Text()); got != "fresh" {
+		t.Fatalf("expected fresh body to replace cached body, got %q", got)
+	}
+	if requests != 2 {
+		t.Fatalf("expected fresh load to make one extra request, got %d requests", requests)
+	}
+}
+
+func TestClientDocumentCacheEvictsOldestEntry(t *testing.T) {
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, `<html><body>`+strings.Repeat(r.URL.Path, 8)+`</body></html>`)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client(), cache: newDocumentCache(80)}
+
+	for _, path := range []string{"/one", "/two", "/one"} {
+		if _, err := client.Document(context.Background(), server.URL+path); err != nil {
+			t.Fatalf("load %s: %v", path, err)
+		}
+	}
+	if requests["/one"] != 2 {
+		t.Fatalf("expected /one to be evicted and fetched again, got %d requests", requests["/one"])
+	}
+	if requests["/two"] != 1 {
+		t.Fatalf("expected /two to stay cached, got %d requests", requests["/two"])
+	}
+}
+
+func TestClientDocumentFreshOversizedResponseClearsCachedEntry(t *testing.T) {
+	body := `<html><body><p>small</p></body></html>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer server.Close()
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := &Client{baseURL: base, http: server.Client(), cache: newDocumentCache(80)}
+
+	if _, err := client.Document(context.Background(), server.URL); err != nil {
+		t.Fatalf("expected initial document load to succeed, got %v", err)
+	}
+	if !client.Cached(server.URL) {
+		t.Fatalf("expected small response to be cached")
+	}
+
+	body = `<html><body><p>` + strings.Repeat("large", 40) + `</p></body></html>`
+	if _, err := client.DocumentFresh(context.Background(), server.URL); err != nil {
+		t.Fatalf("expected oversized fresh document load to succeed, got %v", err)
+	}
+	if client.Cached(server.URL) {
+		t.Fatalf("expected oversized fresh response to clear cached entry")
+	}
+}

--- a/internal/site/service.go
+++ b/internal/site/service.go
@@ -48,11 +48,25 @@ func NewService() *Service {
 	return &Service{client: NewClient()}
 }
 
+// Cached reports whether rawURL resolves to a successfully cached document.
+func (s *Service) Cached(rawURL string) bool {
+	return s.client.Cached(rawURL)
+}
+
 // LoadArchive returns parsed seasons, the selected season index, and top-level competitions.
 // Empty archive pages return nil results and -1; pages with seasons but no competitions
 // return the parsed season context with an error so callers can surface partial state.
 func (s *Service) LoadArchive(ctx context.Context, archiveURL string) ([]Season, int, []Competition, error) {
-	doc, err := s.client.Document(ctx, archiveURL)
+	return s.loadArchive(ctx, archiveURL, false)
+}
+
+// LoadArchiveFresh has the same result/error contract as LoadArchive, but bypasses and replaces cache.
+func (s *Service) LoadArchiveFresh(ctx context.Context, archiveURL string) ([]Season, int, []Competition, error) {
+	return s.loadArchive(ctx, archiveURL, true)
+}
+
+func (s *Service) loadArchive(ctx context.Context, archiveURL string, fresh bool) ([]Season, int, []Competition, error) {
+	doc, err := s.document(ctx, archiveURL, fresh)
 	if err != nil {
 		return nil, -1, nil, err
 	}
@@ -76,7 +90,16 @@ func (s *Service) LoadArchive(ctx context.Context, archiveURL string) ([]Season,
 // League fixtures keep empty MatchURL and MatchID values when the source row has no match page.
 // It returns an error when the page cannot be classified as a supported submenu or a valid league.
 func (s *Service) LoadCompetition(ctx context.Context, competitionURL string) (*CompetitionMenu, *LeaguePage, error) {
-	doc, err := s.client.Document(ctx, competitionURL)
+	return s.loadCompetition(ctx, competitionURL, false)
+}
+
+// LoadCompetitionFresh has the same result/error contract as LoadCompetition, but bypasses and replaces cache.
+func (s *Service) LoadCompetitionFresh(ctx context.Context, competitionURL string) (*CompetitionMenu, *LeaguePage, error) {
+	return s.loadCompetition(ctx, competitionURL, true)
+}
+
+func (s *Service) loadCompetition(ctx context.Context, competitionURL string, fresh bool) (*CompetitionMenu, *LeaguePage, error) {
+	doc, err := s.document(ctx, competitionURL, fresh)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -134,7 +157,16 @@ func (s *Service) LoadLeague(ctx context.Context, leagueURL string) (*LeaguePage
 // LoadMatch returns a parsed match page. Fetch/parse failures return nil; validation failures
 // may return a partial page with stable URL/title/ID fields alongside the error.
 func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, error) {
-	doc, err := s.client.Document(ctx, matchURL)
+	return s.loadMatch(ctx, matchURL, false)
+}
+
+// LoadMatchFresh has the same result/error contract as LoadMatch, but bypasses and replaces cache.
+func (s *Service) LoadMatchFresh(ctx context.Context, matchURL string) (*MatchPage, error) {
+	return s.loadMatch(ctx, matchURL, true)
+}
+
+func (s *Service) loadMatch(ctx context.Context, matchURL string, fresh bool) (*MatchPage, error) {
+	doc, err := s.document(ctx, matchURL, fresh)
 	if err != nil {
 		return nil, err
 	}
@@ -153,6 +185,13 @@ func (s *Service) LoadMatch(ctx context.Context, matchURL string) (*MatchPage, e
 	}
 
 	return match, nil
+}
+
+func (s *Service) document(ctx context.Context, rawURL string, fresh bool) (*goquery.Document, error) {
+	if fresh {
+		return s.client.DocumentFresh(ctx, rawURL)
+	}
+	return s.client.Document(ctx, rawURL)
 }
 
 func validateLeaguePage(page *LeaguePage) error {

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -15,21 +15,37 @@ const cmdTimeout = 20 * time.Second
 const selectorSeasonLoadDelay = 300 * time.Millisecond
 
 func (m Model) loadArchiveCmd(url string) tea.Cmd {
+	return m.loadArchive(url, false)
+}
+
+func (m Model) loadArchiveFreshCmd(url string) tea.Cmd {
+	return m.loadArchive(url, true)
+}
+
+func (m Model) loadArchive(url string, fresh bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
-		seasons, selectedIdx, competitions, err := m.service.LoadArchive(ctx, url)
-		return archiveLoadedMsg{seasons: seasons, selectedIdx: selectedIdx, competitions: competitions, err: err}
+		seasons, selectedIdx, competitions, err := m.loadArchivePage(ctx, url, fresh)
+		return archiveLoadedMsg{seasons: seasons, selectedIdx: selectedIdx, competitions: competitions, fresh: fresh, err: err}
 	}
 }
 
 // selectorOnly refreshes the selector list without auto-loading a competition or closing the selector.
 func (m Model) loadSeasonCompetitionsCmd(url, seasonKey string, selectorOnly bool) tea.Cmd {
+	return m.loadSeasonCompetitions(url, seasonKey, selectorOnly, false)
+}
+
+func (m Model) loadSeasonCompetitionsFreshCmd(url, seasonKey string, selectorOnly bool) tea.Cmd {
+	return m.loadSeasonCompetitions(url, seasonKey, selectorOnly, true)
+}
+
+func (m Model) loadSeasonCompetitions(url, seasonKey string, selectorOnly bool, fresh bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
-		_, _, competitions, err := m.service.LoadArchive(ctx, url)
-		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, selectorOnly: selectorOnly, err: err}
+		_, _, competitions, err := m.loadArchivePage(ctx, url, fresh)
+		return competitionsLoadedMsg{seasonKey: seasonKey, competitions: competitions, selectorOnly: selectorOnly, fresh: fresh, err: err}
 	}
 }
 
@@ -40,21 +56,64 @@ func (m Model) settleSeasonSelectionCmd(url, seasonKey string) tea.Cmd {
 }
 
 func (m Model) loadCompetitionCmd(url, competitionKey string) tea.Cmd {
+	return m.loadCompetition(url, competitionKey, false)
+}
+
+func (m Model) loadCompetitionFreshCmd(url, competitionKey string) tea.Cmd {
+	return m.loadCompetition(url, competitionKey, true)
+}
+
+func (m Model) loadCompetition(url, competitionKey string, fresh bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
-		menu, league, err := m.service.LoadCompetition(ctx, url)
+		menu, league, err := m.loadCompetitionPage(ctx, url, fresh)
 		return competitionMenuLoadedMsg{competitionKey: competitionKey, menu: menu, league: league, err: err}
 	}
 }
 
 func (m Model) loadMatchCmd(url, fixtureKey string) tea.Cmd {
+	return m.loadMatch(url, fixtureKey, false)
+}
+
+func (m Model) loadMatchFreshCmd(url, fixtureKey string) tea.Cmd {
+	return m.loadMatch(url, fixtureKey, true)
+}
+
+func (m Model) loadMatch(url, fixtureKey string, fresh bool) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
 		defer cancel()
-		match, err := m.service.LoadMatch(ctx, url)
+		match, err := m.loadMatchPage(ctx, url, fresh)
 		return matchLoadedMsg{fixtureKey: fixtureKey, match: match, err: err}
 	}
+}
+
+func (m Model) loadArchivePage(ctx context.Context, url string, fresh bool) ([]site.Season, int, []site.Competition, error) {
+	if fresh {
+		if loader, ok := m.service.(freshLoader); ok {
+			return loader.LoadArchiveFresh(ctx, url)
+		}
+	}
+	return m.service.LoadArchive(ctx, url)
+}
+
+func (m Model) loadCompetitionPage(ctx context.Context, url string, fresh bool) (*site.CompetitionMenu, *site.LeaguePage, error) {
+	if fresh {
+		if loader, ok := m.service.(freshLoader); ok {
+			return loader.LoadCompetitionFresh(ctx, url)
+		}
+	}
+	return m.service.LoadCompetition(ctx, url)
+}
+
+func (m Model) loadMatchPage(ctx context.Context, url string, fresh bool) (*site.MatchPage, error) {
+	if fresh {
+		if loader, ok := m.service.(freshLoader); ok {
+			return loader.LoadMatchFresh(ctx, url)
+		}
+	}
+	return m.service.LoadMatch(ctx, url)
 }
 
 func seasonRequestKey(season site.Season) string {

--- a/internal/ui/fixture_navigation_test.go
+++ b/internal/ui/fixture_navigation_test.go
@@ -29,6 +29,8 @@ type recordingLoader struct {
 	leagueCalls  int
 	menuCalls    int
 	matchCalls   int
+	freshMenus   int
+	freshMatches int
 
 	seasons             []site.Season
 	selectedIdx         int
@@ -37,6 +39,7 @@ type recordingLoader struct {
 	menus               map[string]*site.CompetitionMenu
 	league              *site.LeaguePage
 	match               *site.MatchPage
+	cached              map[string]bool
 
 	// compErr, when non-nil, is returned by LoadCompetition instead of the league.
 	compErr error
@@ -48,6 +51,14 @@ func (l *recordingLoader) LoadArchive(_ context.Context, rawURL string) ([]site.
 		return l.seasons, l.selectedIdx, competitions, nil
 	}
 	return l.seasons, l.selectedIdx, l.competitions, nil
+}
+
+func (l *recordingLoader) LoadArchiveFresh(ctx context.Context, rawURL string) ([]site.Season, int, []site.Competition, error) {
+	return l.LoadArchive(ctx, rawURL)
+}
+
+func (l *recordingLoader) Cached(rawURL string) bool {
+	return l.cached[strings.TrimSpace(rawURL)]
 }
 
 func (l *recordingLoader) LoadLeague(context.Context, string) (*site.LeaguePage, error) {
@@ -67,9 +78,19 @@ func (l *recordingLoader) LoadCompetition(_ context.Context, rawURL string) (*si
 	return nil, l.league, nil
 }
 
+func (l *recordingLoader) LoadCompetitionFresh(ctx context.Context, rawURL string) (*site.CompetitionMenu, *site.LeaguePage, error) {
+	l.freshMenus++
+	return l.LoadCompetition(ctx, rawURL)
+}
+
 func (l *recordingLoader) LoadMatch(context.Context, string) (*site.MatchPage, error) {
 	l.matchCalls++
 	return l.match, nil
+}
+
+func (l *recordingLoader) LoadMatchFresh(ctx context.Context, rawURL string) (*site.MatchPage, error) {
+	l.freshMatches++
+	return l.LoadMatch(ctx, rawURL)
 }
 
 func TestFixtureNavigationDoesNotReloadLeague(t *testing.T) {
@@ -169,6 +190,9 @@ func TestPrintableReloadAndQuitKeys(t *testing.T) {
 	}
 	if loader.leagueCalls != 2 {
 		t.Fatalf("expected reload to load league again, got %d league loads", loader.leagueCalls)
+	}
+	if loader.freshMenus != 1 {
+		t.Fatalf("expected reload to bypass cached competition load, got %d fresh loads", loader.freshMenus)
 	}
 
 	_, cmd = updateModelWithMsg(t, m, testRune('q'))
@@ -577,6 +601,28 @@ func TestMatchViewNavigationLoadsAdjacentFixture(t *testing.T) {
 	}
 }
 
+func TestMatchViewReloadUsesFreshMatchLoad(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m.roundCursor = 0
+	m.fixtureCursor = 0
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyEnter))
+	if cmd == nil {
+		t.Fatalf("expected match load command on enter")
+	}
+	m, _ = updateModelWithMsg(t, m, cmd())
+
+	m, cmd = updateModelWithMsg(t, m, testRune('r'))
+	if cmd == nil {
+		t.Fatalf("expected match reload command")
+	}
+	m, _ = updateModelWithMsg(t, m, cmd())
+	if loader.freshMatches != 1 {
+		t.Fatalf("expected match reload to bypass cache, got %d fresh loads", loader.freshMatches)
+	}
+}
+
 func TestMatchViewRoundNavigationLoadsFirstFixture(t *testing.T) {
 	loader := newRecordingLoader()
 	m := bootstrapLeagueLoadedModel(t, loader)
@@ -888,6 +934,57 @@ func TestSelectorSeasonMoveRefreshesCompetitionsInPlace(t *testing.T) {
 	}
 	if loader.leagueCalls != 1 {
 		t.Fatalf("season cursor refresh should not auto-load a league, got %d league calls", loader.leagueCalls)
+	}
+}
+
+func TestSelectorSeasonMoveLoadsCachedCompetitionsImmediately(t *testing.T) {
+	loader := newRecordingLoader()
+	season2024 := site.Season{Label: "2024/2025", URL: "http://www.90minut.pl/archsezon.php?id_sezon=105", SeasonID: "105"}
+	season2025 := site.Season{Label: "2025/2026", URL: "http://www.90minut.pl/archsezon.php?id_sezon=107", SeasonID: "107", Current: true}
+	loader.seasons = []site.Season{season2024, season2025}
+	loader.selectedIdx = 0
+	loader.competitions = []site.Competition{{Name: "Ekstraklasa 2024/2025", URL: "http://www.90minut.pl/liga/1/liga13482.html", LeagueKey: "liga13482"}}
+	loader.archiveCompetitions = map[string][]site.Competition{
+		season2025.URL: {{Name: "Ekstraklasa 2025/2026", URL: "http://www.90minut.pl/liga/1/liga14072.html", LeagueKey: "liga14072"}},
+	}
+	loader.cached = map[string]bool{season2025.URL: true}
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+
+	m, cmd := updateModelWithMsg(t, m, testKey(tea.KeyDown))
+	if cmd == nil {
+		t.Fatalf("expected cached season cursor move to load competitions immediately")
+	}
+	if !m.loading || len(m.competitions) != 0 {
+		t.Fatalf("expected cached season move to enter loading state and clear stale competitions, loading=%v competitions=%+v", m.loading, m.competitions)
+	}
+	if msg, ok := cmd().(competitionsLoadedMsg); !ok || msg.seasonKey != seasonRequestKey(season2025) {
+		t.Fatalf("expected immediate competitions load message for cached season, got %#v", msg)
+	}
+}
+
+func TestSelectorSeasonReloadFreshLoadsSelectedCompetition(t *testing.T) {
+	loader := newRecordingLoader()
+	m := bootstrapLeagueLoadedModel(t, loader)
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyEsc))
+	m, _ = updateModelWithMsg(t, m, testKey(tea.KeyLeft))
+
+	m, cmd := updateModelWithMsg(t, m, testRune('r'))
+	if cmd == nil {
+		t.Fatalf("expected season reload command")
+	}
+	msg, ok := cmd().(competitionsLoadedMsg)
+	if !ok || !msg.fresh {
+		t.Fatalf("expected fresh competitions message, got %#v", msg)
+	}
+	m, cmd = updateModelWithMsg(t, m, msg)
+	if cmd == nil {
+		t.Fatalf("expected selected competition load after season reload")
+	}
+	m, _ = updateModelWithMsg(t, m, cmd())
+	if loader.freshMenus != 1 {
+		t.Fatalf("expected selected competition to load fresh after season reload, got %d fresh loads", loader.freshMenus)
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -29,10 +29,21 @@ type archiveLoader interface {
 	LoadMatch(ctx context.Context, matchURL string) (*site.MatchPage, error)
 }
 
+type cachedLoader interface {
+	Cached(rawURL string) bool
+}
+
+type freshLoader interface {
+	LoadArchiveFresh(ctx context.Context, archiveURL string) ([]site.Season, int, []site.Competition, error)
+	LoadCompetitionFresh(ctx context.Context, competitionURL string) (*site.CompetitionMenu, *site.LeaguePage, error)
+	LoadMatchFresh(ctx context.Context, matchURL string) (*site.MatchPage, error)
+}
+
 type archiveLoadedMsg struct {
 	seasons      []site.Season
 	selectedIdx  int
 	competitions []site.Competition
+	fresh        bool
 	err          error
 }
 
@@ -40,6 +51,7 @@ type competitionsLoadedMsg struct {
 	seasonKey    string
 	competitions []site.Competition
 	selectorOnly bool
+	fresh        bool
 	err          error
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -124,6 +124,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.openSelector()
 			return m, nil
 		}
+		if msg.fresh {
+			return m, m.loadCompetitionFreshCmd(competition.URL, competitionRequestKey(*competition))
+		}
 		return m, m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
 
 	case competitionsLoadedMsg:
@@ -162,6 +165,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.loading = false
 			m.openSelector()
 			return m, nil
+		}
+		if msg.fresh {
+			return m, m.loadCompetitionFreshCmd(competition.URL, competitionRequestKey(*competition))
 		}
 		return m, m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
 
@@ -230,13 +236,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if season == nil || msg.seasonKey != seasonRequestKey(*season) {
 			return m, nil
 		}
-		m.loading = true
-		m.err = ""
-		m.competitionTitle = "Competitions"
-		m.competitions = nil
-		m.competitionCursor = 0
-		m.competitionStack = nil
-		return m, m.loadSeasonCompetitionsCmd(msg.seasonURL, msg.seasonKey, true)
+		return m, m.startSeasonCompetitionLoad(msg.seasonURL, msg.seasonKey, true)
 	}
 
 	return m, nil
@@ -283,11 +283,29 @@ func (m *Model) moveCursor(delta int) tea.Cmd {
 		if season == nil {
 			return nil
 		}
+		if m.cached(season.URL) {
+			return m.startSeasonCompetitionLoad(season.URL, seasonRequestKey(*season), true)
+		}
 		return m.settleSeasonSelectionCmd(season.URL, seasonRequestKey(*season))
 	case focusCompetitions:
 		m.competitionCursor = clamp(m.competitionCursor+delta, 0, len(m.competitions)-1)
 	}
 	return nil
+}
+
+func (m *Model) startSeasonCompetitionLoad(url, seasonKey string, selectorOnly bool) tea.Cmd {
+	m.loading = true
+	m.err = ""
+	m.competitionTitle = "Competitions"
+	m.competitions = nil
+	m.competitionCursor = 0
+	m.competitionStack = nil
+	return m.loadSeasonCompetitionsCmd(url, seasonKey, selectorOnly)
+}
+
+func (m Model) cached(rawURL string) bool {
+	loader, ok := m.service.(cachedLoader)
+	return ok && loader.Cached(rawURL)
 }
 
 func (m *Model) shiftRound(delta int) {
@@ -411,12 +429,12 @@ func (m *Model) handleReload() tea.Cmd {
 		}
 		m.match = nil
 		m.matchScroll = 0
-		return m.loadMatchCmd(fixture.MatchURL, fixtureRequestKey(*fixture))
+		return m.loadMatchFreshCmd(fixture.MatchURL, fixtureRequestKey(*fixture))
 	}
 
 	m.match = nil
 	if len(m.seasons) == 0 {
-		return m.loadArchiveCmd(site.ArchiveURL)
+		return m.loadArchiveFreshCmd(site.ArchiveURL)
 	}
 
 	if m.selectorActive() && m.focus == focusSeasons {
@@ -425,7 +443,7 @@ func (m *Model) handleReload() tea.Cmd {
 			m.loading = false
 			return nil
 		}
-		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), false)
+		return m.loadSeasonCompetitionsFreshCmd(season.URL, seasonRequestKey(*season), false)
 	}
 
 	competition := m.currentCompetition()
@@ -435,11 +453,11 @@ func (m *Model) handleReload() tea.Cmd {
 			m.loading = false
 			return nil
 		}
-		return m.loadSeasonCompetitionsCmd(season.URL, seasonRequestKey(*season), false)
+		return m.loadSeasonCompetitionsFreshCmd(season.URL, seasonRequestKey(*season), false)
 	}
 
 	m.matchView = false
-	return m.loadCompetitionCmd(competition.URL, competitionRequestKey(*competition))
+	return m.loadCompetitionFreshCmd(competition.URL, competitionRequestKey(*competition))
 }
 
 func (m *Model) scrollMatch(delta int) {


### PR DESCRIPTION
## Summary
- add a 20MB per-process FIFO HTML document cache in the site client
- expose fresh load paths so reload bypasses and replaces cached pages
- skip season selector debounce when the selected season archive is already cached
- document reload as a fresh network reload

## Verification
- go test ./...
- git diff --check