### PR TITLE
Add JSON CLI data export

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ go run ./cmd/90minutui
 - Competition submenus for III liga, regional leagues/cups, women, and futsal
 - Linkless fixtures that have scores but no match page
 - Match score, timeline, metadata, lineups, substitutions, and cards
-
-## Planned
-
-- CLI/query API for scripts and non-interactive use
+- CLI/query API for scripts and non-interactive use: see [CLI Data Export](docs/cli.md)
 
 ## Boundaries
 

--- a/cmd/90minutui/main.go
+++ b/cmd/90minutui/main.go
@@ -2,16 +2,22 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/adrunkhuman/90minuTUI/internal/cli"
 	"github.com/adrunkhuman/90minuTUI/internal/site"
 	"github.com/adrunkhuman/90minuTUI/internal/ui"
 )
 
 func main() {
 	svc := site.NewService()
+	if code, handled := runCLI(os.Args, os.Stdout, os.Stderr, svc); handled {
+		os.Exit(code)
+	}
+
 	model := ui.NewModel(svc)
 
 	p := tea.NewProgram(model)
@@ -19,4 +25,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "app error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func runCLI(args []string, stdout, stderr io.Writer, svc cli.Service) (int, bool) {
+	if len(args) <= 1 {
+		return 0, false
+	}
+	if cli.IsCommand(args[1]) {
+		return cli.Run(args[1:], stdout, stderr, svc), true
+	}
+	fmt.Fprintf(stderr, "unknown command %q\n", args[1])
+	return 1, true
 }

