### PR TITLE
Resolve fixture club IDs from all standings

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,8 +151,8 @@ Use exported `url` values for exact follow-up fetches. `league_key` identifies o
 - Missing source values are `""`.
 - `season_id` identifies a season, `league_key` identifies a season-specific competition page, and `match_id` identifies a match.
 - `club_id`, `player_id`, and `referee_id` preserve the corresponding source identities across seasons when `90minut.pl` provides an entity link.
-- `club_id` is exported on standings rows. Fixture `home_club_id` and `away_club_id` are resolved from that league page's standings.
+- `club_id` is exported on standings rows. Fixture `home_club_id` and `away_club_id` are resolved from all standings sections on that league page.
 - `player_id` identifies the primary player represented by a lineup entry. Substitution names embedded in that entry do not currently have separate exported IDs.
-- Entity ID fields are `""` when the source page does not provide enough information; names are display labels, not identity keys.
+- Entity ID fields are `""` when the source page does not provide enough information. In particular, fixture club IDs can be empty for qualifying or knockout-only teams absent from every standings section; names are display labels, not identity keys.
 - `url` is the exact fetch identifier for follow-up commands.
 - The app uses a per-process cache only. Each new process fetches fresh data.

--- a/internal/site/league_parser.go
+++ b/internal/site/league_parser.go
@@ -24,18 +24,11 @@ func parseLeaguePage(doc *goquery.Document, url string) *LeaguePage {
 	}
 
 	page.Rounds = normalizeLeagueOrder(rounds, page.Title)
-	assignFixtureClubIDs(page.Rounds, page.Standings)
+	assignFixtureClubIDs(page.Rounds, parseStandingClubIDs(doc))
 	return page
 }
 
-func assignFixtureClubIDs(rounds []Round, standings []StandingRow) {
-	clubIDs := make(map[string]string, len(standings))
-	for _, row := range standings {
-		if row.ClubID != "" {
-			clubIDs[normalizeWhitespace(row.Team)] = row.ClubID
-		}
-	}
-
+func assignFixtureClubIDs(rounds []Round, clubIDs map[string]string) {
 	for i := range rounds {
 		for j := range rounds[i].Fixtures {
 			fixture := &rounds[i].Fixtures[j]
@@ -43,6 +36,33 @@ func assignFixtureClubIDs(rounds []Round, standings []StandingRow) {
 			fixture.AwayClubID = clubIDs[normalizeWhitespace(fixture.Away)]
 		}
 	}
+}
+
+func parseStandingClubIDs(doc *goquery.Document) map[string]string {
+	clubIDs := make(map[string]string)
+	leagueTables(doc).Each(func(_ int, table *goquery.Selection) {
+		header := table.Find("tr").FilterFunction(func(_ int, row *goquery.Selection) bool {
+			text := normalizeWhitespace(row.Text())
+			return strings.Contains(text, "Nazwa") && strings.Contains(text, "Pkt.")
+		}).First()
+		if header.Length() == 0 {
+			return
+		}
+
+		table.Find("tr").Each(func(_ int, row *goquery.Selection) {
+			tds := row.Find("td")
+			if tds.Length() < 7 {
+				return
+			}
+			link := tds.Eq(1).Find("a[href*='id_klub=']").First()
+			team := normalizeWhitespace(link.Text())
+			clubID := extractQueryParam(link.AttrOr("href", ""), "id_klub")
+			if team != "" && clubID != "" {
+				clubIDs[team] = clubID
+			}
+		})
+	})
+	return clubIDs
 }
 
 func parseRounds(doc *goquery.Document) []Round {

--- a/internal/site/parser_league_test.go
+++ b/internal/site/parser_league_test.go
@@ -216,10 +216,58 @@ func TestParseLeagueStandingsFromCorpus(t *testing.T) {
 
 func TestAssignFixtureClubIDsLeavesUnmatchedTeamEmpty(t *testing.T) {
 	rounds := []Round{{Fixtures: []Fixture{{Home: "Known Team", Away: "Unmatched Team"}}}}
-	assignFixtureClubIDs(rounds, []StandingRow{{Team: "Known Team", ClubID: "10"}})
+	assignFixtureClubIDs(rounds, map[string]string{"Known Team": "10"})
 
 	fixture := rounds[0].Fixtures[0]
 	if fixture.HomeClubID != "10" || fixture.AwayClubID != "" {
 		t.Fatalf("unexpected fixture club ids: %+v", fixture)
+	}
+}
+
+func TestFixtureClubIDsIncludeAllSplitLeagueStandingsSections(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_8694.html")
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/0/liga8694.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	for _, round := range page.Rounds {
+		for _, fixture := range round.Fixtures {
+			if fixture.HomeClubID == "" || fixture.AwayClubID == "" {
+				t.Fatalf("expected fixture club ids for %q vs %q: %+v", fixture.Home, fixture.Away, fixture)
+			}
+		}
+	}
+}
+
+func TestFixtureClubIDsIncludeTiedRowsWithoutPosition(t *testing.T) {
+	doc, _ := fixtureDoc(t, "fixtures/league_13459.html")
+	page := parseLeaguePage(doc, "http://www.90minut.pl/liga/1/liga13459.html")
+	if page == nil {
+		t.Fatalf("expected league page")
+	}
+
+	sloveniaSides := 0
+	for _, round := range page.Rounds {
+		for _, fixture := range round.Fixtures {
+			if fixture.HomeClubID == "" || fixture.AwayClubID == "" {
+				t.Fatalf("expected fixture club ids for %q vs %q: %+v", fixture.Home, fixture.Away, fixture)
+			}
+			if fixture.Home == "Słowenia" {
+				sloveniaSides++
+				if fixture.HomeClubID != "4200" {
+					t.Fatalf("unexpected Słowenia home club id: %+v", fixture)
+				}
+			}
+			if fixture.Away == "Słowenia" {
+				sloveniaSides++
+				if fixture.AwayClubID != "4200" {
+					t.Fatalf("unexpected Słowenia away club id: %+v", fixture)
+				}
+			}
+		}
+	}
+	if sloveniaSides == 0 {
+		t.Fatalf("expected Słowenia fixtures")
 	}
 }


### PR DESCRIPTION
## Summary

- Resolve fixture club IDs from every standings section instead of only the first parsed table.
- Preserve IDs for tied teams whose standings position is blank, including Słowenia at Euro 2024.
- Document that qualifying and knockout-only teams can still have empty fixture club IDs when absent from all standings.

## Verification

- `go test ./...` - passed
- `go vet ./...` - passed
- `git diff --check` - passed