### PR TITLE
Expose stable entity IDs in CLI exports

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ Data goes to stdout. Errors go to stderr. Fetch or parse failure exits non-zero.
 90minutui match 1930640
 ```
 
-Use exported `url` values for exact follow-up fetches. `league_key` is stable for joins and is accepted as a convenience when the league URL uses a known `90minut.pl` league path.
+Use exported `url` values for exact follow-up fetches. `league_key` identifies one competition page and is accepted as a convenience when the league URL uses a known `90minut.pl` league path. League keys change between seasons.
 
 ## Exports
 
@@ -62,6 +62,7 @@ Use exported `url` values for exact follow-up fetches. `league_key` is stable fo
     {
       "position": 1,
       "team": "Team",
+      "club_id": "423",
       "played": 1,
       "won": 1,
       "drawn": 0,
@@ -87,7 +88,9 @@ Use exported `url` values for exact follow-up fetches. `league_key` is stable fo
       "fixtures": [
         {
           "home": "Team A",
+          "home_club_id": "423",
           "away": "Team B",
+          "away_club_id": "424",
           "score": "1-0",
           "when": "18 lipca, 18:00",
           "match_id": "1930640",
@@ -109,6 +112,8 @@ Use exported `url` values for exact follow-up fetches. `league_key` is stable fo
   "competition": "League or cup name",
   "meta": "stadium, attendance, referee",
   "weather": "weather text",
+  "referee": "Referee Name (City)",
+  "referee_id": "1125",
   "home_team": "Team A",
   "away_team": "Team B",
   "score": "1-0",
@@ -127,6 +132,7 @@ Use exported `url` values for exact follow-up fetches. `league_key` is stable fo
   ],
   "home_lineup": [
     {
+      "player_id": "22468",
       "name": "Player A",
       "events": [],
       "raw_text": "Player A"
@@ -143,6 +149,10 @@ Use exported `url` values for exact follow-up fetches. `league_key` is stable fo
 - Subcommands write JSON.
 - Missing lists are `[]`.
 - Missing source values are `""`.
-- `season_id`, `league_key`, and `match_id` are stable keys for joining exports.
+- `season_id` identifies a season, `league_key` identifies a season-specific competition page, and `match_id` identifies a match.
+- `club_id`, `player_id`, and `referee_id` preserve the corresponding source identities across seasons when `90minut.pl` provides an entity link.
+- `club_id` is exported on standings rows. Fixture `home_club_id` and `away_club_id` are resolved from that league page's standings.
+- `player_id` identifies the primary player represented by a lineup entry. Substitution names embedded in that entry do not currently have separate exported IDs.
+- Entity ID fields are `""` when the source page does not provide enough information; names are display labels, not identity keys.
 - `url` is the exact fetch identifier for follow-up commands.
 - The app uses a per-process cache only. Each new process fetches fresh data.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -313,6 +313,7 @@ type fixturesOutput struct {
 type standingJSON struct {
 	Position int    `json:"position"`
 	Team     string `json:"team"`
+	ClubID   string `json:"club_id"`
 	Played   int    `json:"played"`
 	Won      int    `json:"won"`
 	Drawn    int    `json:"drawn"`
@@ -328,12 +329,14 @@ type roundJSON struct {
 }
 
 type fixtureJSON struct {
-	Home     string `json:"home"`
-	Away     string `json:"away"`
-	Score    string `json:"score"`
-	When     string `json:"when"`
-	MatchID  string `json:"match_id"`
-	MatchURL string `json:"match_url"`
+	Home       string `json:"home"`
+	HomeClubID string `json:"home_club_id"`
+	Away       string `json:"away"`
+	AwayClubID string `json:"away_club_id"`
+	Score      string `json:"score"`
+	When       string `json:"when"`
+	MatchID    string `json:"match_id"`
+	MatchURL   string `json:"match_url"`
 }
 
 type matchJSON struct {
@@ -343,6 +346,8 @@ type matchJSON struct {
 	Competition string           `json:"competition"`
 	Meta        string           `json:"meta"`
 	Weather     string           `json:"weather"`
+	Referee     string           `json:"referee"`
+	RefereeID   string           `json:"referee_id"`
 	HomeTeam    string           `json:"home_team"`
 	AwayTeam    string           `json:"away_team"`
 	Score       string           `json:"score"`
@@ -366,9 +371,10 @@ type matchEventJSON struct {
 }
 
 type playerLineJSON struct {
-	Name    string   `json:"name"`
-	Events  []string `json:"events"`
-	RawText string   `json:"raw_text"`
+	Name     string   `json:"name"`
+	PlayerID string   `json:"player_id"`
+	Events   []string `json:"events"`
+	RawText  string   `json:"raw_text"`
 }
 
 func mapSeasons(seasons []site.Season) []seasonJSON {
@@ -398,7 +404,7 @@ func mapLeague(league *site.LeaguePage, includeRounds bool) leagueJSON {
 func mapStandings(rows []site.StandingRow) []standingJSON {
 	out := make([]standingJSON, 0, len(rows))
 	for _, row := range rows {
-		out = append(out, standingJSON{Position: row.Position, Team: row.Team, Played: row.Played, Won: row.Won, Drawn: row.Drawn, Lost: row.Lost, Points: row.Points})
+		out = append(out, standingJSON{Position: row.Position, Team: row.Team, ClubID: row.ClubID, Played: row.Played, Won: row.Won, Drawn: row.Drawn, Lost: row.Lost, Points: row.Points})
 	}
 	return out
 }
@@ -414,7 +420,7 @@ func mapRounds(rounds []site.Round) []roundJSON {
 func mapFixtures(fixtures []site.Fixture) []fixtureJSON {
 	out := make([]fixtureJSON, 0, len(fixtures))
 	for _, fixture := range fixtures {
-		out = append(out, fixtureJSON{Home: fixture.Home, Away: fixture.Away, Score: fixture.Score, When: fixture.WhenInfo, MatchID: fixture.MatchID, MatchURL: fixture.MatchURL})
+		out = append(out, fixtureJSON{Home: fixture.Home, HomeClubID: fixture.HomeClubID, Away: fixture.Away, AwayClubID: fixture.AwayClubID, Score: fixture.Score, When: fixture.WhenInfo, MatchID: fixture.MatchID, MatchURL: fixture.MatchURL})
 	}
 	return out
 }
@@ -427,6 +433,8 @@ func mapMatch(match *site.MatchPage) matchJSON {
 		Competition: match.Competition,
 		Meta:        match.Meta,
 		Weather:     match.Weather,
+		Referee:     match.Referee,
+		RefereeID:   match.RefereeID,
 		HomeTeam:    match.HomeTeam,
 		AwayTeam:    match.AwayTeam,
 		Score:       match.Score,
@@ -462,7 +470,7 @@ func mapPlayerLines(lines []site.PlayerLine) []playerLineJSON {
 		// Keep the JSON contract at [] instead of null for players without events.
 		events := make([]string, 0, len(line.Events))
 		events = append(events, line.Events...)
-		out = append(out, playerLineJSON{Name: line.Name, Events: events, RawText: line.RawText})
+		out = append(out, playerLineJSON{Name: line.Name, PlayerID: line.PlayerID, Events: events, RawText: line.RawText})
 	}
 	return out
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -17,6 +17,7 @@ type fakeService struct {
 	leagueURL  string
 	matchURL   string
 	leagueErrs map[string]error
+	emptyIDs   bool
 
 	archiveErr error
 	leagueErr  error
@@ -48,12 +49,16 @@ func (s *fakeService) LoadLeague(_ context.Context, leagueURL string) (*site.Lea
 	if s.leagueErr != nil {
 		return nil, s.leagueErr
 	}
+	homeClubID, awayClubID := "10", "20"
+	if s.emptyIDs {
+		homeClubID, awayClubID = "", ""
+	}
 	return &site.LeaguePage{
 		Title:     "Ekstraklasa",
 		URL:       site.BaseURL + "/liga/1/liga14072.html",
 		LeagueKey: "liga14072",
-		Standings: []site.StandingRow{{Position: 1, Team: "Team A", ClubID: "10", Played: 1, Won: 1, Points: 3}},
-		Rounds:    []site.Round{{Name: "1. kolejka", Fixtures: []site.Fixture{{Home: "Team A", HomeClubID: "10", Away: "Team B", AwayClubID: "20", Score: "1-0", WhenInfo: "18 lipca, 18:00", MatchURL: site.BaseURL + "/mecz.php?id_mecz=1930640", MatchID: "1930640"}}}},
+		Standings: []site.StandingRow{{Position: 1, Team: "Team A", ClubID: homeClubID, Played: 1, Won: 1, Points: 3}},
+		Rounds:    []site.Round{{Name: "1. kolejka", Fixtures: []site.Fixture{{Home: "Team A", HomeClubID: homeClubID, Away: "Team B", AwayClubID: awayClubID, Score: "1-0", WhenInfo: "18 lipca, 18:00", MatchURL: site.BaseURL + "/mecz.php?id_mecz=1930640", MatchID: "1930640"}}}},
 	}, nil
 }
 
@@ -62,16 +67,20 @@ func (s *fakeService) LoadMatch(_ context.Context, matchURL string) (*site.Match
 	if s.matchErr != nil {
 		return nil, s.matchErr
 	}
+	refereeID, playerID := "30", "40"
+	if s.emptyIDs {
+		refereeID, playerID = "", ""
+	}
 	return &site.MatchPage{
 		URL:        site.BaseURL + "/mecz.php?id_mecz=1930640",
 		MatchID:    "1930640",
 		HomeTeam:   "Team A",
 		AwayTeam:   "Team B",
 		Referee:    "Referee",
-		RefereeID:  "30",
+		RefereeID:  refereeID,
 		Score:      "1-0",
 		Events:     []site.MatchEvent{{MinuteText: "35", Minute: 35, HasMinute: true, Kind: site.EventKindGoal, TeamSide: site.TeamSideHome, Text: "Player 35"}},
-		HomeLineup: []site.PlayerLine{{Name: "Player", PlayerID: "40"}},
+		HomeLineup: []site.PlayerLine{{Name: "Player", PlayerID: playerID}},
 	}, nil
 }
 
@@ -221,6 +230,37 @@ func TestRunFixturesContractFields(t *testing.T) {
 			t.Fatalf("expected round key %q in %#v", key, round)
 		}
 	}
+	fixture := round["fixtures"].([]any)[0].(map[string]any)
+	for _, key := range []string{"home_club_id", "away_club_id"} {
+		if _, ok := fixture[key]; !ok {
+			t.Fatalf("expected fixture key %q in %#v", key, fixture)
+		}
+	}
+}
+
+func TestRunEntityIDFieldsUseEmptyStringsWhenUnavailable(t *testing.T) {
+	svc := &fakeService{emptyIDs: true}
+	leagueStdout, stderr, code := runTestCLI([]string{"league", "liga14072"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected league success, code=%d stderr=%q", code, stderr)
+	}
+	var league map[string]any
+	decodeJSON(t, leagueStdout, &league)
+	standing := league["standings"].([]any)[0].(map[string]any)
+	assertEmptyStringField(t, standing, "club_id")
+	fixture := league["rounds"].([]any)[0].(map[string]any)["fixtures"].([]any)[0].(map[string]any)
+	assertEmptyStringField(t, fixture, "home_club_id")
+	assertEmptyStringField(t, fixture, "away_club_id")
+
+	matchStdout, stderr, code := runTestCLI([]string{"match", "1930640"}, svc)
+	if code != 0 || stderr != "" {
+		t.Fatalf("expected match success, code=%d stderr=%q", code, stderr)
+	}
+	var match map[string]any
+	decodeJSON(t, matchStdout, &match)
+	assertEmptyStringField(t, match, "referee_id")
+	player := match["home_lineup"].([]any)[0].(map[string]any)
+	assertEmptyStringField(t, player, "player_id")
 }
 
 func TestRunReportsErrorsOnStderr(t *testing.T) {
@@ -259,5 +299,13 @@ func decodeJSON(t *testing.T, value string, target any) {
 	t.Helper()
 	if err := json.Unmarshal([]byte(value), target); err != nil {
 		t.Fatalf("decode JSON %q: %v", value, err)
+	}
+}
+
+func assertEmptyStringField(t *testing.T, object map[string]any, key string) {
+	t.Helper()
+	value, ok := object[key]
+	if !ok || value != "" {
+		t.Fatalf("expected %q to be present as an empty string in %#v", key, object)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -52,8 +52,8 @@ func (s *fakeService) LoadLeague(_ context.Context, leagueURL string) (*site.Lea
 		Title:     "Ekstraklasa",
 		URL:       site.BaseURL + "/liga/1/liga14072.html",
 		LeagueKey: "liga14072",
-		Standings: []site.StandingRow{{Position: 1, Team: "Team A", Played: 1, Won: 1, Points: 3}},
-		Rounds:    []site.Round{{Name: "1. kolejka", Fixtures: []site.Fixture{{Home: "Team A", Away: "Team B", Score: "1-0", WhenInfo: "18 lipca, 18:00", MatchURL: site.BaseURL + "/mecz.php?id_mecz=1930640", MatchID: "1930640"}}}},
+		Standings: []site.StandingRow{{Position: 1, Team: "Team A", ClubID: "10", Played: 1, Won: 1, Points: 3}},
+		Rounds:    []site.Round{{Name: "1. kolejka", Fixtures: []site.Fixture{{Home: "Team A", HomeClubID: "10", Away: "Team B", AwayClubID: "20", Score: "1-0", WhenInfo: "18 lipca, 18:00", MatchURL: site.BaseURL + "/mecz.php?id_mecz=1930640", MatchID: "1930640"}}}},
 	}, nil
 }
 
@@ -67,9 +67,11 @@ func (s *fakeService) LoadMatch(_ context.Context, matchURL string) (*site.Match
 		MatchID:    "1930640",
 		HomeTeam:   "Team A",
 		AwayTeam:   "Team B",
+		Referee:    "Referee",
+		RefereeID:  "30",
 		Score:      "1-0",
 		Events:     []site.MatchEvent{{MinuteText: "35", Minute: 35, HasMinute: true, Kind: site.EventKindGoal, TeamSide: site.TeamSideHome, Text: "Player 35"}},
-		HomeLineup: []site.PlayerLine{{Name: "Player"}},
+		HomeLineup: []site.PlayerLine{{Name: "Player", PlayerID: "40"}},
 	}, nil
 }
 
@@ -135,6 +137,9 @@ func TestRunLeagueNormalizesLeagueKey(t *testing.T) {
 	if got.LeagueKey != "liga14072" || len(got.Standings) != 1 || len(got.Rounds) != 1 {
 		t.Fatalf("unexpected league output: %+v", got)
 	}
+	if got.Standings[0].ClubID != "10" || got.Rounds[0].Fixtures[0].HomeClubID != "10" || got.Rounds[0].Fixtures[0].AwayClubID != "20" {
+		t.Fatalf("expected club ids in league output: %+v", got)
+	}
 	if svc.leagueURL != site.BaseURL+"/liga/1/liga14072.html" {
 		t.Fatalf("unexpected league URL: %q", svc.leagueURL)
 	}
@@ -174,6 +179,9 @@ func TestRunMatchNormalizesMatchID(t *testing.T) {
 	decodeJSON(t, stdout, &got)
 	if got.MatchID != "1930640" || got.Events[0].Kind != site.EventKindGoal || got.HomeLineup[0].Name != "Player" {
 		t.Fatalf("unexpected match output: %+v", got)
+	}
+	if got.RefereeID != "30" || got.Referee != "Referee" || got.HomeLineup[0].PlayerID != "40" {
+		t.Fatalf("expected referee and player ids in match output: %+v", got)
 	}
 	if svc.matchURL != site.BaseURL+"/mecz.php?id_mecz=1930640" {
 		t.Fatalf("unexpected match URL: %q", svc.matchURL)

--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -24,7 +24,25 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	}
 
 	page.Rounds = normalizeLeagueOrder(rounds, page.Title)
+	assignFixtureClubIDs(page.Rounds, page.Standings)
 	return page
+}
+
+func assignFixtureClubIDs(rounds []Round, standings []StandingRow) {
+	clubIDs := make(map[string]string, len(standings))
+	for _, row := range standings {
+		if row.ClubID != "" {
+			clubIDs[normalizeWhitespace(row.Team)] = row.ClubID
+		}
+	}
+
+	for i := range rounds {
+		for j := range rounds[i].Fixtures {
+			fixture := &rounds[i].Fixtures[j]
+			fixture.HomeClubID = clubIDs[normalizeWhitespace(fixture.Home)]
+			fixture.AwayClubID = clubIDs[normalizeWhitespace(fixture.Away)]
+		}
+	}
 }
 
 func parseRounds(doc *goquery.Document) []Round {
@@ -397,7 +415,9 @@ func parseStandingRow(row *goquery.Selection) (StandingRow, bool) {
 	}
 
 	position := parseIntCell(strings.TrimSuffix(normalizeWhitespace(tds.Eq(0).Text()), "."))
-	team := normalizeWhitespace(tds.Eq(1).Text())
+	teamCell := tds.Eq(1)
+	team := normalizeWhitespace(teamCell.Text())
+	clubID := extractQueryParam(teamCell.Find("a[href*='id_klub=']").First().AttrOr("href", ""), "id_klub")
 	played := parseIntCell(tds.Eq(2).Text())
 	points := parseIntCell(tds.Eq(3).Text())
 	won := parseIntCell(tds.Eq(4).Text())
@@ -411,6 +431,7 @@ func parseStandingRow(row *goquery.Selection) (StandingRow, bool) {
 	return StandingRow{
 		Position: position,
 		Team:     team,
+		ClubID:   clubID,
 		Played:   played,
 		Won:      won,
 		Drawn:    drawn,

--- a/internal/site/match_parser.go
+++ b/internal/site/match_parser.go
@@ -28,6 +28,7 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 	page.Competition = normalizeWhitespace(table.Find("tr").First().Find("b").First().Text())
 	page.Meta = firstMetaLine(table)
 	page.Weather = normalizeWhitespace(table.Find("img[src*='pog_termo']").Parent().Text())
+	page.Referee, page.RefereeID = parseReferee(table)
 
 	table.Find("tr").Each(func(_ int, row *goquery.Selection) {
 		tds := row.Find("td")
@@ -115,6 +116,15 @@ func parseMatchPage(doc *goquery.Document, url string) *MatchPage {
 	})
 
 	return page
+}
+
+func parseReferee(table *goquery.Selection) (string, string) {
+	link := table.Find("a[href*='sedzia.php']").First()
+	if link.Length() == 0 {
+		return "", ""
+	}
+
+	return normalizeWhitespace(link.Text()), extractQueryParam(link.AttrOr("href", ""), "id")
 }
 
 func scoreRowEventKind(row *goquery.Selection) (MatchEventKind, bool) {
@@ -330,7 +340,11 @@ func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 	}
 
 	name := raw
-	anchors := make([]string, 0, 3)
+	type playerAnchor struct {
+		name string
+		id   string
+	}
+	anchors := make([]playerAnchor, 0, 3)
 	markersByPlayer := make(map[string][]string, 2)
 	currentPlayer := ""
 
@@ -339,11 +353,15 @@ func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 		case html.ElementNode:
 			switch strings.ToLower(node.Data) {
 			case "a":
-				playerName := normalizeWhitespace(goquery.NewDocumentFromNode(node).Text())
+				anchor := goquery.NewDocumentFromNode(node)
+				playerName := normalizeWhitespace(anchor.Text())
 				if playerName == "" {
 					continue
 				}
-				anchors = append(anchors, playerName)
+				anchors = append(anchors, playerAnchor{
+					name: playerName,
+					id:   extractQueryParam(anchor.AttrOr("href", ""), "id"),
+				})
 				if len(anchors) == 1 {
 					name = playerName
 				}
@@ -374,7 +392,7 @@ func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 
 	if cell.Find("img[src*='sub.gif']").Length() > 0 && len(anchors) > 1 {
 		// A single lineup cell can contain a chain: starter -> entrant -> next entrant.
-		replacement := anchors[1]
+		replacement := anchors[1].name
 		minute := substitutionMinute(raw, replacement)
 		if minute != "" {
 			events = append(events, fmt.Sprintf("%s' -> %s", minute, replacement))
@@ -385,17 +403,17 @@ func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 
 	extraEvents := make([]MatchEvent, 0, 2)
 	for i := 1; i < len(anchors); i++ {
-		for _, marker := range markersByPlayer[anchors[i]] {
+		for _, marker := range markersByPlayer[anchors[i].name] {
 			extraEvents = append(extraEvents, MatchEvent{
 				Kind:     MatchEventKind(marker),
 				TeamSide: side,
-				Text:     anchors[i],
+				Text:     anchors[i].name,
 			})
 		}
 	}
 	if cell.Find("img[src*='sub.gif']").Length() > 0 {
 		for i := 2; i < len(anchors); i++ {
-			minute := substitutionMinute(raw, anchors[i])
+			minute := substitutionMinute(raw, anchors[i].name)
 			m, s, ok := parseMinute(minute)
 			extraEvents = append(extraEvents, MatchEvent{
 				MinuteText:      minute,
@@ -404,15 +422,20 @@ func parsePlayerCell(cell *goquery.Selection, side TeamSide) *parsedPlayerCell {
 				HasMinute:       ok,
 				Kind:            "SUB",
 				TeamSide:        side,
-				Text:            substitutionEventText(anchors[i-1], anchors[i], ""),
-				SubstitutionOut: anchors[i-1],
-				SubstitutionIn:  anchors[i],
+				Text:            substitutionEventText(anchors[i-1].name, anchors[i].name, ""),
+				SubstitutionOut: anchors[i-1].name,
+				SubstitutionIn:  anchors[i].name,
 			})
 		}
 	}
 
+	playerID := ""
+	if len(anchors) > 0 {
+		playerID = anchors[0].id
+	}
+
 	return &parsedPlayerCell{
-		Player:      &PlayerLine{Name: name, Events: events, RawText: raw},
+		Player:      &PlayerLine{Name: name, PlayerID: playerID, Events: events, RawText: raw},
 		ExtraEvents: extraEvents,
 	}
 }

--- a/internal/site/models.go
+++ b/internal/site/models.go
@@ -23,9 +23,11 @@ type CompetitionMenu struct {
 }
 
 type Fixture struct {
-	Home  string
-	Away  string
-	Score string
+	Home       string
+	HomeClubID string
+	Away       string
+	AwayClubID string
+	Score      string
 	// WhenInfo keeps date/time text and any trailing source metadata that does not belong in the score cell.
 	WhenInfo string
 	// MatchURL stays empty when 90minut publishes a fixture row without a drillable match page.
@@ -61,6 +63,7 @@ type Round struct {
 type StandingRow struct {
 	Position int
 	Team     string
+	ClubID   string
 	Played   int
 	Won      int
 	Drawn    int
@@ -85,6 +88,8 @@ type MatchPage struct {
 	Competition string
 	Meta        string
 	Weather     string
+	Referee     string
+	RefereeID   string
 	HomeTeam    string
 	AwayTeam    string
 	Score       string
@@ -135,7 +140,8 @@ const (
 )
 
 type PlayerLine struct {
-	Name string
+	Name     string
+	PlayerID string
 	// Events stores raw lineup-cell markers until parser normalization emits MatchEvent values.
 	Events  []string
 	RawText string

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -192,4 +192,34 @@ func TestParseLeagueStandingsFromCorpus(t *testing.T) {
 			}
 		}
 	}
+
+	wantFixtureClubIDs := map[string][2]string{
+		"1659715": {"132", "423"},
+		"1659716": {"330", "171"},
+	}
+	for _, round := range page.Rounds {
+		for _, fixture := range round.Fixtures {
+			want, ok := wantFixtureClubIDs[fixture.MatchID]
+			if !ok {
+				continue
+			}
+			if fixture.HomeClubID != want[0] || fixture.AwayClubID != want[1] {
+				t.Fatalf("unexpected club ids for match %s: got %q vs %q, want %q vs %q", fixture.MatchID, fixture.HomeClubID, fixture.AwayClubID, want[0], want[1])
+			}
+			delete(wantFixtureClubIDs, fixture.MatchID)
+		}
+	}
+	if len(wantFixtureClubIDs) != 0 {
+		t.Fatalf("expected fixture mappings were not found: %#v", wantFixtureClubIDs)
+	}
+}
+
+func TestAssignFixtureClubIDsLeavesUnmatchedTeamEmpty(t *testing.T) {
+	rounds := []Round{{Fixtures: []Fixture{{Home: "Known Team", Away: "Unmatched Team"}}}}
+	assignFixtureClubIDs(rounds, []StandingRow{{Team: "Known Team", ClubID: "10"}})
+
+	fixture := rounds[0].Fixtures[0]
+	if fixture.HomeClubID != "10" || fixture.AwayClubID != "" {
+		t.Fatalf("unexpected fixture club ids: %+v", fixture)
+	}
 }

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -178,10 +178,18 @@ func TestParseLeagueStandingsFromCorpus(t *testing.T) {
 	}
 
 	first := page.Standings[0]
-	if first.Position != 1 || first.Team != "Legia Warszawa" {
+	if first.Position != 1 || first.Team != "Legia Warszawa" || first.ClubID != "171" {
 		t.Fatalf("unexpected first standings row: %+v", first)
 	}
 	if first.Played != 30 || first.Won != 19 || first.Drawn != 7 || first.Lost != 4 || first.Points != 64 {
 		t.Fatalf("unexpected first standings stats: %+v", first)
+	}
+
+	for _, round := range page.Rounds {
+		for _, fixture := range round.Fixtures {
+			if fixture.HomeClubID == "" || fixture.AwayClubID == "" {
+				t.Fatalf("expected fixture club ids for %q vs %q: %+v", fixture.Home, fixture.Away, fixture)
+			}
+		}
 	}
 }

--- a/internal/site/parser_match_test.go
+++ b/internal/site/parser_match_test.go
@@ -163,3 +163,20 @@ func TestParseMatchFixtureKeepsChainedSubstitutions(t *testing.T) {
 		t.Fatalf("expected both chained substitution events, got %#v", page.Events)
 	}
 }
+
+func TestParseMatchFixtureExtractsPlayerAndRefereeIDs(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/match_2022810.html")
+	page := parseMatchPage(doc, "http://www.90minut.pl/mecz.php?id_mecz=2022810")
+	if page == nil {
+		t.Fatalf("expected match page")
+	}
+	if page.Referee != "Łukasz Karski (Słupsk)" || page.RefereeID != "1125" {
+		t.Fatalf("unexpected referee identity: name=%q id=%q", page.Referee, page.RefereeID)
+	}
+	if len(page.HomeLineup) == 0 || page.HomeLineup[0].Name != "(30) Dominik Hładun" || page.HomeLineup[0].PlayerID != "22468" {
+		t.Fatalf("unexpected home lineup identity: %+v", page.HomeLineup)
+	}
+	if len(page.AwayLineup) == 0 || page.AwayLineup[0].Name != "(1) Ivan Brkić" || page.AwayLineup[0].PlayerID != "49041" {
+		t.Fatalf("unexpected away lineup identity: %+v", page.AwayLineup)
+	}
+}

--- a/internal/site/parser_regression_test.go
+++ b/internal/site/parser_regression_test.go
@@ -64,7 +64,7 @@ func TestParseMatchPageWithout480Width(t *testing.T) {
 	<tr><td colspan="3">1 marca 2026, 18:00</td></tr>
 	<tr><td>GKS Tychy</td><td>2-1</td><td>Odra Opole</td></tr>
 	<tr><td>(12) Jan Kowalski</td><td>-</td><td></td></tr>
-	<tr bgcolor="#f4f4f4"><td><a href="/wystepy.php?id=1">Jan Kowalski</a></td><td></td><td><a href="/wystepy.php?id=2">Piotr Nowak</a></td></tr>
+	<tr bgcolor="#f4f4f4"><td><a href="/wystepy.php">Jan Kowalski</a></td><td></td><td><a href="/wystepy.php?id=2">Piotr Nowak</a></td></tr>
 	</table>
 	</body></html>`
 
@@ -88,6 +88,15 @@ func TestParseMatchPageWithout480Width(t *testing.T) {
 	}
 	if len(page.HomeLineup) != 1 || len(page.AwayLineup) != 1 {
 		t.Fatalf("expected lineup extraction, home=%d away=%d", len(page.HomeLineup), len(page.AwayLineup))
+	}
+	if page.HomeLineup[0].Name != "Jan Kowalski" || page.HomeLineup[0].PlayerID != "" {
+		t.Fatalf("expected unlinked home player name with empty id, got %+v", page.HomeLineup[0])
+	}
+	if page.AwayLineup[0].Name != "Piotr Nowak" || page.AwayLineup[0].PlayerID != "2" {
+		t.Fatalf("unexpected linked away player identity: %+v", page.AwayLineup[0])
+	}
+	if page.Referee != "" || page.RefereeID != "" {
+		t.Fatalf("expected empty referee identity, got name=%q id=%q", page.Referee, page.RefereeID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve club, player, and referee source IDs in parsed site models.
- Export entity IDs through league, fixture, and match JSON contracts.
- Document identity scope and missing-value behavior.

## Verification

- go test ./... - passed
- go vet ./... - passed
- git diff --check - passed