--- a/cmd/90minutui/main_test.go
+++ b/cmd/90minutui/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
+)
+
+type mainFakeService struct{}
+
+func (mainFakeService) LoadArchive(context.Context, string) ([]site.Season, int, []site.Competition, error) {
+	return []site.Season{{Label: "2025/26", SeasonID: "107"}}, 0, nil, nil
+}
+
+func (mainFakeService) LoadCompetition(context.Context, string) (*site.CompetitionMenu, *site.LeaguePage, error) {
+	return nil, nil, nil
+}
+
+func (mainFakeService) LoadLeague(context.Context, string) (*site.LeaguePage, error) {
+	return &site.LeaguePage{}, nil
+}
+
+func (mainFakeService) LoadMatch(context.Context, string) (*site.MatchPage, error) {
+	return &site.MatchPage{}, nil
+}
+
+func TestRunCLIRoutesKnownCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, handled := runCLI([]string{"90minutui", "seasons"}, &stdout, &stderr, mainFakeService{})
+	if !handled || code != 0 || stderr.Len() != 0 {
+		t.Fatalf("expected handled success, handled=%v code=%d stderr=%q", handled, code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"seasons"`) {
+		t.Fatalf("expected seasons JSON on stdout, got %q", stdout.String())
+	}
+}
+
+func TestRunCLIRejectsUnknownCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code, handled := runCLI([]string{"90minutui", "bogus"}, &stdout, &stderr, mainFakeService{})
+	if !handled || code != 1 || stdout.Len() != 0 || !strings.Contains(stderr.String(), `unknown command "bogus"`) {
+		t.Fatalf("expected unknown command error, handled=%v code=%d stdout=%q stderr=%q", handled, code, stdout.String(), stderr.String())
+	}
+}
+
+func TestRunCLIIgnoresNoArgs(t *testing.T) {
+	code, handled := runCLI([]string{"90minutui"}, ioDiscard{}, ioDiscard{}, mainFakeService{})
+	if handled || code != 0 {
+		t.Fatalf("expected no args to fall through to TUI, handled=%v code=%d", handled, code)
+	}
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,148 @@
+# CLI Data Export
+
+`90minutui` exports parsed `90minut.pl` data as JSON for scripts.
+
+Data goes to stdout. Errors go to stderr. Fetch or parse failure exits non-zero.
+
+## Usage
+
+```bash
+90minutui seasons
+90minutui competitions --season 107
+90minutui competitions --url 'http://www.90minut.pl/ligireg.php?poziom=4&id_sezon=105'
+90minutui league 'http://www.90minut.pl/liga/1/liga14072.html'
+90minutui fixtures 'http://www.90minut.pl/liga/1/liga14072.html'
+90minutui match 1930640
+```
+
+Use exported `url` values for exact follow-up fetches. `league_key` is stable for joins and is accepted as a convenience when the league URL uses a known `90minut.pl` league path.
+
+## Exports
+
+### seasons
+
+```json
+{
+  "seasons": [
+    {
+      "label": "2025/26",
+      "season_id": "107",
+      "url": "http://www.90minut.pl/archsezon.php?id_sezon=107",
+      "current": true
+    }
+  ]
+}
+```
+
+### competitions
+
+```json
+{
+  "title": "Competitions",
+  "season_id": "107",
+  "url": "http://www.90minut.pl/archsezon.php?id_sezon=107",
+  "competitions": [
+    {
+      "name": "PKO Bank Polski Ekstraklasa 2025/2026",
+      "league_key": "liga14072",
+      "url": "http://www.90minut.pl/liga/1/liga14072.html"
+    }
+  ]
+}
+```
+
+### league
+
+```json
+{
+  "title": "PKO Bank Polski Ekstraklasa 2025/2026",
+  "league_key": "liga14072",
+  "url": "http://www.90minut.pl/liga/1/liga14072.html",
+  "standings": [
+    {
+      "position": 1,
+      "team": "Team",
+      "played": 1,
+      "won": 1,
+      "drawn": 0,
+      "lost": 0,
+      "points": 3
+    }
+  ],
+  "rounds": []
+}
+```
+
+### fixtures
+
+```json
+{
+  "league_key": "liga14072",
+  "url": "http://www.90minut.pl/liga/1/liga14072.html",
+  "rounds": [
+    {
+      "phase": "",
+      "section": "",
+      "name": "1. kolejka",
+      "fixtures": [
+        {
+          "home": "Team A",
+          "away": "Team B",
+          "score": "1-0",
+          "when": "18 lipca, 18:00",
+          "match_id": "1930640",
+          "match_url": "http://www.90minut.pl/mecz.php?id_mecz=1930640"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### match
+
+```json
+{
+  "match_id": "1930640",
+  "url": "http://www.90minut.pl/mecz.php?id_mecz=1930640",
+  "title": "Match title",
+  "competition": "League or cup name",
+  "meta": "stadium, attendance, referee",
+  "weather": "weather text",
+  "home_team": "Team A",
+  "away_team": "Team B",
+  "score": "1-0",
+  "events": [
+    {
+      "minute": 35,
+      "minute_text": "35",
+      "stoppage": 0,
+      "has_minute": true,
+      "kind": "GOAL",
+      "team_side": "home",
+      "text": "Player 35",
+      "substitution_out": "",
+      "substitution_in": ""
+    }
+  ],
+  "home_lineup": [
+    {
+      "name": "Player A",
+      "events": [],
+      "raw_text": "Player A"
+    }
+  ],
+  "away_lineup": [],
+  "news_title": "",
+  "news_url": ""
+}
+```
+
+## Notes
+
+- Subcommands write JSON.
+- Missing lists are `[]`.
+- Missing source values are `""`.
+- `season_id`, `league_key`, and `match_id` are stable keys for joining exports.
+- `url` is the exact fetch identifier for follow-up commands.
+- The app uses a per-process cache only. Each new process fetches fresh data.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -214,6 +214,9 @@ func printUsage(w io.Writer) {
   90minutui league <league-key-or-url>
   90minutui fixtures <league-key-or-url>
   90minutui match <match-id-or-url>
+
+Full API reference:
+  https://github.com/adrunkhuman/90minuTUI/blob/master/docs/cli.md
 `)
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,465 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
+)
+
+const timeout = 20 * time.Second
+
+var leagueKeyRe = regexp.MustCompile(`(?i)^liga\d+$`)
+var numericIDRe = regexp.MustCompile(`^\d+$`)
+
+type Service interface {
+	LoadArchive(ctx context.Context, archiveURL string) ([]site.Season, int, []site.Competition, error)
+	LoadCompetition(ctx context.Context, competitionURL string) (*site.CompetitionMenu, *site.LeaguePage, error)
+	LoadLeague(ctx context.Context, leagueURL string) (*site.LeaguePage, error)
+	LoadMatch(ctx context.Context, matchURL string) (*site.MatchPage, error)
+}
+
+func IsCommand(name string) bool {
+	switch name {
+	case "seasons", "competitions", "league", "fixtures", "match", "help", "-h", "--help":
+		return true
+	default:
+		return false
+	}
+}
+
+func Run(args []string, stdout, stderr io.Writer, svc Service) int {
+	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
+		printUsage(stdout)
+		return 0
+	}
+
+	if err := run(args, stdout, svc); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func run(args []string, stdout io.Writer, svc Service) error {
+	switch args[0] {
+	case "seasons":
+		return runSeasons(args[1:], stdout, svc)
+	case "competitions":
+		return runCompetitions(args[1:], stdout, svc)
+	case "league":
+		return runLeague(args[1:], stdout, svc)
+	case "fixtures":
+		return runFixtures(args[1:], stdout, svc)
+	case "match":
+		return runMatch(args[1:], stdout, svc)
+	default:
+		return fmt.Errorf("unknown command %q", args[0])
+	}
+}
+
+func runSeasons(args []string, stdout io.Writer, svc Service) error {
+	fs := newFlagSet("seasons")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("seasons does not accept positional arguments")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	seasons, _, _, err := svc.LoadArchive(ctx, site.ArchiveURL)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, seasonsOutput{Seasons: mapSeasons(seasons)})
+}
+
+func runCompetitions(args []string, stdout io.Writer, svc Service) error {
+	fs := newFlagSet("competitions")
+	season := fs.String("season", "", "season id or archive URL")
+	competitionURL := fs.String("url", "", "competition submenu URL")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("competitions does not accept positional arguments")
+	}
+	if strings.TrimSpace(*season) == "" && strings.TrimSpace(*competitionURL) == "" {
+		return errors.New("competitions requires --season or --url")
+	}
+	if strings.TrimSpace(*season) != "" && strings.TrimSpace(*competitionURL) != "" {
+		return errors.New("competitions accepts only one of --season or --url")
+	}
+	if strings.TrimSpace(*competitionURL) != "" {
+		return runCompetitionMenu(stdout, svc, *competitionURL)
+	}
+
+	archiveURL := seasonURL(*season)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, _, competitions, err := svc.LoadArchive(ctx, archiveURL)
+	if err != nil {
+		return err
+	}
+
+	return writeJSON(stdout, competitionsOutput{Title: "Competitions", SeasonID: seasonID(archiveURL), URL: archiveURL, Competitions: mapCompetitions(competitions)})
+}
+
+func runCompetitionMenu(stdout io.Writer, svc Service, rawURL string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	menu, league, err := svc.LoadCompetition(ctx, rawURL)
+	if err != nil {
+		return err
+	}
+	if menu == nil {
+		if league != nil {
+			return errors.New("competition URL is a terminal league; use league or fixtures")
+		}
+		return errors.New("competition URL returned no submenu")
+	}
+
+	return writeJSON(stdout, competitionsOutput{Title: menu.Title, SeasonID: seasonID(menu.URL), URL: menu.URL, Competitions: mapCompetitions(menu.Items)})
+}
+
+func runLeague(args []string, stdout io.Writer, svc Service) error {
+	league, err := loadLeagueArg(args, svc)
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, mapLeague(league, true))
+}
+
+func runFixtures(args []string, stdout io.Writer, svc Service) error {
+	league, err := loadLeagueArg(args, svc)
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, fixturesOutput{LeagueKey: league.LeagueKey, URL: league.URL, Rounds: mapRounds(league.Rounds)})
+}
+
+func runMatch(args []string, stdout io.Writer, svc Service) error {
+	fs := newFlagSet("match")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("match requires match id or URL")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	match, err := svc.LoadMatch(ctx, matchURL(fs.Arg(0)))
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, mapMatch(match))
+}
+
+func loadLeagueArg(args []string, svc Service) (*site.LeaguePage, error) {
+	fs := newFlagSet("league")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if fs.NArg() != 1 {
+		return nil, errors.New("league requires league key or URL")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return loadLeague(ctx, svc, fs.Arg(0))
+}
+
+func loadLeague(ctx context.Context, svc Service, value string) (*site.LeaguePage, error) {
+	candidates := leagueURLs(value)
+	var lastErr error
+	for _, candidate := range candidates {
+		league, err := svc.LoadLeague(ctx, candidate)
+		if err == nil {
+			return league, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func newFlagSet(name string) *flag.FlagSet {
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	return fs
+}
+
+func writeJSON(w io.Writer, value any) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func printUsage(w io.Writer) {
+	_, _ = fmt.Fprint(w, `Usage:
+  90minutui seasons
+  90minutui competitions --season <season-id-or-url>
+  90minutui competitions --url <competition-submenu-url>
+  90minutui league <league-key-or-url>
+  90minutui fixtures <league-key-or-url>
+  90minutui match <match-id-or-url>
+`)
+}
+
+func seasonURL(value string) string {
+	value = strings.TrimSpace(value)
+	if isAbsURL(value) {
+		return value
+	}
+	if numericIDRe.MatchString(value) {
+		return site.BaseURL + "/archsezon.php?id_sezon=" + value
+	}
+	return value
+}
+
+func leagueURL(value string) string {
+	return leagueURLs(value)[0]
+}
+
+func leagueURLs(value string) []string {
+	value = strings.TrimSpace(value)
+	if isAbsURL(value) {
+		return []string{value}
+	}
+	if leagueKeyRe.MatchString(value) {
+		key := strings.ToLower(value)
+		// Older 90minut league pages may live under /liga/0/.
+		return []string{site.BaseURL + "/liga/1/" + key + ".html", site.BaseURL + "/liga/0/" + key + ".html"}
+	}
+	return []string{value}
+}
+
+func matchURL(value string) string {
+	value = strings.TrimSpace(value)
+	if isAbsURL(value) {
+		return value
+	}
+	if numericIDRe.MatchString(value) {
+		return site.BaseURL + "/mecz.php?id_mecz=" + value
+	}
+	return value
+}
+
+func isAbsURL(value string) bool {
+	u, err := url.Parse(value)
+	return err == nil && u.IsAbs()
+}
+
+func seasonID(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Query().Get("id_sezon"))
+}
+
+type seasonsOutput struct {
+	Seasons []seasonJSON `json:"seasons"`
+}
+
+type seasonJSON struct {
+	Label    string `json:"label"`
+	SeasonID string `json:"season_id"`
+	URL      string `json:"url"`
+	Current  bool   `json:"current"`
+}
+
+type competitionsOutput struct {
+	Title        string            `json:"title"`
+	SeasonID     string            `json:"season_id"`
+	URL          string            `json:"url"`
+	Competitions []competitionJSON `json:"competitions"`
+}
+
+type competitionJSON struct {
+	Name      string `json:"name"`
+	LeagueKey string `json:"league_key"`
+	URL       string `json:"url"`
+}
+
+type leagueJSON struct {
+	Title     string         `json:"title"`
+	LeagueKey string         `json:"league_key"`
+	URL       string         `json:"url"`
+	Standings []standingJSON `json:"standings"`
+	Rounds    []roundJSON    `json:"rounds"`
+}
+
+type fixturesOutput struct {
+	LeagueKey string      `json:"league_key"`
+	URL       string      `json:"url"`
+	Rounds    []roundJSON `json:"rounds"`
+}
+
+type standingJSON struct {
+	Position int    `json:"position"`
+	Team     string `json:"team"`
+	Played   int    `json:"played"`
+	Won      int    `json:"won"`
+	Drawn    int    `json:"drawn"`
+	Lost     int    `json:"lost"`
+	Points   int    `json:"points"`
+}
+
+type roundJSON struct {
+	Phase    site.RoundPhase `json:"phase"`
+	Section  string          `json:"section"`
+	Name     string          `json:"name"`
+	Fixtures []fixtureJSON   `json:"fixtures"`
+}
+
+type fixtureJSON struct {
+	Home     string `json:"home"`
+	Away     string `json:"away"`
+	Score    string `json:"score"`
+	When     string `json:"when"`
+	MatchID  string `json:"match_id"`
+	MatchURL string `json:"match_url"`
+}
+
+type matchJSON struct {
+	MatchID     string           `json:"match_id"`
+	URL         string           `json:"url"`
+	Title       string           `json:"title"`
+	Competition string           `json:"competition"`
+	Meta        string           `json:"meta"`
+	Weather     string           `json:"weather"`
+	HomeTeam    string           `json:"home_team"`
+	AwayTeam    string           `json:"away_team"`
+	Score       string           `json:"score"`
+	Events      []matchEventJSON `json:"events"`
+	HomeLineup  []playerLineJSON `json:"home_lineup"`
+	AwayLineup  []playerLineJSON `json:"away_lineup"`
+	NewsTitle   string           `json:"news_title"`
+	NewsURL     string           `json:"news_url"`
+}
+
+type matchEventJSON struct {
+	MinuteText      string              `json:"minute_text"`
+	Minute          int                 `json:"minute"`
+	Stoppage        int                 `json:"stoppage"`
+	HasMinute       bool                `json:"has_minute"`
+	Kind            site.MatchEventKind `json:"kind"`
+	TeamSide        site.TeamSide       `json:"team_side"`
+	Text            string              `json:"text"`
+	SubstitutionOut string              `json:"substitution_out"`
+	SubstitutionIn  string              `json:"substitution_in"`
+}
+
+type playerLineJSON struct {
+	Name    string   `json:"name"`
+	Events  []string `json:"events"`
+	RawText string   `json:"raw_text"`
+}
+
+func mapSeasons(seasons []site.Season) []seasonJSON {
+	out := make([]seasonJSON, 0, len(seasons))
+	for _, season := range seasons {
+		out = append(out, seasonJSON{Label: season.Label, SeasonID: season.SeasonID, URL: season.URL, Current: season.Current})
+	}
+	return out
+}
+
+func mapCompetitions(competitions []site.Competition) []competitionJSON {
+	out := make([]competitionJSON, 0, len(competitions))
+	for _, competition := range competitions {
+		out = append(out, competitionJSON{Name: competition.Name, LeagueKey: competition.LeagueKey, URL: competition.URL})
+	}
+	return out
+}
+
+func mapLeague(league *site.LeaguePage, includeRounds bool) leagueJSON {
+	out := leagueJSON{Title: league.Title, LeagueKey: league.LeagueKey, URL: league.URL, Standings: mapStandings(league.Standings), Rounds: []roundJSON{}}
+	if includeRounds {
+		out.Rounds = mapRounds(league.Rounds)
+	}
+	return out
+}
+
+func mapStandings(rows []site.StandingRow) []standingJSON {
+	out := make([]standingJSON, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, standingJSON{Position: row.Position, Team: row.Team, Played: row.Played, Won: row.Won, Drawn: row.Drawn, Lost: row.Lost, Points: row.Points})
+	}
+	return out
+}
+
+func mapRounds(rounds []site.Round) []roundJSON {
+	out := make([]roundJSON, 0, len(rounds))
+	for _, round := range rounds {
+		out = append(out, roundJSON{Phase: round.Phase, Section: round.Section, Name: round.Name, Fixtures: mapFixtures(round.Fixtures)})
+	}
+	return out
+}
+
+func mapFixtures(fixtures []site.Fixture) []fixtureJSON {
+	out := make([]fixtureJSON, 0, len(fixtures))
+	for _, fixture := range fixtures {
+		out = append(out, fixtureJSON{Home: fixture.Home, Away: fixture.Away, Score: fixture.Score, When: fixture.WhenInfo, MatchID: fixture.MatchID, MatchURL: fixture.MatchURL})
+	}
+	return out
+}
+
+func mapMatch(match *site.MatchPage) matchJSON {
+	return matchJSON{
+		MatchID:     match.MatchID,
+		URL:         match.URL,
+		Title:       match.Title,
+		Competition: match.Competition,
+		Meta:        match.Meta,
+		Weather:     match.Weather,
+		HomeTeam:    match.HomeTeam,
+		AwayTeam:    match.AwayTeam,
+		Score:       match.Score,
+		Events:      mapMatchEvents(match.Events),
+		HomeLineup:  mapPlayerLines(match.HomeLineup),
+		AwayLineup:  mapPlayerLines(match.AwayLineup),
+		NewsTitle:   match.NewsTitle,
+		NewsURL:     match.NewsURL,
+	}
+}
+
+func mapMatchEvents(events []site.MatchEvent) []matchEventJSON {
+	out := make([]matchEventJSON, 0, len(events))
+	for _, event := range events {
+		out = append(out, matchEventJSON{
+			MinuteText:      event.MinuteText,
+			Minute:          event.Minute,
+			Stoppage:        event.Stoppage,
+			HasMinute:       event.HasMinute,
+			Kind:            event.Kind,
+			TeamSide:        event.TeamSide,
+			Text:            event.Text,
+			SubstitutionOut: event.SubstitutionOut,
+			SubstitutionIn:  event.SubstitutionIn,
+		})
+	}
+	return out
+}
+
+func mapPlayerLines(lines []site.PlayerLine) []playerLineJSON {
+	out := make([]playerLineJSON, 0, len(lines))
+	for _, line := range lines {
+		// Keep the JSON contract at [] instead of null for players without events.
+		events := make([]string, 0, len(line.Events))
+		events = append(events, line.Events...)
+		out = append(out, playerLineJSON{Name: line.Name, Events: events, RawText: line.RawText})
+	}
+	return out
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/adrunkhuman/90minuTUI/internal/site"
+)
+
+type fakeService struct {
+	archiveURL string
+	menuURL    string
+	leagueURL  string
+	matchURL   string
+	leagueErrs map[string]error
+
+	archiveErr error
+	leagueErr  error
+	matchErr   error
+}
+
+func (s *fakeService) LoadArchive(_ context.Context, archiveURL string) ([]site.Season, int, []site.Competition, error) {
+	s.archiveURL = archiveURL
+	if s.archiveErr != nil {
+		return nil, -1, nil, s.archiveErr
+	}
+	return []site.Season{{Label: "2025/26", URL: site.BaseURL + "/archsezon.php?id_sezon=107", SeasonID: "107", Current: true}}, 0, []site.Competition{{Name: "Ekstraklasa", URL: site.BaseURL + "/liga/1/liga14072.html", LeagueKey: "liga14072"}}, nil
+}
+
+func (s *fakeService) LoadCompetition(_ context.Context, competitionURL string) (*site.CompetitionMenu, *site.LeaguePage, error) {
+	s.menuURL = competitionURL
+	return &site.CompetitionMenu{
+		Title: "III liga 2024/25",
+		URL:   site.BaseURL + "/ligireg.php?poziom=4&id_sezon=105",
+		Items: []site.Competition{{Name: "III liga, gr. I", URL: site.BaseURL + "/liga/1/liga13507.html", LeagueKey: "liga13507"}},
+	}, nil, nil
+}
+
+func (s *fakeService) LoadLeague(_ context.Context, leagueURL string) (*site.LeaguePage, error) {
+	s.leagueURL = leagueURL
+	if err := s.leagueErrs[leagueURL]; err != nil {
+		return nil, err
+	}
+	if s.leagueErr != nil {
+		return nil, s.leagueErr
+	}
+	return &site.LeaguePage{
+		Title:     "Ekstraklasa",
+		URL:       site.BaseURL + "/liga/1/liga14072.html",
+		LeagueKey: "liga14072",
+		Standings: []site.StandingRow{{Position: 1, Team: "Team A", Played: 1, Won: 1, Points: 3}},
+		Rounds:    []site.Round{{Name: "1. kolejka", Fixtures: []site.Fixture{{Home: "Team A", Away: "Team B", Score: "1-0", WhenInfo: "18 lipca, 18:00", MatchURL: site.BaseURL + "/mecz.php?id_mecz=1930640", MatchID: "1930640"}}}},
+	}, nil
+}
+
+func (s *fakeService) LoadMatch(_ context.Context, matchURL string) (*site.MatchPage, error) {
+	s.matchURL = matchURL
+	if s.matchErr != nil {
+		return nil, s.matchErr
+	}
+	return &site.MatchPage{
+		URL:        site.BaseURL + "/mecz.php?id_mecz=1930640",
+		MatchID:    "1930640",
+		HomeTeam:   "Team A",
+		AwayTeam:   "Team B",
+		Score:      "1-0",
+		Events:     []site.MatchEvent{{MinuteText: "35", Minute: 35, HasMinute: true, Kind: site.EventKindGoal, TeamSide: site.TeamSideHome, Text: "Player 35"}},
+		HomeLineup: []site.PlayerLine{{Name: "Player"}},
+	}, nil
+}
+
+func TestRunSeasonsExportsJSON(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"seasons"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got seasonsOutput
+	decodeJSON(t, stdout, &got)
+	if len(got.Seasons) != 1 || got.Seasons[0].SeasonID != "107" || !got.Seasons[0].Current {
+		t.Fatalf("unexpected seasons output: %+v", got)
+	}
+	if svc.archiveURL != site.ArchiveURL {
+		t.Fatalf("unexpected archive URL: %q", svc.archiveURL)
+	}
+}
+
+func TestRunCompetitionsNormalizesSeasonID(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"competitions", "--season", "107"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got competitionsOutput
+	decodeJSON(t, stdout, &got)
+	if got.SeasonID != "107" || len(got.Competitions) != 1 || got.Competitions[0].LeagueKey != "liga14072" {
+		t.Fatalf("unexpected competitions output: %+v", got)
+	}
+	if got.Title != "Competitions" || got.URL == "" {
+		t.Fatalf("expected competitions metadata, got %+v", got)
+	}
+	if svc.archiveURL != site.BaseURL+"/archsezon.php?id_sezon=107" {
+		t.Fatalf("unexpected archive URL: %q", svc.archiveURL)
+	}
+}
+
+func TestRunCompetitionsExpandsSubmenuURL(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"competitions", "--url", site.BaseURL + "/ligireg.php?poziom=4&id_sezon=105"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got competitionsOutput
+	decodeJSON(t, stdout, &got)
+	if got.Title != "III liga 2024/25" || got.SeasonID != "105" || got.Competitions[0].LeagueKey != "liga13507" {
+		t.Fatalf("unexpected submenu competitions output: %+v", got)
+	}
+	if svc.menuURL == "" {
+		t.Fatalf("expected submenu URL to be loaded")
+	}
+}
+
+func TestRunLeagueNormalizesLeagueKey(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"league", "liga14072"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got leagueJSON
+	decodeJSON(t, stdout, &got)
+	if got.LeagueKey != "liga14072" || len(got.Standings) != 1 || len(got.Rounds) != 1 {
+		t.Fatalf("unexpected league output: %+v", got)
+	}
+	if svc.leagueURL != site.BaseURL+"/liga/1/liga14072.html" {
+		t.Fatalf("unexpected league URL: %q", svc.leagueURL)
+	}
+}
+
+func TestRunLeagueKeyFallsBackToLigaZeroPath(t *testing.T) {
+	svc := &fakeService{leagueErrs: map[string]error{site.BaseURL + "/liga/1/liga8694.html": errors.New("missing")}}
+	stdout, stderr, code := runTestCLI([]string{"league", "liga8694"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q stdout=%q", code, stderr, stdout)
+	}
+	if svc.leagueURL != site.BaseURL+"/liga/0/liga8694.html" {
+		t.Fatalf("expected /liga/0/ fallback, got %q", svc.leagueURL)
+	}
+}
+
+func TestRunFixturesExportsRoundsOnly(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"fixtures", "liga14072"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got fixturesOutput
+	decodeJSON(t, stdout, &got)
+	if got.LeagueKey != "liga14072" || len(got.Rounds) != 1 || got.Rounds[0].Fixtures[0].MatchID != "1930640" {
+		t.Fatalf("unexpected fixtures output: %+v", got)
+	}
+}
+
+func TestRunMatchNormalizesMatchID(t *testing.T) {
+	svc := &fakeService{}
+	stdout, stderr, code := runTestCLI([]string{"match", "1930640"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got matchJSON
+	decodeJSON(t, stdout, &got)
+	if got.MatchID != "1930640" || got.Events[0].Kind != site.EventKindGoal || got.HomeLineup[0].Name != "Player" {
+		t.Fatalf("unexpected match output: %+v", got)
+	}
+	if svc.matchURL != site.BaseURL+"/mecz.php?id_mecz=1930640" {
+		t.Fatalf("unexpected match URL: %q", svc.matchURL)
+	}
+}
+
+func TestRunMatchUsesArrayForEmptyPlayerEvents(t *testing.T) {
+	stdout, stderr, code := runTestCLI([]string{"match", "1930640"}, &fakeService{})
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got map[string]any
+	decodeJSON(t, stdout, &got)
+	homeLineup := got["home_lineup"].([]any)
+	player := homeLineup[0].(map[string]any)
+	if events, ok := player["events"].([]any); !ok || len(events) != 0 {
+		t.Fatalf("expected player events to be [], got %#v", player["events"])
+	}
+}
+
+func TestRunFixturesContractFields(t *testing.T) {
+	stdout, stderr, code := runTestCLI([]string{"fixtures", "liga14072"}, &fakeService{})
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected success, code=%d stderr=%q", code, stderr)
+	}
+	var got map[string]any
+	decodeJSON(t, stdout, &got)
+	for _, key := range []string{"league_key", "url", "rounds"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("expected fixtures output key %q in %#v", key, got)
+		}
+	}
+	rounds := got["rounds"].([]any)
+	round := rounds[0].(map[string]any)
+	for _, key := range []string{"phase", "section", "name", "fixtures"} {
+		if _, ok := round[key]; !ok {
+			t.Fatalf("expected round key %q in %#v", key, round)
+		}
+	}
+}
+
+func TestRunReportsErrorsOnStderr(t *testing.T) {
+	svc := &fakeService{leagueErr: errors.New("league failed")}
+	stdout, stderr, code := runTestCLI([]string{"league", "liga14072"}, svc)
+	if code != 1 || stdout != "" || !strings.Contains(stderr, "league failed") {
+		t.Fatalf("expected CLI error, code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func TestRunRequiresSeasonForCompetitions(t *testing.T) {
+	stdout, stderr, code := runTestCLI([]string{"competitions"}, &fakeService{})
+	if code != 1 || stdout != "" || !strings.Contains(stderr, "--season or --url") {
+		t.Fatalf("expected missing season error, code=%d stdout=%q stderr=%q", code, stdout, stderr)
+	}
+}
+
+func runTestCLI(args []string, svc Service) (string, string, int) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(args, &stdout, &stderr, svc)
+	return stdout.String(), stderr.String(), code
+}
+
+func decodeJSON(t *testing.T, value string, target any) {
+	t.Helper()
+	if err := json.Unmarshal([]byte(value), target); err != nil {
+		t.Fatalf("decode JSON %q: %v", value, err)
+	}
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -230,6 +230,16 @@ func TestRunRequiresSeasonForCompetitions(t *testing.T) {
 	}
 }
 
+func TestRunHelpLinksFullAPIReference(t *testing.T) {
+	stdout, stderr, code := runTestCLI([]string{"--help"}, &fakeService{})
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected help success, code=%d stderr=%q", code, stderr)
+	}
+	if !strings.Contains(stdout, "https://github.com/adrunkhuman/90minuTUI/blob/master/docs/cli.md") {
+		t.Fatalf("expected help to link API reference, got %q", stdout)
+	}
+}
+
 func runTestCLI(args []string, svc Service) (string, string, int) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Summary
- add JSON CLI subcommands for seasons, competitions, league, fixtures, and match exports
- keep no-arg behavior as the interactive TUI
- support exact URL inputs plus season IDs, match IDs, and common league keys
- add submenu expansion via competitions --url for regional/III liga-style drilldowns
- document usage and export formats in docs/cli.md

## Verification
- go test ./...
- git diff --check
- live CLI smoke tests against seasons, competitions, leagues, fixtures, matches, submenu expansion, and /liga/0 fallback

Refs #19